### PR TITLE
Update manifest.json

### DIFF
--- a/config/archive/manifest.json
+++ b/config/archive/manifest.json
@@ -1,7 +1,6 @@
 {
     "name" : "clickhouse-kafka-connect",
     "version" : "${project.version}",
-    "implementation-version" : "${project.version}",
     "title" : "ClickHouse Connector for Apache Kafka",
     "description" : "the official Kafka Connect Sink connector for ClickHouse.",
     "documentation_url": "https://clickhouse.com/docs/en/integrations/kafka/clickhouse-kafka-connect-sink",


### PR DESCRIPTION
This removes the line from the manifest - it's added to the jar in the gradle flow, so it only causes issues with confluent-hub being there.
