### PR TITLE
Tweak log statement to reduce empty output

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTask.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTask.java
@@ -47,7 +47,9 @@ public class ClickHouseSinkTask extends SinkTask {
             long putStat = System.currentTimeMillis();
             this.proxySinkTask.put(records);
             long putEnd = System.currentTimeMillis();
-            LOGGER.info("Put records: {} in {} ms", records.size(), putEnd - putStat);
+            if (!records.isEmpty()) {
+                LOGGER.info("Put records: {} in {} ms", records.size(), putEnd - putStat);
+            }
         } catch (Exception e) {
             LOGGER.trace("Passing the exception to the exception handler.");
             boolean errorTolerance = clickHouseSinkConfig != null && clickHouseSinkConfig.isErrorsTolerance();


### PR DESCRIPTION
## Summary
* Turns out this message prints periodically when we have 0 records, but it probably shouldn't.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
