### PR TITLE
Bump ClickHouse-java version into 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 1.2.7
+* Bump clickhouse-java to 0.8.0
 * Fix for handling of nullable fields in tuples ClickHouse data type
 
 # 1.2.6

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ repositories {
 }
 
 extra.apply {
-    set("clickHouseDriverVersion", "0.7.1")
+    set("clickHouseDriverVersion", "0.8.0")
     set("kafkaVersion", "2.7.0")
 
     // Testing dependencies


### PR DESCRIPTION
## Summary
Bump ClickHouse-java version into 0.8.0

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
