### PR TITLE
 Implement Correct Date Conversion Across All Date Types fixes #154

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -15,6 +15,7 @@ import com.clickhouse.kafka.connect.util.Mask;
 import com.clickhouse.kafka.connect.util.Utils;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import java.util.concurrent.TimeUnit;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -190,7 +190,13 @@ public class ClickHouseWriter implements DBWriter{
         switch (type) {
             case Date:
                 if (value.getFieldType().equals(Schema.Type.INT32)) {
-                    BinaryStreamUtils.writeUnsignedInt16(stream, (Integer) value.getObject());
+                    if (value.getObject().getClass().getName().endsWith(".Date")) {
+                        Date date = (Date)value.getObject();
+                        int timeInDays = (int) TimeUnit.MILLISECONDS.toDays(date.getTime());
+                        BinaryStreamUtils.writeUnsignedInt16(stream, timeInDays);
+                    } else {
+                        BinaryStreamUtils.writeUnsignedInt16(stream, (Integer) value.getObject());
+                    }
                 } else {
                     unsupported = true;
                 }
@@ -199,8 +205,8 @@ public class ClickHouseWriter implements DBWriter{
                 if (value.getFieldType().equals(Schema.Type.INT32)) {
                     if (value.getObject().getClass().getName().endsWith(".Date")) {
                         Date date = (Date)value.getObject();
-                        int time = (int)date.getTime();
-                        BinaryStreamUtils.writeInt32(stream, time);
+                        int timeInDays = (int) TimeUnit.MILLISECONDS.toDays(date.getTime());
+                        BinaryStreamUtils.writeInt32(stream, timeInDays);
                     } else {
                         BinaryStreamUtils.writeInt32(stream, (Integer) value.getObject());
                     }
@@ -210,7 +216,13 @@ public class ClickHouseWriter implements DBWriter{
                 break;
             case DateTime:
                 if (value.getFieldType().equals(Schema.Type.INT64)) {
-                    BinaryStreamUtils.writeUnsignedInt32(stream, (Long) value.getObject());
+                    if (value.getObject().getClass().getName().endsWith(".Date")) {
+                        Date date = (Date)value.getObject();
+                        long time = date.getTime();
+                        BinaryStreamUtils.writeUnsignedInt32(stream, time);
+                    } else {
+                        BinaryStreamUtils.writeUnsignedInt32(stream, (Long) value.getObject());
+                    }
                 } else {
 
                     unsupported = true;

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -216,16 +216,16 @@ public class ClickHouseWriter implements DBWriter{
                 }
                 break;
             case DateTime:
-                if (value.getFieldType().equals(Schema.Type.INT64)) {
+                if (value.getFieldType().equals(Schema.Type.INT32) || value.getFieldType().equals(Schema.Type.INT64)) {
                     if (value.getObject().getClass().getName().endsWith(".Date")) {
                         Date date = (Date)value.getObject();
-                        long time = date.getTime();
-                        BinaryStreamUtils.writeUnsignedInt32(stream, time);
+                        long epochSecond = date.toInstant().getEpochSecond();
+                        BinaryStreamUtils.writeUnsignedInt32(stream, epochSecond);
                     } else {
                         BinaryStreamUtils.writeUnsignedInt32(stream, (Long) value.getObject());
                     }
                 } else {
-
+                    
                     unsupported = true;
                 }
                 break;

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
@@ -396,6 +396,8 @@ public class ClickHouseSinkTaskWithSchemaTest {
                 .field("timestamp_date", Timestamp.SCHEMA)
                 .field("time_int32" , Time.SCHEMA)
                 .field("time_date32" , Time.SCHEMA)
+                .field("date_date", Time.SCHEMA)
+                .field("datetime_date", Timestamp.SCHEMA)
                 .build();
 
 
@@ -421,6 +423,8 @@ public class ClickHouseSinkTaskWithSchemaTest {
                     .put("timestamp_date",  new Date(System.currentTimeMillis()))
                     .put("time_int32", new Date(System.currentTimeMillis()))
                     .put("time_date32", new Date(System.currentTimeMillis()))
+                    .put("date_date", new Date(System.currentTimeMillis()))
+                    .put("datetime_date", new Date(System.currentTimeMillis()))
                     ;
 
 
@@ -634,7 +638,7 @@ public class ClickHouseSinkTaskWithSchemaTest {
 
         String topic = "support-dates-table-test";
         dropTable(chc, topic);
-        createTable(chc, topic, "CREATE TABLE `%s` ( `off16` Int16, date_number Nullable(Date), date32_number Nullable(Date32), datetime_number DateTime, datetime64_number DateTime64, timestamp_int64 Int64, timestamp_date DateTime64, time_int32 Int32, time_date32 Date32 ) Engine = MergeTree ORDER BY off16");
+        createTable(chc, topic, "CREATE TABLE `%s` ( `off16` Int16, date_number Nullable(Date), date32_number Nullable(Date32), datetime_number DateTime, datetime64_number DateTime64, timestamp_int64 Int64, timestamp_date DateTime64, time_int32 Int32, time_date32 Date32, date_date Date, datetime_date DateTime ) Engine = MergeTree ORDER BY off16");
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = createDateType(topic, 1);
 


### PR DESCRIPTION
 Implement Correct Date Conversion Across All Date Types
fixes #154

## Summary
The PR corrects date conversions across Date, Date32, DateTime, and DateTime64. Previously, milliseconds were incorrectly used for date conversion instead of days. This adjustment aligns with Avro's standard 'date' logical type representation that uses days.

In addition, the PR introduces the conversion logic to all date types where it was missing. This ensures consistency and data integrity, preventing potential errors due to datatype mismatch.

Your feedback is appreciated.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
