### PR TITLE
Add UNEXPECTED_END_OF_FILE as RetriableException

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
+++ b/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
@@ -57,6 +57,8 @@ public class Utils {
             ClickHouseException clickHouseException = (ClickHouseException) rootCause;
             LOGGER.warn("ClickHouseException: {}", clickHouseException.getErrorCode());
             switch (clickHouseException.getErrorCode()) {
+                // UNEXPECTED_END_OF_FILE
+                case 3:
                 // TIMEOUT_EXCEEDED
                 case 159:
                 // READONLY


### PR DESCRIPTION
## Summary
A potential solution for https://github.com/ClickHouse/clickhouse-kafka-connect/issues/86

It doesn't solve the core problem which is a connection or server performance but at the moment I'm just restarting tasks every time when this problem occurs. 

## Checklist
- [ ] Unit and integration tests covering the common scenarios were added
