### PR TITLE
wait end of query to make sure the processing is successful

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
@@ -173,6 +173,7 @@ public class ClickHouseSinkConfig {
         this.addClickHouseSetting("insert_quorum", "2", false);
         this.addClickHouseSetting("input_format_skip_unknown_fields", "1", false);
         this.addClickHouseSetting("send_progress_in_http_headers", "1", false);
+        this.addClickHouseSetting("wait_end_of_query", "1", false);
 
         topicToTableMap = new HashMap<>();
         String topicToTableMapString = props.getOrDefault(TABLE_MAPPING, "").trim();


### PR DESCRIPTION
## Summary
wait end of query to avoid situation when an exception happens after the response. see https://clickhouse.com/docs/en/interfaces/http#http_response_codes_caveats
