### PR TITLE
Send an empty array when field is null

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -350,7 +350,7 @@ public class ClickHouseWriter implements DBWriter {
                 BinaryStreamUtils.writeNonNull(stream);
             }
             if (!col.isNullable() && value.getObject() == null) {
-                if (colType == Type.ARRAY && col.getSubType().isNullable())
+                if (colType == Type.ARRAY)
                     BinaryStreamUtils.writeNonNull(stream);
                 else
                     throw new RuntimeException(String.format("An attempt to write null into not nullable column '%s'", col.getName()));

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
@@ -131,8 +131,10 @@ public class ClickHouseSinkTaskWithSchemaTest {
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
-        assertThrowsExactly(RuntimeException.class, () -> chst.put(sr), "An attempt to write null into not nullable column 'arr'");
+        chst.put(sr);
         chst.stop();
+
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
     }
 
     @Test


### PR DESCRIPTION
So this handles the null schema array issue, with a bit of selective logic.

If the subtype is nullable (e.g. Array(Nullable(String))) then we will pass an empty array if the array is sent null.
If the subtype is NOT nullable (e.g. Array(String)) then we through an exception as normal for "null when not nullable".

Since Array itself cannot be nullable, I thought this was a good compromise and consistent with the logic - does it make sense?