### PR TITLE
feat: support complex nested structures

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/data/Data.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/data/Data.java
@@ -3,16 +3,24 @@ package com.clickhouse.kafka.connect.sink.data;
 import org.apache.kafka.connect.data.Schema;
 
 public class Data {
-    private Schema.Type fieldType;
+    private Schema schema;
     private Object object;
 
-    public Data(Schema.Type fieldType, Object object) {
-        this.fieldType = fieldType;
+    public Data(Schema schema, Object object) {
+        this.schema = schema;
         this.object = object;
     }
 
     public Schema.Type getFieldType() {
-        return fieldType;
+        return schema.type();
+    }
+
+    public Schema getMapKeySchema() {
+        return schema.keySchema();
+    }
+
+    public Schema getNestedValueSchema() {
+        return schema.valueSchema();
     }
 
     public Object getObject() {

--- a/src/main/java/com/clickhouse/kafka/connect/sink/data/convert/SchemalessRecordConvertor.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/data/convert/SchemalessRecordConvertor.java
@@ -28,7 +28,7 @@ public class SchemalessRecordConvertor implements RecordConvertor {
         int index = 0;
         map.forEach((key,val) -> {
                     fields.add(new Field(key.toString(), index, Schema.STRING_SCHEMA));
-                    data.put(key.toString(), new Data(Schema.Type.STRING, val == null ? null : val.toString()));
+                    data.put(key.toString(), new Data(Schema.STRING_SCHEMA, val == null ? null : val.toString()));
                 });
         return new Record(SchemaType.SCHEMA_LESS, new OffsetContainer(topic, partition, offset), fields, data, sinkRecord);
     }

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/mapping/Column.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/mapping/Column.java
@@ -20,7 +20,7 @@ public class Column {
     private boolean hasDefaultValue;
     private Column subType = null;
     private Type mapKeyType = Type.NONE;
-    private Type mapValueType = Type.NONE;
+    private Column mapValueType = null;
     private int precision;
     private int scale;
 
@@ -33,7 +33,7 @@ public class Column {
         this.precision = 0;
     }
 
-    private Column(String name, Type type, boolean isNullable, boolean hasDefaultValue, Type mapKeyType, Type mapValueType) {
+    private Column(String name, Type type, boolean isNullable, boolean hasDefaultValue, Type mapKeyType, Column mapValueType) {
         this.name = name;
         this.type = type;
         this.isNullable = isNullable;
@@ -90,7 +90,7 @@ public class Column {
     public Type getMapKeyType() {
         return mapKeyType;
     }
-    public  Type getMapValueType() {
+    public  Column getMapValueType() {
         return mapValueType;
     }
     private static Type dispatchPrimitive(String valueType) {
@@ -181,10 +181,11 @@ public class Column {
         } else if(valueType.startsWith("Map")) {
             type = Type.MAP;
             String value = valueType.substring("Map".length() + 1, valueType.length() - 1);
-            String[] val = value.split(",");
+            String[] val = value.split(",", 2);
             String mapKey = val[0].trim();
             String mapValue = val[1].trim();
-            return new Column(name, type, false, hasDefaultValue, dispatchPrimitive(mapKey), dispatchPrimitive(mapValue));
+            Column mapValueType = extractColumn(name, mapValue, false, hasDefaultValue);
+            return new Column(name, type, false, hasDefaultValue, dispatchPrimitive(mapKey), mapValueType);
         } else if (valueType.startsWith("LowCardinality")) {
             return extractColumn(name, valueType.substring("LowCardinality".length() + 1, valueType.length() - 1), isNull, hasDefaultValue);
         } else if (valueType.startsWith("Nullable")) {

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessProxyTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessProxyTest.java
@@ -148,7 +148,8 @@ public class ClickHouseSinkTaskSchemalessProxyTest {
         String topic = "schemaless_array_string_table_test";
         ClickHouseTestHelpers.dropTable(chc, topic);
         ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE %s ( `off16` Int16, `arr` Array(String), `arr_empty` Array(String), `arr_int8` Array(Int8), " +
-                "`arr_int16` Array(Int16), `arr_int32` Array(Int32), `arr_int64` Array(Int64), `arr_float32` Array(Float32), `arr_float64` Array(Float64), `arr_bool` Array(Bool)  ) Engine = MergeTree ORDER BY off16");
+                "`arr_int16` Array(Int16), `arr_int32` Array(Int32), `arr_int64` Array(Int64), `arr_float32` Array(Float32), `arr_float64` Array(Float64), `arr_bool` Array(Bool)," +
+                "`arr_str_arr` Array(Array(String)), `arr_arr_str_arr` Array(Array(Array(String))), `arr_map` Array(Map(String, String))  ) Engine = MergeTree ORDER BY off16");
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemalessTestData.createArrayType(topic, 1);
 
@@ -167,7 +168,9 @@ public class ClickHouseSinkTaskSchemalessProxyTest {
         String topic = "schemaless_map_table_test";
         ClickHouseTestHelpers.dropTable(chc, topic);
         ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE %s ( `off16` Int16, map_string_string Map(String, String), map_string_int64 Map(String, Int64), " +
-                "map_int64_string Map(Int64, String)  ) Engine = MergeTree ORDER BY off16");
+                "map_int64_string Map(Int64, String), map_string_map Map(String, Map(String, Int64)), map_string_array Map(String, Array(String)), " +
+                "map_map_map Map(String, Map(String, Map(String, String)))   ) Engine = MergeTree ORDER BY off16");
+
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemalessTestData.createMapType(topic, 1);
 
@@ -187,7 +190,8 @@ public class ClickHouseSinkTaskSchemalessProxyTest {
         String topic = "special-char-table-test";
         ClickHouseTestHelpers.dropTable(chc, topic);
         ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE `%s` ( `off16` Int16, map_string_string Map(String, String), map_string_int64 Map(String, Int64), " +
-                "map_int64_string Map(Int64, String)  ) Engine = MergeTree ORDER BY off16");
+                "map_int64_string Map(Int64, String), map_string_map Map(String, Map(String, Int64)), map_string_array Map(String, Array(String)), " +
+                "map_map_map Map(String, Map(String, Map(String, String)))   ) Engine = MergeTree ORDER BY off16");
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemalessTestData.createMapType(topic, 1);
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaProxyTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaProxyTest.java
@@ -118,7 +118,8 @@ public class ClickHouseSinkTaskWithSchemaProxyTest {
         String topic = "map_table_test";
         ClickHouseTestHelpers.dropTable(chc, topic);
         ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE %s ( `off16` Int16, map_string_string Map(String, String), map_string_int64 Map(String, Int64), " +
-                "map_int64_string Map(Int64, String), map_string_map Map(String, Map(String, Int64)), map_string_array Map(String, Array(String))  ) Engine = MergeTree ORDER BY off16");
+                "map_int64_string Map(Int64, String), map_string_map Map(String, Map(String, Int64)), map_string_array Map(String, Array(String))," +
+                "map_map_map Map(String, Map(String, Map(String, String)))  ) Engine = MergeTree ORDER BY off16");
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createMapType(topic, 1);
 
@@ -160,7 +161,8 @@ public class ClickHouseSinkTaskWithSchemaProxyTest {
         String topic = "special-char-table-test";
         ClickHouseTestHelpers.dropTable(chc, topic);
         ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE `%s` ( `off16` Int16, map_string_string Map(String, String), map_string_int64 Map(String, Int64), " +
-                "map_int64_string Map(Int64, String), map_string_map Map(String, Map(String, Int64)), map_string_array Map(String, Array(String))  ) Engine = MergeTree ORDER BY off16");
+                "map_int64_string Map(Int64, String), map_string_map Map(String, Map(String, Int64)), map_string_array Map(String, Array(String))," +
+                "map_map_map Map(String, Map(String, Map(String, String)))  ) Engine = MergeTree ORDER BY off16");
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createMapType(topic, 1);
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaProxyTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaProxyTest.java
@@ -118,7 +118,7 @@ public class ClickHouseSinkTaskWithSchemaProxyTest {
         String topic = "map_table_test";
         ClickHouseTestHelpers.dropTable(chc, topic);
         ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE %s ( `off16` Int16, map_string_string Map(String, String), map_string_int64 Map(String, Int64), " +
-                "map_int64_string Map(Int64, String)  ) Engine = MergeTree ORDER BY off16");
+                "map_int64_string Map(Int64, String), map_string_map Map(String, Map(String, Int64)), map_string_array Map(String, Array(String))  ) Engine = MergeTree ORDER BY off16");
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createMapType(topic, 1);
 
@@ -160,7 +160,7 @@ public class ClickHouseSinkTaskWithSchemaProxyTest {
         String topic = "special-char-table-test";
         ClickHouseTestHelpers.dropTable(chc, topic);
         ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE `%s` ( `off16` Int16, map_string_string Map(String, String), map_string_int64 Map(String, Int64), " +
-                "map_int64_string Map(Int64, String)  ) Engine = MergeTree ORDER BY off16");
+                "map_int64_string Map(Int64, String), map_string_map Map(String, Map(String, Int64)), map_string_array Map(String, Array(String))  ) Engine = MergeTree ORDER BY off16");
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createMapType(topic, 1);
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
@@ -70,7 +70,9 @@ public class ClickHouseSinkTaskWithSchemaTest {
 
         String topic = "array_string_table_test";
         ClickHouseTestHelpers.dropTable(chc, topic);
-        ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE %s ( `off16` Int16, `arr` Array(String), `arr_empty` Array(String), `arr_int8` Array(Int8), `arr_int16` Array(Int16), `arr_int32` Array(Int32), `arr_int64` Array(Int64), `arr_float32` Array(Float32), `arr_float64` Array(Float64), `arr_bool` Array(Bool)  ) Engine = MergeTree ORDER BY off16");
+        ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE %s ( `off16` Int16, `arr` Array(String), `arr_empty` Array(String), " +
+                "`arr_int8` Array(Int8), `arr_int16` Array(Int16), `arr_int32` Array(Int32), `arr_int64` Array(Int64), `arr_float32` Array(Float32), " +
+                "`arr_float64` Array(Float64), `arr_bool` Array(Bool), `arr_str_arr` Array(Array(String)), `arr_map_arr` Array(Map(String, String))  ) Engine = MergeTree ORDER BY off16");
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createArrayType(topic, 1);
 
@@ -107,7 +109,9 @@ public class ClickHouseSinkTaskWithSchemaTest {
 
         String topic = "map_table_test";
         ClickHouseTestHelpers.dropTable(chc, topic);
-        ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE %s ( `off16` Int16, map_string_string Map(String, String), map_string_int64 Map(String, Int64), map_int64_string Map(Int64, String)  ) Engine = MergeTree ORDER BY off16");
+        ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE %s ( `off16` Int16, map_string_string Map(String, String), " +
+                "map_string_int64 Map(String, Int64), map_int64_string Map(Int64, String), map_string_map Map(String, Map(String, Int64))," +
+                "map_string_array Map(String, Array(String))  ) Engine = MergeTree ORDER BY off16");
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createMapType(topic, 1);
 
@@ -183,7 +187,9 @@ public class ClickHouseSinkTaskWithSchemaTest {
 
         String topic = "special-char-table-test";
         ClickHouseTestHelpers.dropTable(chc, topic);
-        ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE `%s` ( `off16` Int16, map_string_string Map(String, String), map_string_int64 Map(String, Int64), map_int64_string Map(Int64, String)  ) Engine = MergeTree ORDER BY off16");
+        ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE `%s` ( `off16` Int16, " +
+                "map_string_string Map(String, String), map_string_int64 Map(String, Int64), map_int64_string Map(Int64, String), " +
+                "map_string_map Map(String, Map(String, Int64)), map_string_array Map(String, Array(String))  ) Engine = MergeTree ORDER BY off16");
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createMapType(topic, 1);
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
@@ -72,7 +72,8 @@ public class ClickHouseSinkTaskWithSchemaTest {
         ClickHouseTestHelpers.dropTable(chc, topic);
         ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE %s ( `off16` Int16, `arr` Array(String), `arr_empty` Array(String), " +
                 "`arr_int8` Array(Int8), `arr_int16` Array(Int16), `arr_int32` Array(Int32), `arr_int64` Array(Int64), `arr_float32` Array(Float32), " +
-                "`arr_float64` Array(Float64), `arr_bool` Array(Bool), `arr_str_arr` Array(Array(String)), `arr_map_arr` Array(Map(String, String))  ) Engine = MergeTree ORDER BY off16");
+                "`arr_float64` Array(Float64), `arr_bool` Array(Bool), `arr_str_arr` Array(Array(String)), `arr_arr_str_arr` Array(Array(Array(String))), " +
+                "`arr_map` Array(Map(String, String))  ) Engine = MergeTree ORDER BY off16");
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createArrayType(topic, 1);
 
@@ -111,7 +112,7 @@ public class ClickHouseSinkTaskWithSchemaTest {
         ClickHouseTestHelpers.dropTable(chc, topic);
         ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE %s ( `off16` Int16, map_string_string Map(String, String), " +
                 "map_string_int64 Map(String, Int64), map_int64_string Map(Int64, String), map_string_map Map(String, Map(String, Int64))," +
-                "map_string_array Map(String, Array(String))  ) Engine = MergeTree ORDER BY off16");
+                "map_string_array Map(String, Array(String)), map_map_map Map(String, Map(String, Map(String, String)))  ) Engine = MergeTree ORDER BY off16");
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createMapType(topic, 1);
 
@@ -189,7 +190,8 @@ public class ClickHouseSinkTaskWithSchemaTest {
         ClickHouseTestHelpers.dropTable(chc, topic);
         ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE `%s` ( `off16` Int16, " +
                 "map_string_string Map(String, String), map_string_int64 Map(String, Int64), map_int64_string Map(Int64, String), " +
-                "map_string_map Map(String, Map(String, Int64)), map_string_array Map(String, Array(String))  ) Engine = MergeTree ORDER BY off16");
+                "map_string_map Map(String, Map(String, Int64)), map_string_array Map(String, Array(String))," +
+                "map_map_map Map(String, Map(String, Map(String, String)))  ) Engine = MergeTree ORDER BY off16");
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createMapType(topic, 1);
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/mapping/ColumnTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/mapping/ColumnTest.java
@@ -62,10 +62,52 @@ class ColumnTest {
     }
 
     @Test
-    public void extractDecimal_14_5() {
+    public void extractDecimal_14_2() {
         Column col = Column.extractColumn("columnName", "Decimal(14,2)", true, false);
         assertEquals(Type.Decimal, col.getType());
         assertEquals(14, col.getPrecision());
         assertEquals(2, col.getScale());
+    }
+
+    @Test
+    public void extractArrayOfDecimalNullable_5() {
+        Column col = Column.extractColumn("columnName", "Array(Nullable(Decimal(5)))", true, false);
+        assertEquals(Type.ARRAY, col.getType());
+
+        Column subType = col.getSubType();
+        assertEquals(Type.Decimal, subType.getType());
+        assertEquals(5, subType.getPrecision());
+        assertTrue(subType.isNullable());
+    }
+
+    @Test
+    public void extractMapOfPrimitives() {
+        Column col = Column.extractColumn("columnName", "Map(String, Decimal(5))", true, false);
+        assertEquals(Type.MAP, col.getType());
+
+        assertNull(col.getSubType());
+        assertEquals(Type.STRING, col.getMapKeyType());
+
+        Column mapValueType = col.getMapValueType();
+        assertEquals(Type.Decimal, mapValueType.getType());
+        assertEquals(5, mapValueType.getPrecision());
+    }
+
+    @Test
+    public void extractMapWithComplexValue() {
+        Column col = Column.extractColumn("columnName", "Map(String, Map(String, Decimal(5)))", true, false);
+        assertEquals(Type.MAP, col.getType());
+
+        assertNull(col.getSubType());
+        assertEquals(Type.STRING, col.getMapKeyType());
+
+        Column mapValueType = col.getMapValueType();
+        assertEquals(Type.MAP, mapValueType.getType());
+        assertEquals(Type.STRING, mapValueType.getMapKeyType());
+
+        Column nestedMapValue = mapValueType.getMapValueType();
+        assertEquals(Type.Decimal, nestedMapValue.getType());
+        assertEquals(5, nestedMapValue.getPrecision());
+
     }
 }

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/mapping/ColumnTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/mapping/ColumnTest.java
@@ -81,6 +81,22 @@ class ColumnTest {
     }
 
     @Test
+    public void extractArrayOfArrayOfArrayOfString() {
+        Column col = Column.extractColumn("columnName", "Array(Array(Array(String)))", true, false);
+        assertEquals(Type.ARRAY, col.getType());
+
+        Column subType = col.getSubType();
+        assertEquals(Type.ARRAY, subType.getType());
+
+        Column subSubType = subType.getSubType();
+        assertEquals(Type.ARRAY, subSubType.getType());
+
+        Column subSubSubType = subSubType.getSubType();
+        assertEquals(Type.STRING, subSubSubType.getType());
+        assertNull(subSubSubType.getSubType());
+    }
+
+    @Test
     public void extractMapOfPrimitives() {
         Column col = Column.extractColumn("columnName", "Map(String, Decimal(5))", true, false);
         assertEquals(Type.MAP, col.getType());
@@ -108,6 +124,23 @@ class ColumnTest {
         Column nestedMapValue = mapValueType.getMapValueType();
         assertEquals(Type.Decimal, nestedMapValue.getType());
         assertEquals(5, nestedMapValue.getPrecision());
+    }
 
+    @Test
+    public void extractMapOfMapOfMapOfString() {
+        Column col = Column.extractColumn("columnName", "Map(String, Map(String, Map(String, String)))", true, false);
+        assertEquals(Type.MAP, col.getType());
+        assertEquals(Type.STRING, col.getMapKeyType());
+        assertNull(col.getSubType());
+
+        Column subType = col.getMapValueType();
+        assertEquals(Type.MAP, subType.getType());
+        assertEquals(Type.STRING, subType.getMapKeyType());
+        assertNull(col.getSubType());
+
+        Column subSubType = subType.getMapValueType();
+        assertEquals(Type.MAP, subSubType.getType());
+        assertEquals(Type.STRING, subSubType.getMapKeyType());
+        assertNull(col.getSubType());
     }
 }

--- a/src/test/java/com/clickhouse/kafka/connect/sink/helper/SchemaTestData.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/helper/SchemaTestData.java
@@ -174,7 +174,8 @@ public class SchemaTestData {
         Schema ARRAY_FLOAT32_SCHEMA = SchemaBuilder.array(Schema.FLOAT32_SCHEMA).build();
         Schema ARRAY_FLOAT64_SCHEMA = SchemaBuilder.array(Schema.FLOAT64_SCHEMA).build();
         Schema ARRAY_BOOLEAN_SCHEMA = SchemaBuilder.array(Schema.BOOLEAN_SCHEMA).build();
-
+        Schema ARRAY_STRING_ARRAY_SCHEMA = SchemaBuilder.array(ARRAY_SCHEMA).build();
+        Schema ARRAY_MAP_ARRAY_SCHEMA = SchemaBuilder.array(SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA));
 
 
         Schema NESTED_SCHEMA = SchemaBuilder.struct()
@@ -188,6 +189,8 @@ public class SchemaTestData {
                 .field("arr_float32", ARRAY_FLOAT32_SCHEMA)
                 .field("arr_float64", ARRAY_FLOAT64_SCHEMA)
                 .field("arr_bool", ARRAY_BOOLEAN_SCHEMA)
+                .field("arr_str_arr", ARRAY_STRING_ARRAY_SCHEMA)
+                .field("arr_map_arr", ARRAY_MAP_ARRAY_SCHEMA)
                 .build();
 
 
@@ -203,6 +206,8 @@ public class SchemaTestData {
             List<Float> arrayFloat32Tmp = Arrays.asList((float)1,(float)2);
             List<Double> arrayFloat64Tmp = Arrays.asList((double)1,(double)2);
             List<Boolean> arrayBoolTmp = Arrays.asList(true,false);
+            List<List<String>> arrayStrArray = Arrays.asList(arrayTmp, arrayTmp);
+            List<Map<String, String>> arrayMapArray = Arrays.asList(Map.of("k1", "v1", "k2", "v2"));
 
 
             Struct value_struct = new Struct(NESTED_SCHEMA)
@@ -216,6 +221,8 @@ public class SchemaTestData {
                     .put("arr_float32", arrayFloat32Tmp)
                     .put("arr_float64", arrayFloat64Tmp)
                     .put("arr_bool", arrayBoolTmp)
+                    .put("arr_str_arr", arrayStrArray)
+                    .put("arr_map_arr", arrayMapArray)
                     ;
 
 
@@ -312,12 +319,16 @@ public class SchemaTestData {
         Schema MAP_SCHEMA_STRING_STRING = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA);
         Schema MAP_SCHEMA_STRING_INT64 = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT64_SCHEMA);
         Schema MAP_SCHEMA_INT64_STRING = SchemaBuilder.map(Schema.INT64_SCHEMA, Schema.STRING_SCHEMA);
+        Schema MAP_SCHEMA_STRING_MAP = SchemaBuilder.map(Schema.STRING_SCHEMA, SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT64_SCHEMA));
+        Schema MAP_SCHEMA_STRING_ARRAY = SchemaBuilder.map(Schema.STRING_SCHEMA, SchemaBuilder.array(Schema.STRING_SCHEMA));
 
         Schema NESTED_SCHEMA = SchemaBuilder.struct()
                 .field("off16", Schema.INT16_SCHEMA)
                 .field("map_string_string", MAP_SCHEMA_STRING_STRING)
                 .field("map_string_int64", MAP_SCHEMA_STRING_INT64)
                 .field("map_int64_string", MAP_SCHEMA_INT64_STRING)
+                .field("map_string_map", MAP_SCHEMA_STRING_MAP)
+                .field("map_string_array", MAP_SCHEMA_STRING_ARRAY)
                 .build();
 
 
@@ -339,12 +350,24 @@ public class SchemaTestData {
                     (long)2, "v2"
             );
 
+            Map<String,Map<String, Long>> mapStringMap = Map.of(
+                    "k1", Map.of("nk1", (long)1, "nk2", (long)2),
+                    "k2", Map.of("nk1", (long)3, "nk2", (long)4)
+            );
+
+            Map<String, List<String>> mapStringArray = Map.of(
+                    "k1", Arrays.asList("v1", "v2"),
+                    "k2", Arrays.asList("v3", "v4")
+            );
+
 
             Struct value_struct = new Struct(NESTED_SCHEMA)
                     .put("off16", (short)n)
                     .put("map_string_string", mapStringString)
                     .put("map_string_int64", mapStringLong)
                     .put("map_int64_string", mapLongString)
+                    .put("map_string_map", mapStringMap)
+                    .put("map_string_array", mapStringArray)
                     ;
 
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/helper/SchemaTestData.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/helper/SchemaTestData.java
@@ -175,7 +175,8 @@ public class SchemaTestData {
         Schema ARRAY_FLOAT64_SCHEMA = SchemaBuilder.array(Schema.FLOAT64_SCHEMA).build();
         Schema ARRAY_BOOLEAN_SCHEMA = SchemaBuilder.array(Schema.BOOLEAN_SCHEMA).build();
         Schema ARRAY_STRING_ARRAY_SCHEMA = SchemaBuilder.array(ARRAY_SCHEMA).build();
-        Schema ARRAY_MAP_ARRAY_SCHEMA = SchemaBuilder.array(SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA));
+        Schema ARRAY_ARRAY_STRING_ARRAY_SCHEMA = SchemaBuilder.array(SchemaBuilder.array(ARRAY_SCHEMA)).build();
+        Schema ARRAY_MAP_SCHEMA = SchemaBuilder.array(SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA));
 
 
         Schema NESTED_SCHEMA = SchemaBuilder.struct()
@@ -190,7 +191,8 @@ public class SchemaTestData {
                 .field("arr_float64", ARRAY_FLOAT64_SCHEMA)
                 .field("arr_bool", ARRAY_BOOLEAN_SCHEMA)
                 .field("arr_str_arr", ARRAY_STRING_ARRAY_SCHEMA)
-                .field("arr_map_arr", ARRAY_MAP_ARRAY_SCHEMA)
+                .field("arr_arr_str_arr", ARRAY_ARRAY_STRING_ARRAY_SCHEMA)
+                .field("arr_map", ARRAY_MAP_SCHEMA)
                 .build();
 
 
@@ -207,7 +209,8 @@ public class SchemaTestData {
             List<Double> arrayFloat64Tmp = Arrays.asList((double)1,(double)2);
             List<Boolean> arrayBoolTmp = Arrays.asList(true,false);
             List<List<String>> arrayStrArray = Arrays.asList(arrayTmp, arrayTmp);
-            List<Map<String, String>> arrayMapArray = Arrays.asList(Map.of("k1", "v1", "k2", "v2"));
+            List<List<List<String>>> arrayArrayStrArray = Arrays.asList(Arrays.asList(arrayTmp, arrayTmp));
+            List<Map<String, String>> arrayMap = Arrays.asList(Map.of("k1", "v1", "k2", "v2"));
 
 
             Struct value_struct = new Struct(NESTED_SCHEMA)
@@ -222,7 +225,8 @@ public class SchemaTestData {
                     .put("arr_float64", arrayFloat64Tmp)
                     .put("arr_bool", arrayBoolTmp)
                     .put("arr_str_arr", arrayStrArray)
-                    .put("arr_map_arr", arrayMapArray)
+                    .put("arr_arr_str_arr", arrayArrayStrArray)
+                    .put("arr_map", arrayMap)
                     ;
 
 
@@ -321,6 +325,7 @@ public class SchemaTestData {
         Schema MAP_SCHEMA_INT64_STRING = SchemaBuilder.map(Schema.INT64_SCHEMA, Schema.STRING_SCHEMA);
         Schema MAP_SCHEMA_STRING_MAP = SchemaBuilder.map(Schema.STRING_SCHEMA, SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT64_SCHEMA));
         Schema MAP_SCHEMA_STRING_ARRAY = SchemaBuilder.map(Schema.STRING_SCHEMA, SchemaBuilder.array(Schema.STRING_SCHEMA));
+        Schema MAP_MAP_MAP_SCHEMA = SchemaBuilder.map(Schema.STRING_SCHEMA, SchemaBuilder.map(Schema.STRING_SCHEMA, SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA)));
 
         Schema NESTED_SCHEMA = SchemaBuilder.struct()
                 .field("off16", Schema.INT16_SCHEMA)
@@ -329,6 +334,7 @@ public class SchemaTestData {
                 .field("map_int64_string", MAP_SCHEMA_INT64_STRING)
                 .field("map_string_map", MAP_SCHEMA_STRING_MAP)
                 .field("map_string_array", MAP_SCHEMA_STRING_ARRAY)
+                .field("map_map_map", MAP_MAP_MAP_SCHEMA)
                 .build();
 
 
@@ -359,6 +365,10 @@ public class SchemaTestData {
                     "k1", Arrays.asList("v1", "v2"),
                     "k2", Arrays.asList("v3", "v4")
             );
+            Map<String, Map<String, Map<String, String>>> mapMapMap = Map.of(
+                    "k1", Map.of("nk1", Map.of("nk2", "v1")),
+                    "k2", Map.of("nk1", Map.of("nk2", "v2"))
+            );
 
 
             Struct value_struct = new Struct(NESTED_SCHEMA)
@@ -368,6 +378,7 @@ public class SchemaTestData {
                     .put("map_int64_string", mapLongString)
                     .put("map_string_map", mapStringMap)
                     .put("map_string_array", mapStringArray)
+                    .put("map_map_map", mapMapMap)
                     ;
 
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/helper/SchemalessTestData.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/helper/SchemalessTestData.java
@@ -119,6 +119,9 @@ public class SchemalessTestData {
             List<Float> arrayFloat32Tmp = Arrays.asList((float)1.0,(float)2.0);
             List<Double> arrayFloat64Tmp = Arrays.asList((double)1.1,(double)2.1);
             List<Boolean> arrayBoolTmp = Arrays.asList(true,false);
+            List<List<String>> arrayStrArray = Arrays.asList(arrayTmp, arrayTmp);
+            List<List<List<String>>> arrayArrayStrArray = Arrays.asList(Arrays.asList(arrayTmp, arrayTmp));
+            List<Map<String, String>> arrayMap = Arrays.asList(Map.of("k1", "v1", "k2", "v2"));
 
             Map<String, Object> value_struct = new HashMap<>();
             value_struct.put("arr", arrayTmp);
@@ -131,6 +134,9 @@ public class SchemalessTestData {
             value_struct.put("arr_float32", arrayFloat32Tmp);
             value_struct.put("arr_float64", arrayFloat64Tmp);
             value_struct.put("arr_bool", arrayBoolTmp);
+            value_struct.put("arr_str_arr", arrayStrArray);
+            value_struct.put("arr_arr_str_arr", arrayArrayStrArray);
+            value_struct.put("arr_map", arrayMap);
 
             SinkRecord sr = new SinkRecord(
                     topic,
@@ -170,6 +176,20 @@ public class SchemalessTestData {
                     (long)2, "v2"
             );
 
+            Map<String,Map<String, Long>> mapStringMap = Map.of(
+                    "k1", Map.of("nk1", (long)1, "nk2", (long)2),
+                    "k2", Map.of("nk1", (long)3, "nk2", (long)4)
+            );
+
+            Map<String, List<String>> mapStringArray = Map.of(
+                    "k1", Arrays.asList("v1", "v2"),
+                    "k2", Arrays.asList("v3", "v4")
+            );
+            Map<String, Map<String, Map<String, String>>> mapMapMap = Map.of(
+                    "k1", Map.of("nk1", Map.of("nk2", "v1")),
+                    "k2", Map.of("nk1", Map.of("nk2", "v2"))
+            );
+
 
 
             Map<String, Object> value_struct = new HashMap<>();
@@ -177,6 +197,9 @@ public class SchemalessTestData {
             value_struct.put("map_string_string", mapStringString);
             value_struct.put("map_string_int64", mapStringLong);
             value_struct.put("map_int64_string", mapLongString);
+            value_struct.put("map_string_map", mapStringMap);
+            value_struct.put("map_string_array", mapStringArray);
+            value_struct.put("map_map_map", mapMapMap);
 
             SinkRecord sr = new SinkRecord(
                     topic,

--- a/src/test/java/com/clickhouse/kafka/connect/sink/processing/ProcessingTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/processing/ProcessingTest.java
@@ -41,7 +41,7 @@ public class ProcessingTest {
                     null,
                     null,
                     0);
-            Record record = Record.newRecord(SchemaType.SCHEMA, topic, partition, n, null, Collections.singletonMap("off", new Data(Schema.Type.INT8, n)), sr);
+            Record record = Record.newRecord(SchemaType.SCHEMA, topic, partition, n, null, Collections.singletonMap("off", new Data(Schema.INT8_SCHEMA, n)), sr);
             records.add(record);
         });
         return records;


### PR DESCRIPTION
## Summary
This PR introduces support of complex types for `Map` and `Array` types. I.e:

- `Array(Primitive)` -> `Array(T)`
- `Map(Primitive, Primitive)` -> `Map(Primitive, T)`

Key for map is still primitive, mostly because of supported types for key are limited: String, Integer, LowCardinality, FixedString, UUID, Date, DateTime, Date32, Enum - [docs](https://clickhouse.com/docs/en/sql-reference/data-types/map)


It should affect [documentation of supported types with schema declared](https://clickhouse.com/docs/en/integrations/kafka/clickhouse-kafka-connect-sink#supported-data-types):
PR to docs: https://github.com/ClickHouse/clickhouse-docs/pull/1917

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [X] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
