### PR TITLE
Added extra break down of time measurement for insert operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.0.17
 * Added support for ClickHouse Enum type #370
+* Added extra break down of time measurement for insert operations 
 
 ## 1.0.16
 * Removed 1002 from the retriable exceptions list as it's a catch-all for all other exceptions


### PR DESCRIPTION
## Summary
Added extra break down of time measurement for insert operations

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
