### PR TITLE
issue 250: fix ingestion of arrays of nullable primitives

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -435,6 +435,9 @@ public class ClickHouseWriter implements DBWriter {
                     BinaryStreamUtils.writeVarInt(stream, sizeArrObject);
                     arrObject.forEach(v -> {
                         try {
+                            if (col.getSubType().isNullable() && v != null) {
+                                BinaryStreamUtils.writeNonNull(stream);
+                            }
                             doWritePrimitive(col.getSubType().getType(), value.getFieldType(), stream, v);
                         } catch (IOException e) {
                             throw new RuntimeException(e);

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
@@ -81,6 +81,24 @@ public class ClickHouseSinkTaskWithSchemaTest {
 
         assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
     }
+
+    @Test
+    public void arrayNullableSubtypesTest() {
+        Map<String, String> props = getTestProperties();
+        ClickHouseHelperClient chc = createClient(props);
+
+        String topic = "array_nullable_subtypes_table_test";
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE %s ( `off16` Int16, `arr_nullable_str` Array(Nullable(String)), `arr_empty_nullable_str` Array(Nullable(String)), `arr_nullable_int8` Array(Nullable(Int8)), `arr_nullable_int16` Array(Nullable(Int16)), `arr_nullable_int32` Array(Nullable(Int32)), `arr_nullable_int64` Array(Nullable(Int64)), `arr_nullable_float32` Array(Nullable(Float32)), `arr_nullable_float64` Array(Nullable(Float64)), `arr_nullable_bool` Array(Nullable(Bool))  ) Engine = MergeTree ORDER BY off16");
+        Collection<SinkRecord> sr = SchemaTestData.createArrayNullableSubtypes(topic, 1);
+
+        ClickHouseSinkTask chst = new ClickHouseSinkTask();
+        chst.start(props);
+        chst.put(sr);
+        chst.stop();
+
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+    }
     
     @Test
     public void mapTypesTest() {

--- a/src/test/java/com/clickhouse/kafka/connect/sink/helper/SchemaTestData.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/helper/SchemaTestData.java
@@ -180,6 +180,74 @@ public class SchemaTestData {
         });
         return array;
     }
+    public static Collection<SinkRecord> createArrayNullableSubtypes(String topic, int partition) {
+        Schema ARRAY_OPTIONAL_STRING_SCHEMA = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).build();
+        Schema ARRAY_OPTIONAL_INT8_SCHEMA = SchemaBuilder.array(Schema.OPTIONAL_INT8_SCHEMA).build();
+        Schema ARRAY_OPTIONAL_INT16_SCHEMA = SchemaBuilder.array(Schema.OPTIONAL_INT16_SCHEMA).build();
+        Schema ARRAY_OPTIONAL_INT32_SCHEMA = SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).build();
+        Schema ARRAY_OPTIONAL_INT64_SCHEMA = SchemaBuilder.array(Schema.OPTIONAL_INT64_SCHEMA).build();
+        Schema ARRAY_OPTIONAL_FLOAT32_SCHEMA = SchemaBuilder.array(Schema.OPTIONAL_FLOAT32_SCHEMA).build();
+        Schema ARRAY_OPTIONAL_FLOAT64_SCHEMA = SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).build();
+        Schema ARRAY_OPTIONAL_BOOLEAN_SCHEMA = SchemaBuilder.array(Schema.OPTIONAL_BOOLEAN_SCHEMA).build();
+
+
+
+        Schema NESTED_SCHEMA = SchemaBuilder.struct()
+                .field("off16", Schema.INT16_SCHEMA)
+                .field("arr_nullable_str", ARRAY_OPTIONAL_STRING_SCHEMA)
+                .field("arr_empty_nullable_str", ARRAY_OPTIONAL_STRING_SCHEMA)
+                .field("arr_nullable_int8", ARRAY_OPTIONAL_INT8_SCHEMA)
+                .field("arr_nullable_int16", ARRAY_OPTIONAL_INT16_SCHEMA)
+                .field("arr_nullable_int32", ARRAY_OPTIONAL_INT32_SCHEMA)
+                .field("arr_nullable_int64", ARRAY_OPTIONAL_INT64_SCHEMA)
+                .field("arr_nullable_float32", ARRAY_OPTIONAL_FLOAT32_SCHEMA)
+                .field("arr_nullable_float64", ARRAY_OPTIONAL_FLOAT64_SCHEMA)
+                .field("arr_nullable_bool", ARRAY_OPTIONAL_BOOLEAN_SCHEMA)
+                .build();
+
+        List<SinkRecord> array = new ArrayList<>();
+        LongStream.range(0, 1000).forEachOrdered(n -> {
+
+            List<String> arrayNullableStrTmp = Arrays.asList("1","2");
+            List<String> arrayNullableStrEmpty = new ArrayList<>();
+            List<Byte> arrayNullableInt8Tmp = Arrays.asList((byte)1,null);
+            List<Short> arrayNullableInt16Tmp = Arrays.asList((short)1, null);
+            List<Integer> arrayNullableInt32Tmp = Arrays.asList((int)1,null);
+            List<Long> arrayNullableInt64Tmp = Arrays.asList((long)1,null);
+            List<Float> arrayNullableFloat32Tmp = Arrays.asList((float)1,null);
+            List<Double> arrayNullableFloat64Tmp = Arrays.asList((double)1,null);
+            List<Boolean> arrayNullableBoolTmp = Arrays.asList(true,null);
+
+
+            Struct value_struct = new Struct(NESTED_SCHEMA)
+                    .put("off16", (short)n)
+                    .put("arr_nullable_str", arrayNullableStrTmp)
+                    .put("arr_empty_nullable_str", arrayNullableStrEmpty)
+                    .put("arr_nullable_int8", arrayNullableInt8Tmp)
+                    .put("arr_nullable_int16", arrayNullableInt16Tmp)
+                    .put("arr_nullable_int32", arrayNullableInt32Tmp)
+                    .put("arr_nullable_int64", arrayNullableInt64Tmp)
+                    .put("arr_nullable_float32", arrayNullableFloat32Tmp)
+                    .put("arr_nullable_float64", arrayNullableFloat64Tmp)
+                    .put("arr_nullable_bool", arrayNullableBoolTmp)
+                    ;
+
+
+            SinkRecord sr = new SinkRecord(
+                    topic,
+                    partition,
+                    null,
+                    null, NESTED_SCHEMA,
+                    value_struct,
+                    n,
+                    System.currentTimeMillis(),
+                    TimestampType.CREATE_TIME
+            );
+
+            array.add(sr);
+        });
+        return array;
+    }
     public static Collection<SinkRecord> createMapType(String topic, int partition) {
 
         Schema MAP_SCHEMA_STRING_STRING = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA);


### PR DESCRIPTION
## Summary
Fixes ingestion for arrays of nullable primitives by writing the nullable byte before each non-null element
Issue: https://github.com/ClickHouse/clickhouse-kafka-connect/issues/250

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
