### PR TITLE
fix 'overlapping' logic

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/kafka/RangeContainer.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/kafka/RangeContainer.java
@@ -51,23 +51,23 @@ public class RangeContainer extends TopicPartitionContainer {
         long actualMinOffset = rangeContainer.getMinOffset();
         long actualMaxOffset = rangeContainer.getMaxOffset();
 
-        // SAME State [0,10] Actual [0,10]
-        if (maxOffset == actualMaxOffset && minOffset == actualMinOffset)
+        // SAME State [0, 10] Actual [0, 10]
+        if (actualMaxOffset == maxOffset && actualMinOffset <= minOffset)
             return RangeState.SAME;
-        // NEW State [0,10] Actual [11,20]
+        // NEW State [0, 10] Actual [11, 20]
         if (actualMinOffset > maxOffset)
             return RangeState.NEW;
-        // CONTAINS [0,10] Actual [1, 10]
+        // CONTAINS [0, 10] Actual [1, 10]
         if (actualMaxOffset <= maxOffset && actualMinOffset >= minOffset)
             return RangeState.CONTAINS;
-        // ZEROED [10, 20] Actual [0, 10]
-        if (actualMinOffset < minOffset && actualMinOffset == 0)
-            return RangeState.ZERO;
-        // ERROR [10,20] Actual [8, X]
-        if (actualMinOffset < minOffset)
-            return RangeState.ERROR;
         // OVER_LAPPING
-        return RangeState.OVER_LAPPING;
+        if (actualMaxOffset > maxOffset)
+            return RangeState.OVER_LAPPING;
+        // ZEROED [10, 20] Actual [0, 10]
+        if (actualMinOffset == 0)
+            return RangeState.ZERO;
+        // ERROR [10, 20] Actual [8, 19]
+        return RangeState.ERROR;
     }
 
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/kafa/RangeContainerTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/kafa/RangeContainerTest.java
@@ -16,9 +16,11 @@ public class RangeContainerTest {
     @Test
     @DisplayName("sameRangeTest")
     public void sameRangeTest() {
-        RangeContainer rangeContainerFirst = new RangeContainer(topic, partition, 10, 0);
-        RangeContainer rangeContainerSecond = new RangeContainer(topic, partition, 10, 0);
-        assertEquals(RangeState.SAME, rangeContainerFirst.getOverLappingState(rangeContainerSecond));
+        RangeContainer rangeContainerFirst = new RangeContainer(topic, partition, 10, 1);
+        RangeContainer rangeContainerSecond01 = new RangeContainer(topic, partition, 10, 1);
+        RangeContainer rangeContainerSecond02 = new RangeContainer(topic, partition, 10, 0);
+        assertEquals(RangeState.SAME, rangeContainerFirst.getOverLappingState(rangeContainerSecond01));
+        assertEquals(RangeState.SAME, rangeContainerFirst.getOverLappingState(rangeContainerSecond02));
 
     }
 
@@ -59,14 +61,16 @@ public class RangeContainerTest {
     @Test
     @DisplayName("overlapRangeTest")
     public void overlapRangeTest() {
-        RangeContainer rangeContainerFirst = new RangeContainer(topic, partition, 10, 0);
+        RangeContainer rangeContainerFirst = new RangeContainer(topic, partition, 10, 1);
         RangeContainer rangeContainerSecond01 = new RangeContainer(topic, partition, 19, 10);
         RangeContainer rangeContainerSecond02 = new RangeContainer(topic, partition, 19, 3);
         RangeContainer rangeContainerSecond03 = new RangeContainer(topic, partition, 20, 6);
+        RangeContainer rangeContainerSecond04 = new RangeContainer(topic, partition, 11, 0);
 
         assertEquals(RangeState.OVER_LAPPING, rangeContainerFirst.getOverLappingState(rangeContainerSecond01));
         assertEquals(RangeState.OVER_LAPPING, rangeContainerFirst.getOverLappingState(rangeContainerSecond02));
         assertEquals(RangeState.OVER_LAPPING, rangeContainerFirst.getOverLappingState(rangeContainerSecond03));
+        assertEquals(RangeState.OVER_LAPPING, rangeContainerFirst.getOverLappingState(rangeContainerSecond04));
 
     }
 


### PR DESCRIPTION
## Summary

1. Excluded excess data processing when state = `BEFORE_PROCESSING'
2. Fixed order of chunks in overlapping range cases
3. Prevented insertion of the 1 chunk in overlapping range case when state = `BEFORE_PROCESSING' and 1 chunk boundaries are not the same as state
4. Fixed and extended different range overlapping cases taking into account that records are trimmed before processing, for example:
```
State                 Actual                 Current                 After fix
[2, 10]               [0, 11]                ZERO                    OVER_LAPPING
[2, 10]               [0, 10]                ZERO                    SAME
[2, 10]               [1, 11]                ERROR                   OVER_LAPPING
[2, 10]               [1, 10]                ERROR                   SAME
```


## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
