### PR TITLE
Added 202 to throw RetriableException for Kafka Connect able to recover.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.15 2023-05-30
+* Added 202 (TOO_MANY_SIMULTANEOUS_QUERIES) Code to retry list [Issue](https://github.com/ClickHouse/clickhouse-kafka-connect/issues/109) 
+
 ## 0.0.14, 2023-05-24
 * Fix for LowCardinality(t) and LowCardinality(Nullable(t)) [Issue](https://github.com/ClickHouse/clickhouse-kafka-connect/issues/105)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ plugins {
 }
 
 group = "com.clickhouse.kafka"
-version = "v0.0.14-beta"
+version = "v0.0.15-beta"
 description = "The official ClickHouse Apache Kafka Connect Connector."
 
 repositories {

--- a/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
+++ b/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
@@ -55,7 +55,7 @@ public class Utils {
         Exception rootCause = Utils.getRootCause(e, true);
         if (rootCause instanceof ClickHouseException) {
             ClickHouseException clickHouseException = (ClickHouseException) rootCause;
-            LOGGER.warn("ClickHouseException: {}", clickHouseException.getErrorCode());
+            LOGGER.warn("ClickHouseException code: {}", clickHouseException.getErrorCode());
             switch (clickHouseException.getErrorCode()) {
                 // UNEXPECTED_END_OF_FILE
                 case 3:
@@ -71,6 +71,8 @@ public class Utils {
                 case 210:
                 // SYSTEM_ERROR
                 case 425:
+                // TOO_MANY_SIMULTANEOUS_QUERIES
+                case 202:
                     throw new RetriableException(e);
                 default:
                     LOGGER.error("Error code [{}] wasn't in the acceptable list.", clickHouseException.getErrorCode());


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
