### PR TITLE
Adding ds_store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ build
 
 # Ignore IntelliJ
 .idea
+
+# Mac Folder Details
+.DS_Store


### PR DESCRIPTION
## Summary
This is a dev QOL change - macs create .DS_Store files that we don't want to really bring around in our git repo
