### PR TITLE
Adding to simulate 25 error parsing from ClickHouse

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTask.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTask.java
@@ -87,6 +87,10 @@ public class ClickHouseSinkTask extends SinkTask {
         }
     }
 
+    public void setErrorReporter(ErrorReporter errorReporter) {
+        this.errorReporter = errorReporter;
+    }
+
 
     private ErrorReporter createErrorReporter() {
         ErrorReporter result = devNullErrorReporter();


### PR DESCRIPTION
## Summary
Adding a test that simulates 25 Error codes from ClickHosue and checking that we find the same number of records in DLQ queue 

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
