### PR TITLE
Missing field in record causes NullPointerException (for optional columns)

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -279,6 +279,11 @@ public class ClickHouseWriter implements DBWriter{
                     // this the situation when the col is not isNullable, but the data is null here we need to drop the records
                     throw new RuntimeException(("col.isNullable() is false and value is empty"));
                 }
+                // If the column is nullable and the given record doesn't have the field, it's ok to ignore it.
+                if (col.isNullable() && value.getObject() == null) {
+                    BinaryStreamUtils.writeNull(stream);
+                    return;
+                }
                 switch (colType) {
                     case INT8:
                     case INT16:


### PR DESCRIPTION
Given the following Avro schema:

```json
{
  "name": "payload",
  "type": "record",
  "fields": [
    {
      "name": "field_a",
      "type": ["null", "boolean"],
      "default": null
    },
    {
      "name": "field_b",
      "type": ["null", "boolean"],
      "default": null
    }
  ]
}
```

Note that both fields in payload are [optional](https://avro.apache.org/docs/1.11.1/specification/#unions).

It is allowed to encode the following object with this schema:

```javascript
{
   payload: {field_a: true}
}
```

This encoded message will cause a NullPointerException in the clickhouse sink connector:

- From the schema the existance of "field_b" will be defered, so [this check](https://github.com/ClickHouse/clickhouse-kafka-connect/blob/v0.0.11-beta/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java#L270) will not lead to a null value.
- The [call to](https://github.com/ClickHouse/clickhouse-kafka-connect/blob/v0.0.11-beta/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java#L291) `object.getValue()` will return a null value
- The null value will cause a NullPointerException when trying to extract the [primitive value](https://github.com/ClickHouse/clickhouse-kafka-connect/blob/cb47fa70f9aa4d901d6bce910896ca0b1fd90fa2/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java#L258)

I created a suggestion on how to fix this issue - what are your thoughts?

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
