### PR TITLE
Adding Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+ARG CONFLUENT_VERSION
+FROM confluentinc/cp-server-connect-base:${CONFLUENT_VERSION}
+
+ARG CONNECTOR_VERSION
+RUN confluent-hub install --no-prompt clickhouse/clickhouse-kafka-connect:${CONNECTOR_VERSION}


### PR DESCRIPTION
This is a basic Dockerfile to bundle Confluent and our Kafka connector.

To run this: 
`docker build . -t clickhouse-kafka-connect:1.0.6 --build-arg CONFLUENT_VERSION=7.5.0 --build-arg CONNECTOR_VERSION=v1.0.6`

