### PR TITLE
Supporting table mapping

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
@@ -23,7 +23,7 @@ public class ClickHouseSinkConfig {
     public static final String EXACTLY_ONCE = "exactlyOnce";
     public static final String SUPPRESS_TABLE_EXISTENCE_EXCEPTION = "suppressTableExistenceException";
     public static final String CLICKHOUSE_SETTINGS = "clickhouseSettings";
-    public static final String TABLE_MAPPING = "tableMapping";
+    public static final String TABLE_MAPPING = "topic2TableMap";
     public static final String ERRORS_TOLERANCE = "errors.tolerance";
     public static final String TABLE_REFRESH_INTERVAL = "tableRefreshInterval";
 

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -161,11 +161,13 @@ public class ClickHouseWriter implements DBWriter {
         try {
             Record first = records.get(0);
             String topic = first.getTopic();
-            Table table = this.mapping.get(Utils.escapeTopicName(topic));
+//            Table table = this.mapping.get(Utils.escapeTopicName(topic));
+            Table table = this.mapping.get(Utils.getTableName(topic, csc.getTopicToTableMap()));
             LOGGER.debug("Actual Min Offset: {} Max Offset: {} Partition: {}",
                     first.getRecordOffsetContainer().getOffset(),
                     records.get(records.size() - 1).getRecordOffsetContainer().getOffset(),
                     first.getRecordOffsetContainer().getPartition());
+            LOGGER.debug("Table name: {}", table.getName());
 
             switch (first.getSchemaType()) {
                 case SCHEMA:
@@ -446,7 +448,7 @@ public class ClickHouseWriter implements DBWriter {
         Record first = records.get(0);
         String topic = first.getTopic();
         LOGGER.info("Inserting {} records into topic {}", batchSize, topic);
-        Table table = this.mapping.get(Utils.escapeTopicName(topic));
+        Table table = this.mapping.get(Utils.getTableName(topic, csc.getTopicToTableMap()));
         if (table == null) {
             //TODO to pick the correct exception here
             throw new RuntimeException(String.format("Table %s does not exist.", topic));
@@ -523,7 +525,7 @@ public class ClickHouseWriter implements DBWriter {
         Record first = records.get(0);
         String topic = first.getTopic();
         LOGGER.info(String.format("Number of records to insert %d to table name %s", batchSize, topic));
-        Table table = this.mapping.get(Utils.escapeTopicName(topic));
+        Table table = this.mapping.get(Utils.getTableName(topic, csc.getTopicToTableMap()));
         if (table == null) {
             if (csc.getSuppressTableExistenceException()) {
                 LOGGER.error("Table {} does not exist - see docs for more details about table names and topic names.", topic);

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -161,7 +161,6 @@ public class ClickHouseWriter implements DBWriter {
         try {
             Record first = records.get(0);
             String topic = first.getTopic();
-//            Table table = this.mapping.get(Utils.escapeTopicName(topic));
             Table table = this.mapping.get(Utils.getTableName(topic, csc.getTopicToTableMap()));
             LOGGER.debug("Actual Min Offset: {} Max Offset: {} Partition: {}",
                     first.getRecordOffsetContainer().getOffset(),

--- a/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
+++ b/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
+import java.util.Map;
 
 public class Utils {
 
@@ -99,6 +100,16 @@ public class Utils {
         if (errorReporter != null && record.getSinkRecord() != null) {
             errorReporter.report(record.getSinkRecord(), exception);
         }
+    }
+
+    public static String getTableName(String topicName, Map<String, String> topicToTableMap) {
+        String tableName = topicToTableMap.get(topicName);
+        LOGGER.debug("Topic name: {}, Table Name: {}", topicName, tableName);
+        if (tableName == null) {
+            tableName = topicName;
+        }
+
+        return escapeTopicName(tableName);
     }
 
 }


### PR DESCRIPTION
This adds a new setting to allow customers to specify a mapping between topic and table names (without a transformer)
