### PR TITLE
Don't validate JSON records against the table schema

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -3,9 +3,7 @@ package com.clickhouse.kafka.connect.sink.db;
 import com.clickhouse.client.*;
 import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.client.data.BinaryStreamUtils;
-import com.clickhouse.kafka.connect.ClickHouseSinkConnector;
 import com.clickhouse.kafka.connect.sink.ClickHouseSinkConfig;
-import com.clickhouse.kafka.connect.sink.ClickHouseSinkTask;
 import com.clickhouse.kafka.connect.sink.data.Data;
 import com.clickhouse.kafka.connect.sink.data.Record;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
@@ -17,13 +15,10 @@ import com.clickhouse.kafka.connect.util.Mask;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.apache.kafka.connect.data.Field;
-import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -140,7 +135,6 @@ public class ClickHouseWriter implements DBWriter{
         }
     }
 
-
     private boolean validateDataSchema(Table table, Record record, boolean onlyFieldsName) {
         boolean validSchema = true;
         for (Column col : table.getColumns() ) {
@@ -153,7 +147,7 @@ public class ClickHouseWriter implements DBWriter{
                     validSchema = false;
                     LOGGER.error(String.format("Table column name [%s] is not found in data record.", colName));
                 }
-                if (onlyFieldsName != true) {
+                if (!onlyFieldsName) {
                     String colTypeName = type.name();
                     String dataTypeName = obj.getFieldType().getName().toUpperCase();
                     // TODO: make extra validation for Map/Array type
@@ -346,13 +340,8 @@ public class ClickHouseWriter implements DBWriter{
             throw new RuntimeException(String.format("Table %s does not exists", topic));
         }
 
-        if ( !validateDataSchema(table, first, true) )
-            throw new RuntimeException();
-
-
-
-
-
+        // We don't validate the schema for JSON inserts.  ClickHouse will ignore unknown fields based on the
+        // input_format_skip_unknown_fields setting, and missing fields will use ClickHouse defaults
 
         try (ClickHouseClient client = ClickHouseClient.newInstance(ClickHouseProtocol.HTTP)) {
             ClickHouseRequest.Mutation request = client.connect(chc.getServer())
@@ -361,6 +350,7 @@ public class ClickHouseWriter implements DBWriter{
                     .format(ClickHouseFormat.JSONEachRow)
                     // this is needed to get meaningful response summary
                     .set("insert_quorum", 2)
+                    .set("input_format_skip_unknown_fields", 1)
                     .set("send_progress_in_http_headers", 1);
 
 

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
@@ -140,6 +140,11 @@ public class ClickHouseHelperClient {
                 ClickHouseValue v = r.getValue(0);
                 String value = v.asString();
                 String[] cols = value.split("\t");
+                String defaultKind = cols[2];
+                if ("ALIAS".equals(defaultKind) || "MATERIALIZED".equals(defaultKind)) {
+                    // Only insert into "real" columns
+                    continue;
+                }
                 String name = cols[0];
                 String type = cols[1];
                 table.addColumn(Column.extractColumn(name, type, false));


### PR DESCRIPTION
JSON records don't normally have to match the table schema.  Unknown fields can be ignored (with a setting), and missing fields will use defaults.