### PR TITLE
Log the state of enableDbTopicSplit instead of printing it

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -602,7 +602,7 @@ public class ClickHouseWriter implements DBWriter {
         //https://devqa.io/how-to-convert-java-map-to-json/
         boolean enableDbTopicSplit = csc.getEnableDbTopicSplit();
         String dbTopicSplitChar = csc.getDbTopicSplitChar();
-        System.out.println("enableDbTopicSplit: " + enableDbTopicSplit);
+        LOGGER.trace("enableDbTopicSplit: {}", enableDbTopicSplit);
         Gson gson = new Gson();
         long s1 = System.currentTimeMillis();
         long s2 = 0;


### PR DESCRIPTION
## Summary
The line `enableDbTopicSplit: false` is spamming our logs without being able to control it via the LOG4J settings.
I am changing it to being logged instead - I chose the TRACE level, but I am happy to change it to another level of course, just let me know.



## Checklist
* Since the change is so tiny, I didn't do any of the Checklist. Let me know if you need anything.
