### PR TITLE
Fix null pointer exception on ClickHouse connection activation failure

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTask.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTask.java
@@ -82,7 +82,9 @@ public class ClickHouseSinkTask extends SinkTask {
 
     @Override
     public void stop() {
-        this.proxySinkTask.stop();
+        if (this.proxySinkTask != null) {
+            this.proxySinkTask.stop();
+        }
     }
 
 


### PR DESCRIPTION
## Summary

If ClickHouse server is unreacheable, `ProxySinkTask` throws an exception in the constructor:

https://github.com/ClickHouse/clickhouse-kafka-connect/blob/e8403546bcca216a067c04c1f1ca59a9dac09e8f/src/main/java/com/clickhouse/kafka/connect/sink/ProxySinkTask.java#L63

Thus, `proxySinkTask` is `null` because it was not initialized in the constructor:

https://github.com/ClickHouse/clickhouse-kafka-connect/blob/e8403546bcca216a067c04c1f1ca59a9dac09e8f/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTask.java#L57

See logs below for more info

<details>

<summary>Logs with NullPointerException</summary>

```plaintext
[2024-02-28 16:57:35,986] INFO [clickhouse-sink-connector|task-0] Start SinkTask:  (com.clickhouse.kafka.connect.sink.ClickHouseSinkTask:49)
[2024-02-28 16:57:35,987] INFO [clickhouse-sink-connector|task-0] Errant record reporter not configured. (com.clickhouse.kafka.connect.sink.ClickHouseSinkTask:97)
[2024-02-28 16:57:35,987] INFO [clickhouse-sink-connector|task-0] Enable ExactlyOnce? false (com.clickhouse.kafka.connect.sink.ProxySinkTask:43)
[2024-02-28 16:57:35,990] INFO [clickhouse-sink-connector|task-0] ClickHouse URL: http://clickhouse:8123/default (com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient:81)
[2024-02-28 16:57:36,120] INFO [clickhouse-sink-connector|task-0] Ping was successful. (com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient:105)
[2024-02-28 16:57:36,127] INFO [clickhouse-sink-connector|task-0] Connected to ClickHouse version: 24.1.5.6 (com.clickhouse.kafka.connect.sink.db.ClickHouseWriter:78)
[2024-02-28 16:57:36,132] ERROR [clickhouse-sink-connector|task-0] Did not find any tables in destination Please create before running. (com.clickhouse.kafka.connect.sink.db.ClickHouseWriter:102)
[2024-02-28 16:57:36,132] ERROR [clickhouse-sink-connector|task-0] WorkerSinkTask{id=clickhouse-sink-connector-0} Task threw an uncaught and unrecoverable exception. Task is being killed and will not recover until manually restarted (org.apache.kafka.connect.runtime.WorkerTask:212)
java.lang.RuntimeException: Connection to ClickHouse is not active.
        at com.clickhouse.kafka.connect.sink.ProxySinkTask.<init>(ProxySinkTask.java:63)
        at com.clickhouse.kafka.connect.sink.ClickHouseSinkTask.start(ClickHouseSinkTask.java:57)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.initializeAndStart(WorkerSinkTask.java:329)
        at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:202)
        at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:259)
        at org.apache.kafka.connect.runtime.isolation.Plugins.lambda$withClassLoader$1(Plugins.java:237)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
        at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.base/java.lang.Thread.run(Unknown Source)
[2024-02-28 16:57:36,134] WARN [clickhouse-sink-connector|task-0] Could not stop task (org.apache.kafka.connect.runtime.WorkerSinkTask:180)
java.lang.NullPointerException: Cannot invoke "com.clickhouse.kafka.connect.sink.ProxySinkTask.stop()" because "this.proxySinkTask" is null
        at com.clickhouse.kafka.connect.sink.ClickHouseSinkTask.stop(ClickHouseSinkTask.java:85)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.close(WorkerSinkTask.java:178)
        at org.apache.kafka.connect.runtime.WorkerTask.doClose(WorkerTask.java:183)
        at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:216)
        at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:259)
        at org.apache.kafka.connect.runtime.isolation.Plugins.lambda$withClassLoader$1(Plugins.java:237)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
        at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.base/java.lang.Thread.run(Unknown Source)
[2024-02-28 16:57:36,135] INFO [clickhouse-sink-connector|task-0] [Consumer clientId=connector-consumer-clickhouse-sink-connector-0, groupId=connect-clickhouse-sink-connector] Resetting generation and member id due to: consumer pro-actively leaving the group (org.apache.kafka.clients.consumer.internals.ConsumerCoordinator:1055)
[2024-02-28 16:57:36,135] INFO [clickhouse-sink-connector|task-0] [Consumer clientId=connector-consumer-clickhouse-sink-connector-0, groupId=connect-clickhouse-sink-connector] Request joining group due to: consumer pro-actively leaving the group (org.apache.kafka.clients.consumer.internals.ConsumerCoordinator:1102)
[2024-02-28 16:57:36,137] INFO [clickhouse-sink-connector|task-0] Metrics scheduler closed (org.apache.kafka.common.metrics.Metrics:694)
[2024-02-28 16:57:36,137] INFO [clickhouse-sink-connector|task-0] Closing reporter org.apache.kafka.common.metrics.JmxReporter (org.apache.kafka.common.metrics.Metrics:698)
[2024-02-28 16:57:36,138] INFO [clickhouse-sink-connector|task-0] Closing reporter org.apache.kafka.common.telemetry.internals.ClientTelemetryReporter (org.apache.kafka.common.metrics.Metrics:698)
[2024-02-28 16:57:36,138] INFO [clickhouse-sink-connector|task-0] Metrics reporters closed (org.apache.kafka.common.metrics.Metrics:704)
[2024-02-28 16:57:36,139] INFO [clickhouse-sink-connector|task-0] App info kafka.consumer for connector-consumer-clickhouse-sink-connector-0 unregistered (org.apache.kafka.common.utils.AppInfoParser:88)
```

</details>

## Checklist

n/a