### PR TITLE
Add supported_encodings to manifest

### DIFF
--- a/config/archive/manifest.json
+++ b/config/archive/manifest.json
@@ -28,6 +28,7 @@
     ],
 
     "features" : {
+      "supported_encodings" : [ "JSON","Avro" ],
       "confluent_control_center_integration" : true,
       "delivery_guarantee": ["exactly_once"],
       "single_message_transforms" : true,


### PR DESCRIPTION
## Summary
Adding supported_encodings to manifest for listing in confluent hub 
