### PR TITLE
Feature Request 258: Support for data ingestion into `Array(DateTime64(3))` type columns

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -320,6 +320,7 @@ public class ClickHouseWriter implements DBWriter {
                     BinaryStreamUtils.writeInt32(stream, (Integer) value);
                 }
                 break;
+            case DateTime64:
             case INT64:
                 if (value.getClass().getName().endsWith(".Date")) {
                     Date date = (Date) value;
@@ -360,8 +361,6 @@ public class ClickHouseWriter implements DBWriter {
             case UUID:
                 BinaryStreamUtils.writeUuid(stream, UUID.fromString((String) value));
                 break;
-            case DateTime64:
-                BinaryStreamUtils.writeInt64(stream, (Long) value);
         }
     }
 

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -360,6 +360,8 @@ public class ClickHouseWriter implements DBWriter {
             case UUID:
                 BinaryStreamUtils.writeUuid(stream, UUID.fromString((String) value));
                 break;
+            case DateTime64:
+                BinaryStreamUtils.writeInt64(stream, (Long) value);
         }
     }
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
@@ -207,7 +207,7 @@ public class ClickHouseSinkTaskWithSchemaTest {
 
         String topic = "support-array-datetime64-table-test";
         ClickHouseTestHelpers.dropTable(chc, topic);
-        ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE `%s` ( `off16` Int16, arr_datetime64_number Array(DateTime64) ) Engine = MergeTree ORDER BY off16");
+        ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE `%s` ( `off16` Int16, arr_datetime64_number Array(DateTime64), arr_timestamp_date Array(DateTime64) ) Engine = MergeTree ORDER BY off16");
         Collection<SinkRecord> sr = SchemaTestData.createArrayDateTime64Type(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
@@ -199,6 +199,24 @@ public class ClickHouseSinkTaskWithSchemaTest {
 
         assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
     }
+
+    @Test
+    public void supportArrayDateTime64Test() {
+        Map<String, String> props = getTestProperties();
+        ClickHouseHelperClient chc = createClient(props);
+
+        String topic = "support-array-datetime64-table-test";
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE `%s` ( `off16` Int16, arr_datetime64_number Array(DateTime64) ) Engine = MergeTree ORDER BY off16");
+        Collection<SinkRecord> sr = SchemaTestData.createArrayDateTime64Type(topic, 1);
+
+        ClickHouseSinkTask chst = new ClickHouseSinkTask();
+        chst.start(props);
+        chst.put(sr);
+        chst.stop();
+
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+    }
     
     @Test
     public void detectUnsupportedDataConversions() {

--- a/src/test/java/com/clickhouse/kafka/connect/sink/helper/SchemaTestData.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/helper/SchemaTestData.java
@@ -431,6 +431,7 @@ public class SchemaTestData {
             Schema NESTED_SCHEMA = SchemaBuilder.struct()
                     .field("off16", Schema.INT16_SCHEMA)
                     .field("arr_datetime64_number", SchemaBuilder.array(Schema.INT64_SCHEMA).build())
+                    .field("arr_timestamp_date", SchemaBuilder.array(Timestamp.SCHEMA).build())
                     .build();
 
 
@@ -438,11 +439,15 @@ public class SchemaTestData {
             LongStream.range(0, 1000).forEachOrdered(n -> {
                 long currentTime1 = System.currentTimeMillis();
                 long currentTime2 = System.currentTimeMillis();
+                Date date1 = new Date(System.currentTimeMillis());
+                Date date2 = new Date(System.currentTimeMillis());
                 List<Long> arrayDateTime64Number = Arrays.asList(currentTime1, currentTime2);
+                List<Date> arrayTimestamps = Arrays.asList(date1, date2);
 
                 Struct value_struct = new Struct(NESTED_SCHEMA)
                         .put("off16", (short)n)
                         .put("arr_datetime64_number", arrayDateTime64Number)
+                        .put("arr_timestamp_date", arrayTimestamps)
                         ;
 
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/helper/SchemaTestData.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/helper/SchemaTestData.java
@@ -426,6 +426,41 @@ public class SchemaTestData {
         });
         return array;
     }
+    public static Collection<SinkRecord> createArrayDateTime64Type(String topic, int partition) {
+
+            Schema NESTED_SCHEMA = SchemaBuilder.struct()
+                    .field("off16", Schema.INT16_SCHEMA)
+                    .field("arr_datetime64_number", SchemaBuilder.array(Schema.INT64_SCHEMA).build())
+                    .build();
+
+
+            List<SinkRecord> array = new ArrayList<>();
+            LongStream.range(0, 1000).forEachOrdered(n -> {
+                long currentTime1 = System.currentTimeMillis();
+                long currentTime2 = System.currentTimeMillis();
+                List<Long> arrayDateTime64Number = Arrays.asList(currentTime1, currentTime2);
+
+                Struct value_struct = new Struct(NESTED_SCHEMA)
+                        .put("off16", (short)n)
+                        .put("arr_datetime64_number", arrayDateTime64Number)
+                        ;
+
+
+                SinkRecord sr = new SinkRecord(
+                        topic,
+                        partition,
+                        null,
+                        null, NESTED_SCHEMA,
+                        value_struct,
+                        n,
+                        System.currentTimeMillis(),
+                        TimestampType.CREATE_TIME
+                );
+
+                array.add(sr);
+            });
+            return array;
+        }
     public static Collection<SinkRecord> createUnsupportedDataConversions(String topic, int partition) {
 
         Schema NESTED_SCHEMA = SchemaBuilder.struct()


### PR DESCRIPTION
## Summary
This change adds support for data ingestion into `Array(DateTime64(3))` type columns by supporting ingestion of arrays of longs & of arrays of Date objects. A refactor may be needed to maintain the semantics of not interpreting the DateTime64 type as a primitive type, but the logic seems to work as is.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
