### PR TITLE
Use combination of database and topic for connect state table for virtual topic

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/ProxySinkTask.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ProxySinkTask.java
@@ -61,7 +61,7 @@ public class ProxySinkTask {
         boolean isStarted = dbWriter.start(clickHouseSinkConfig);
         if (!isStarted)
             throw new RuntimeException("Connection to ClickHouse is not active.");
-        processing = new Processing(stateProvider, dbWriter, errorReporter);
+        processing = new Processing(stateProvider, dbWriter, errorReporter, clickHouseSinkConfig);
 
         this.statistics = MBeanServerUtils.registerMBean(new SinkTaskStatistics(), getMBeanNAme());
     }


### PR DESCRIPTION
The connector will cause problems and restart if the table name is the same because we split the topic into two parts. For consistency, I think its good to use the whole topic for the connect_state table.

Thanks in advance for your suggestions :) 

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
