### PR TITLE
Escape dbTopicSeperatorChar correctly using quote

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/data/convert/RecordConvertor.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/data/convert/RecordConvertor.java
@@ -1,5 +1,6 @@
 package com.clickhouse.kafka.connect.sink.data.convert;
 
+import java.util.regex.Pattern;
 import org.apache.kafka.connect.data.Schema;
 import com.clickhouse.kafka.connect.sink.data.Record;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -9,7 +10,7 @@ public abstract class RecordConvertor {
         String database = configurationDatabase;
         String topic = sinkRecord.topic();
         if (splitDBTopic) {
-            String[] parts = topic.split(dbTopicSeparatorChar);
+            String[] parts = topic.split(Pattern.quote(dbTopicSeparatorChar));
             if (parts.length == 2) {
                 database = parts[0];
                 topic = parts[1];


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

It doesn't split parts correct if the dbTopicSeperatorChar is dot so escaping it properly to avoid regex match

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
