### PR TITLE
Adjust testing password

### DIFF
--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseBase.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseBase.java
@@ -34,7 +34,7 @@ public class ClickHouseBase {
             initialPing();
             return;
         }
-        db = new ClickHouseContainer(ClickHouseTestHelpers.CLICKHOUSE_DOCKER_IMAGE).withPassword("test_password");
+        db = new ClickHouseContainer(ClickHouseTestHelpers.CLICKHOUSE_DOCKER_IMAGE).withPassword("test_password").withEnv("CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT", "1");
         db.start();
     }
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseBase.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseBase.java
@@ -34,7 +34,7 @@ public class ClickHouseBase {
             initialPing();
             return;
         }
-        db = new ClickHouseContainer(ClickHouseTestHelpers.CLICKHOUSE_DOCKER_IMAGE);
+        db = new ClickHouseContainer(ClickHouseTestHelpers.CLICKHOUSE_DOCKER_IMAGE).withEnv("CLICKHOUSE_PASSWORD", "test_password");
         db.start();
     }
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseBase.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseBase.java
@@ -34,7 +34,7 @@ public class ClickHouseBase {
             initialPing();
             return;
         }
-        db = new ClickHouseContainer(ClickHouseTestHelpers.CLICKHOUSE_DOCKER_IMAGE).withEnv("CLICKHOUSE_PASSWORD", "test_password");
+        db = new ClickHouseContainer(ClickHouseTestHelpers.CLICKHOUSE_DOCKER_IMAGE).withPassword("test_password");
         db.start();
     }
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessProxyTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessProxyTest.java
@@ -29,7 +29,10 @@ public class ClickHouseSinkTaskSchemalessProxyTest extends ClickHouseBase {
     public static void setup() throws IOException {
         Network network = Network.newNetwork();
         // Note: we are using a different version of ClickHouse for the proxy - https://github.com/ClickHouse/ClickHouse/issues/58828
-        db = new ClickHouseContainer(ClickHouseTestHelpers.CLICKHOUSE_FOR_PROXY_DOCKER_IMAGE).withNetwork(network).withNetworkAliases("clickhouse");
+        db = new ClickHouseContainer(ClickHouseTestHelpers.CLICKHOUSE_FOR_PROXY_DOCKER_IMAGE)
+                .withNetwork(network)
+                .withNetworkAliases("clickhouse")
+                .withEnv("CLICKHOUSE_PASSWORD", "test_password");
         db.start();
 
         toxiproxy = new ToxiproxyContainer("ghcr.io/shopify/toxiproxy:2.7.0").withNetwork(network).withNetworkAliases("toxiproxy");

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessProxyTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessProxyTest.java
@@ -32,7 +32,7 @@ public class ClickHouseSinkTaskSchemalessProxyTest extends ClickHouseBase {
         db = new ClickHouseContainer(ClickHouseTestHelpers.CLICKHOUSE_FOR_PROXY_DOCKER_IMAGE)
                 .withNetwork(network)
                 .withNetworkAliases("clickhouse")
-                .withEnv("CLICKHOUSE_PASSWORD", "test_password");
+                .withPassword("test_password");
         db.start();
 
         toxiproxy = new ToxiproxyContainer("ghcr.io/shopify/toxiproxy:2.7.0").withNetwork(network).withNetworkAliases("toxiproxy");

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessProxyTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessProxyTest.java
@@ -32,7 +32,8 @@ public class ClickHouseSinkTaskSchemalessProxyTest extends ClickHouseBase {
         db = new ClickHouseContainer(ClickHouseTestHelpers.CLICKHOUSE_FOR_PROXY_DOCKER_IMAGE)
                 .withNetwork(network)
                 .withNetworkAliases("clickhouse")
-                .withPassword("test_password");
+                .withPassword("test_password")
+                .withEnv("CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT", "1");
         db.start();
 
         toxiproxy = new ToxiproxyContainer("ghcr.io/shopify/toxiproxy:2.7.0").withNetwork(network).withNetworkAliases("toxiproxy");

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskStringTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskStringTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
     private int countRowsWithEmojis(ClickHouseHelperClient chc, String topic) {
-        String queryCount = "select count(*) from " + topic + " where str LIKE '%\uD83D\uDE00%'";
+        String queryCount = "select count(*) from " + topic + " where str LIKE '%\uD83D\uDE00%' SETTINGS select_sequential_consistency = 1";
         try {
             Records records = chc.getClient().queryRecords(queryCount).get();
             String value = records.iterator().next().getString(1);

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskStringTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskStringTest.java
@@ -35,7 +35,7 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         }
     }
     private int countRows(ClickHouseHelperClient chc, String topic) {
-        String queryCount = String.format("select count(*) from `%s`", topic);
+        String queryCount = String.format("select count(*) from `%s` SETTINGS select_sequential_consistency = 1", topic);
         try {
             Records records = chc.getClient().queryRecords(queryCount).get();
             String value = records.iterator().next().getString(1);

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaProxyTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaProxyTest.java
@@ -42,7 +42,7 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
         db = new org.testcontainers.clickhouse.ClickHouseContainer(ClickHouseTestHelpers.CLICKHOUSE_FOR_PROXY_DOCKER_IMAGE)
                 .withNetwork(network)
                 .withNetworkAliases("clickhouse")
-                .withEnv("CLICKHOUSE_PASSWORD", "test_password");
+                .withPassword("test_password");
         db.start();
 
         toxiproxy = new ToxiproxyContainer("ghcr.io/shopify/toxiproxy:2.7.0").withNetwork(network).withNetworkAliases("toxiproxy");

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaProxyTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaProxyTest.java
@@ -39,7 +39,10 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
     public static void setup() throws IOException {
         Network network = Network.newNetwork();
         // Note: we are using a different version of ClickHouse for the proxy - https://github.com/ClickHouse/ClickHouse/issues/58828
-        db = new org.testcontainers.clickhouse.ClickHouseContainer(ClickHouseTestHelpers.CLICKHOUSE_FOR_PROXY_DOCKER_IMAGE).withNetwork(network).withNetworkAliases("clickhouse");
+        db = new org.testcontainers.clickhouse.ClickHouseContainer(ClickHouseTestHelpers.CLICKHOUSE_FOR_PROXY_DOCKER_IMAGE)
+                .withNetwork(network)
+                .withNetworkAliases("clickhouse")
+                .withEnv("CLICKHOUSE_PASSWORD", "test_password");
         db.start();
 
         toxiproxy = new ToxiproxyContainer("ghcr.io/shopify/toxiproxy:2.7.0").withNetwork(network).withNetworkAliases("toxiproxy");

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaProxyTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaProxyTest.java
@@ -42,7 +42,8 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
         db = new org.testcontainers.clickhouse.ClickHouseContainer(ClickHouseTestHelpers.CLICKHOUSE_FOR_PROXY_DOCKER_IMAGE)
                 .withNetwork(network)
                 .withNetworkAliases("clickhouse")
-                .withPassword("test_password");
+                .withPassword("test_password")
+                .withEnv("CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT", "1");
         db.start();
 
         toxiproxy = new ToxiproxyContainer("ghcr.io/shopify/toxiproxy:2.7.0").withNetwork(network).withNetworkAliases("toxiproxy");

--- a/src/test/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseTestHelpers.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseTestHelpers.java
@@ -183,7 +183,7 @@ public class ClickHouseTestHelpers {
     }
 
     public static int countRows(ClickHouseHelperClient chc, String tableName) {
-        String queryCount = String.format("SELECT COUNT(*) FROM `%s`", tableName);
+        String queryCount = String.format("SELECT COUNT(*) FROM `%s` SETTINGS select_sequential_consistency = 1", tableName);
 
         try {
             optimizeTable(chc, tableName);
@@ -212,7 +212,7 @@ public class ClickHouseTestHelpers {
     }
 
     public static int countRowsWithEmojis(ClickHouseHelperClient chc, String tableName) {
-        String queryCount = "SELECT COUNT(*) FROM `" + tableName + "` WHERE str LIKE '%\uD83D\uDE00%'";
+        String queryCount = "SELECT COUNT(*) FROM `" + tableName + "` WHERE str LIKE '%\uD83D\uDE00%' SETTINGS select_sequential_consistency = 1";
         try {
             Records records = chc.getClient().queryRecords(queryCount).get(CLOUD_TIMEOUT_VALUE, CLOUD_TIMEOUT_UNIT);
             String value = records.iterator().next().getString(1);


### PR DESCRIPTION
## Summary
Because of changes to default port behavior, the tests broke. Setting a password for the default user resolves this.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
