### PR TITLE
Implemented writing JSON as string and converting  struct to json

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,8 @@ plugins {
     id("com.github.gmazzo.buildconfig") version "5.5.0"
     id("com.diffplug.spotless") version "7.0.2"
     id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.google.protobuf") version "0.9.5"
+
 }
 
 group = "com.clickhouse.kafka"
@@ -124,6 +126,15 @@ dependencies {
     testImplementation("com.clickhouse:client-v2:${project.extra["clickHouseDriverVersion"]}")
     testImplementation("com.clickhouse:clickhouse-http-client:${project.extra["clickHouseDriverVersion"]}")
 
+    // Protobuf dependencies
+    testImplementation("com.google.protobuf:protobuf-java:3.25.1")
+    testImplementation("io.confluent:kafka-protobuf-serializer:7.9.1")
+    testImplementation("io.confluent:kafka-connect-protobuf-converter:7.9.1")
+
+//    // Schema Registry client for testing
+    testImplementation("io.confluent:kafka-schema-registry-client:7.5.4")
+    testImplementation("io.confluent:kafka-schema-registry:7.5.4")
+    testImplementation("io.confluent:kafka-schema-serializer:7.5.4")
 }
 
 
@@ -254,4 +265,11 @@ tasks.register<Zip>("createConfluentArchive") {
     archiveAppendix.set(archiveFilename)
     archiveVersion.set(project.version.toString())
     destinationDirectory.set(file("$buildDir/confluent"))
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.25.1"
+    }
+//    generatedFilesBaseDir = "$buildDir/generated/source/proto"
 }

--- a/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
@@ -94,6 +94,7 @@ public class ClickHouseSinkConfig {
     private final boolean bypassSchemaValidation;
     private final boolean bypassFieldCleanup;
     private final boolean ignorePartitionsWhenBatching;
+    private final boolean binaryFormatWrtiteJsonAsString;
 
     public enum InsertFormats {
         NONE,
@@ -269,6 +270,10 @@ public class ClickHouseSinkConfig {
         this.bypassSchemaValidation = Boolean.parseBoolean(props.getOrDefault(BYPASS_SCHEMA_VALIDATION, "false"));
         this.bypassFieldCleanup = Boolean.parseBoolean(props.getOrDefault(BYPASS_FIELD_CLEANUP, "false"));
         this.ignorePartitionsWhenBatching = Boolean.parseBoolean(props.getOrDefault(IGNORE_PARTITIONS_WHEN_BATCHING, "false"));
+
+
+        String jsonAsString = getClickhouseSettings().get("input_format_binary_read_json_as_string");
+        this.binaryFormatWrtiteJsonAsString = jsonAsString != null && (jsonAsString.equalsIgnoreCase("true") || jsonAsString.equals("1"));
 
         LOGGER.debug("ClickHouseSinkConfig: hostname: {}, port: {}, database: {}, username: {}, sslEnabled: {}, timeout: {}, retry: {}, exactlyOnce: {}",
                 hostname, port, database, username, sslEnabled, timeout, retry, exactlyOnce);

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -28,7 +28,10 @@ import com.clickhouse.kafka.connect.sink.db.mapping.Type;
 import com.clickhouse.kafka.connect.sink.dlq.ErrorReporter;
 import com.clickhouse.kafka.connect.util.QueryIdentifier;
 import com.clickhouse.kafka.connect.util.Utils;
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -71,6 +74,11 @@ public class ClickHouseWriter implements DBWriter {
 
     private Map<String, Table> mapping = null;
     private AtomicBoolean isUpdateMappingRunning = new AtomicBoolean(false);
+    private boolean binaryFormatWrtiteJsonAsString = false;
+
+    private Gson schemaExcludingJsonWriter = new GsonBuilder().setExclusionStrategies(
+            new SchemaFieldExclusionStrategy()
+    ).create(); // used only for JSON writing
 
     public ClickHouseWriter() {
         this.mapping = new HashMap<String, Table>();
@@ -81,6 +89,9 @@ public class ClickHouseWriter implements DBWriter {
     }
     protected void setSinkConfig(ClickHouseSinkConfig csc) {
         this.csc = csc;
+
+        String jsonAsString = csc.getClickhouseSettings().get("input_format_binary_read_json_as_string");
+        this.binaryFormatWrtiteJsonAsString = jsonAsString != null && (jsonAsString.equalsIgnoreCase("true") || jsonAsString.equals("1"));
     }
     protected Map<String, Table> getMapping() {
         return mapping;
@@ -89,7 +100,7 @@ public class ClickHouseWriter implements DBWriter {
     @Override
     public boolean start(ClickHouseSinkConfig csc) {
         LOGGER.trace("Starting ClickHouseWriter");
-        this.csc = csc;
+        setSinkConfig(csc);
         String clientVersion = csc.getClientVersion();
         boolean useClientV2 = clientVersion.equals("V1") ? false : true;
 
@@ -260,6 +271,15 @@ public class ClickHouseWriter implements DBWriter {
 
                                 if (("DECIMAL".equalsIgnoreCase(colTypeName) && objSchema.name().equals("org.apache.kafka.connect.data.Decimal")))
                                     continue;
+
+                                if (type == Type.JSON) {
+                                    if (binaryFormatWrtiteJsonAsString &&
+                                            (dataTypeName.equals("STRUCT") || dataTypeName.equals("STRING"))) {
+                                        // we will convert struct to a string
+                                        //  suppose to have JSON already
+                                        continue;
+                                    }
+                                }
 
                                 validSchema = false;
                                 LOGGER.error(String.format("Table column name [%s] type [%s] is not matching data column type [%s]", col.getName(), colTypeName, dataTypeName));
@@ -520,6 +540,21 @@ public class ClickHouseWriter implements DBWriter {
                     );
                 }
                 break;
+            case JSON:
+                if (binaryFormatWrtiteJsonAsString) {
+                    if (value.getFieldType() == Schema.Type.STRUCT) {
+                        value.getObject(); // map<String, Object>
+                        String json = schemaExcludingJsonWriter.toJson(value.getObject());
+                        BinaryStreamUtils.writeString(stream, json.getBytes(StandardCharsets.UTF_8));
+                    } else if (value.getFieldType() == Schema.Type.STRING) {
+                        BinaryStreamUtils.writeString(stream, ((String) value.getObject()).getBytes(StandardCharsets.UTF_8));
+                    } else {
+                        throw new RuntimeException("Unsupported field type: " + value.getFieldType() + " for column type [JSON]");
+                    }
+                    break;
+                } else {
+                    throw new RuntimeException("Writing JSON in binary is not supported yet. Use `input_format_binary_read_json_as_string=1` in clickhouse settings to allow writing as string");
+                }
             default:
                 // If you wonder, how NESTED works in JDBC:
                 // https://github.com/ClickHouse/clickhouse-java/blob/6cbbd8fe3f86ac26d12a95e0c2b964f3a3755fc9/clickhouse-data/src/main/java/com/clickhouse/data/format/ClickHouseRowBinaryProcessor.java#L159
@@ -961,6 +996,7 @@ public class ClickHouseWriter implements DBWriter {
                         data = new HashMap<>(16);
                         Struct struct = (Struct) record.getSinkRecord().value();
                         for (Field field : struct.schema().fields()) {
+                            Object value = struct.get(field.name());
                             data.put(field.name(), struct.get(field));//Doesn't handle multi-level object depth
                         }
                         break;
@@ -976,6 +1012,7 @@ public class ClickHouseWriter implements DBWriter {
                         record.getRecordOffsetContainer().getPartition(),
                         record.getRecordOffsetContainer().getOffset(),
                         gsonString);
+                System.out.println(gsonString);
                 BinaryStreamUtils.writeBytes(stream, gsonString.getBytes(StandardCharsets.UTF_8));
             } else {
                 LOGGER.warn(String.format("Getting empty record skip the insert topic[%s] offset[%d]", record.getTopic(), record.getSinkRecord().kafkaOffset()));
@@ -1216,5 +1253,21 @@ public class ClickHouseWriter implements DBWriter {
     @Override
     public long recordsInserted() {
         return 0;
+    }
+
+    private static class SchemaFieldExclusionStrategy implements ExclusionStrategy {
+
+        @Override
+        public boolean shouldSkipField(FieldAttributes f) {
+            if (f.getDeclaringClass() == Data.class && f.getName().equals("schema"))  {
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public boolean shouldSkipClass(Class<?> clazz) {
+            return false;
+        }
     }
 }

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -74,7 +74,6 @@ public class ClickHouseWriter implements DBWriter {
 
     private Map<String, Table> mapping = null;
     private AtomicBoolean isUpdateMappingRunning = new AtomicBoolean(false);
-    private boolean binaryFormatWrtiteJsonAsString = false;
 
     private Gson schemaExcludingJsonWriter = new GsonBuilder().setExclusionStrategies(
             new SchemaFieldExclusionStrategy()
@@ -89,9 +88,6 @@ public class ClickHouseWriter implements DBWriter {
     }
     protected void setSinkConfig(ClickHouseSinkConfig csc) {
         this.csc = csc;
-
-        String jsonAsString = csc.getClickhouseSettings().get("input_format_binary_read_json_as_string");
-        this.binaryFormatWrtiteJsonAsString = jsonAsString != null && (jsonAsString.equalsIgnoreCase("true") || jsonAsString.equals("1"));
     }
     protected Map<String, Table> getMapping() {
         return mapping;
@@ -273,7 +269,7 @@ public class ClickHouseWriter implements DBWriter {
                                     continue;
 
                                 if (type == Type.JSON) {
-                                    if (binaryFormatWrtiteJsonAsString &&
+                                    if (csc.isBinaryFormatWrtiteJsonAsString() &&
                                             (dataTypeName.equals("STRUCT") || dataTypeName.equals("STRING"))) {
                                         // we will convert struct to a string
                                         //  suppose to have JSON already
@@ -541,7 +537,7 @@ public class ClickHouseWriter implements DBWriter {
                 }
                 break;
             case JSON:
-                if (binaryFormatWrtiteJsonAsString) {
+                if (csc.isBinaryFormatWrtiteJsonAsString()) {
                     if (value.getFieldType() == Schema.Type.STRUCT) {
                         String json = schemaExcludingJsonWriter.toJson(value.getObject());
                         BinaryStreamUtils.writeString(stream, json.getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -543,7 +543,6 @@ public class ClickHouseWriter implements DBWriter {
             case JSON:
                 if (binaryFormatWrtiteJsonAsString) {
                     if (value.getFieldType() == Schema.Type.STRUCT) {
-                        value.getObject(); // map<String, Object>
                         String json = schemaExcludingJsonWriter.toJson(value.getObject());
                         BinaryStreamUtils.writeString(stream, json.getBytes(StandardCharsets.UTF_8));
                     } else if (value.getFieldType() == Schema.Type.STRING) {
@@ -996,7 +995,6 @@ public class ClickHouseWriter implements DBWriter {
                         data = new HashMap<>(16);
                         Struct struct = (Struct) record.getSinkRecord().value();
                         for (Field field : struct.schema().fields()) {
-                            Object value = struct.get(field.name());
                             data.put(field.name(), struct.get(field));//Doesn't handle multi-level object depth
                         }
                         break;
@@ -1012,7 +1010,6 @@ public class ClickHouseWriter implements DBWriter {
                         record.getRecordOffsetContainer().getPartition(),
                         record.getRecordOffsetContainer().getOffset(),
                         gsonString);
-                System.out.println(gsonString);
                 BinaryStreamUtils.writeBytes(stream, gsonString.getBytes(StandardCharsets.UTF_8));
             } else {
                 LOGGER.warn(String.format("Getting empty record skip the insert topic[%s] offset[%d]", record.getTopic(), record.getSinkRecord().kafkaOffset()));

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/mapping/Column.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/mapping/Column.java
@@ -150,6 +150,9 @@ public class Column {
                     type = Type.Decimal;
                 } else if (valueType.startsWith("FixedString")) {
                     type = Type.FIXED_STRING;
+                } else if (valueType.startsWith("JSON")) {
+                    // There are some parameters that we ignore because server will handle them for us
+                    type = Type.JSON;
                 }
 
                 break;

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/mapping/Type.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/mapping/Type.java
@@ -31,4 +31,5 @@ public enum Type {
     FIXED_STRING,
     Enum8,
     Enum16,
+    JSON
 }

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessTest.java
@@ -4,6 +4,7 @@ import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
 import com.clickhouse.kafka.connect.sink.helper.SchemalessTestData;
+import com.clickhouse.kafka.connect.sink.junit.extension.SinceClickHouseVersion;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.Test;
 
@@ -224,6 +225,7 @@ public class ClickHouseSinkTaskSchemalessTest extends ClickHouseBase {
 
 
     @Test
+    @SinceClickHouseVersion("24.10")
     public void jsonTypeTest() {
         Map<String, String> props = createProps();
         ClickHouseHelperClient chc = createClient(props);

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessTest.java
@@ -4,9 +4,11 @@ import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
 import com.clickhouse.kafka.connect.sink.helper.SchemalessTestData;
+import com.clickhouse.kafka.connect.sink.junit.extension.FromVersionConditionExtension;
 import com.clickhouse.kafka.connect.sink.junit.extension.SinceClickHouseVersion;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.Serializable;
 import java.util.Collection;
@@ -16,6 +18,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(FromVersionConditionExtension.class)
 public class ClickHouseSinkTaskSchemalessTest extends ClickHouseBase {
 
     @Test

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessTest.java
@@ -1,12 +1,15 @@
 package com.clickhouse.kafka.connect.sink;
 
+import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
 import com.clickhouse.kafka.connect.sink.helper.SchemalessTestData;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.Test;
 
+import java.io.Serializable;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -214,6 +217,27 @@ public class ClickHouseSinkTaskSchemalessTest extends ClickHouseBase {
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(smallerCollection);
+        chst.put(sr);
+        chst.stop();
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+    }
+
+
+    @Test
+    public void jsonTypeTest() {
+        Map<String, String> props = createProps();
+        ClickHouseHelperClient chc = createClient(props);
+
+        String topic = createTopicName("schemaless_json_table_test");
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        Map<String, Serializable> clientSettings = new HashMap<>();
+        clientSettings.put(ClientConfigProperties.serverSetting("allow_experimental_json_type"), "1");
+        ClickHouseTestHelpers.createTable(chc, topic, "CREATE TABLE %s ( `off16` Int16, " +
+                " `content` JSON, `struct` JSON ) Engine = MergeTree ORDER BY off16", clientSettings);
+
+        Collection<SinkRecord> sr = SchemalessTestData.createJSONType(topic, 1, 10);
+        ClickHouseSinkTask chst = new ClickHouseSinkTask();
+        chst.start(props);
         chst.put(sr);
         chst.stop();
         assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
@@ -882,6 +882,7 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
     }
 
     @Test
+    @SinceClickHouseVersion("24.10")
     public void testWritingJsonAsStringWithRowBinary() {
         Map<String, String> props = createProps();
         ClickHouseHelperClient chc = createClient(props);

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
@@ -4,7 +4,6 @@ import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
 import com.clickhouse.kafka.connect.sink.helper.SchemaTestData;
-import com.clickhouse.kafka.connect.sink.helper.SchemalessTestData;
 import com.clickhouse.kafka.connect.sink.junit.extension.FromVersionConditionExtension;
 import com.clickhouse.kafka.connect.sink.junit.extension.SinceClickHouseVersion;
 import com.clickhouse.kafka.connect.util.Utils;
@@ -19,7 +18,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.shaded.org.apache.commons.lang3.RandomUtils;
 
-import java.awt.desktop.SystemSleepEvent;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -30,7 +28,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.clickhouse.kafka.connect.sink.ClickHouseSinkConfig.TABLE_REFRESH_INTERVAL;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(FromVersionConditionExtension.class)
 public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {

--- a/src/test/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseTestHelpers.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseTestHelpers.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 public class ClickHouseTestHelpers {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClickHouseTestHelpers.class);
-    public static final String CLICKHOUSE_VERSION_DEFAULT = "24.3";
+    public static final String CLICKHOUSE_VERSION_DEFAULT = "24.10";
     public static final String CLICKHOUSE_PROXY_VERSION_DEFAULT = "23.8";
     public static final String CLICKHOUSE_DOCKER_IMAGE = String.format("clickhouse/clickhouse-server:%s", getClickhouseVersion());
     public static final String CLICKHOUSE_FOR_PROXY_DOCKER_IMAGE = String.format("clickhouse/clickhouse-server:%s", CLICKHOUSE_PROXY_VERSION_DEFAULT);

--- a/src/test/java/com/clickhouse/kafka/connect/sink/helper/SchemaTestData.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/helper/SchemaTestData.java
@@ -1,5 +1,6 @@
 package com.clickhouse.kafka.connect.sink.helper;
 
+import com.clickhouse.kafka.connect.test.TestProtos;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -1494,5 +1495,40 @@ public class SchemaTestData {
             array.add(sr);
         });
         return array;
+    }
+
+    public static TestProtos.TestMessage createUserMessage() {
+        return TestProtos.TestMessage.newBuilder()
+                .setId(123)
+                .setName("Test User")
+                .setIsActive(true)
+                .setScore(95.5)
+                .addAllTags(Arrays.asList("tag1", "tag2"))
+                .setUserInfo(
+                        TestProtos.UserInfo.newBuilder()
+                                .setEmail("user@example.com")
+                                .setAge(30)
+                                .setUserType(TestProtos.UserInfo.UserType.PREMIUM)
+                                .build()
+                )
+                .build();
+    }
+
+    public static TestProtos.TestMessage createProductMessage() {
+        return TestProtos.TestMessage.newBuilder()
+                .setId(456)
+                .setName("Test Product")
+                .setIsActive(true)
+                .setScore(4.5)
+                .addAllTags(Arrays.asList("electronics", "gadgets"))
+                .setProductInfo(
+                        TestProtos.ProductInfo.newBuilder()
+                                .setSku("PROD-123")
+                                .setPrice(99.99)
+                                .setInStock(true)
+                                .addAllCategories(Arrays.asList("Electronics", "Gadgets"))
+                                .build()
+                )
+                .build();
     }
 }

--- a/src/test/java/com/clickhouse/kafka/connect/sink/helper/SchemaTestData.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/helper/SchemaTestData.java
@@ -415,6 +415,50 @@ public class SchemaTestData {
         });
         return array;
     }
+
+    public static Collection<SinkRecord> createJSONType(String topic, int partition, int totalRecords) {
+
+        Schema CONTENT_SCHEMA = SchemaBuilder.struct()
+                .field("k1", Schema.STRING_SCHEMA)
+                .field("k2", Schema.STRING_SCHEMA);
+
+        Schema NESTED_SCHEMA = SchemaBuilder.struct()
+                .field("off16", Schema.INT16_SCHEMA)
+                .field("struct_content", CONTENT_SCHEMA)
+                .field("json_as_str", Schema.STRING_SCHEMA)
+                .build();
+
+
+        List<SinkRecord> array = new ArrayList<>();
+        LongStream.range(0, totalRecords).forEachOrdered(n -> {
+
+            Struct content = new Struct(CONTENT_SCHEMA)
+                    .put("k1", "v1" + n)
+                    .put("k2", "v2" + n);
+
+            Struct value_struct = new Struct(NESTED_SCHEMA)
+                    .put("off16", (short)n)
+                    .put("struct_content", content)
+                    .put("json_as_str", "{\"k3\":\"v3\", \"k4\":\"v4\"}")
+                    ;
+
+
+            SinkRecord sr = new SinkRecord(
+                    topic,
+                    partition,
+                    null,
+                    null, NESTED_SCHEMA,
+                    value_struct,
+                    n,
+                    System.currentTimeMillis(),
+                    TimestampType.CREATE_TIME
+            );
+
+            array.add(sr);
+        });
+        return array;
+    }
+
     public static Collection<SinkRecord> createTupleType(String topic, int partition) {
         return createTupleType(topic, partition, DEFAULT_TOTAL_RECORDS);
     }

--- a/src/test/java/com/clickhouse/kafka/connect/sink/helper/SchemalessTestData.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/helper/SchemalessTestData.java
@@ -1,6 +1,9 @@
 package com.clickhouse.kafka.connect.sink.helper;
 
 import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import java.math.BigDecimal;
@@ -205,6 +208,46 @@ public class SchemalessTestData {
             value_struct.put("map_string_map", mapStringMap);
             value_struct.put("map_string_array", mapStringArray);
             value_struct.put("map_map_map", mapMapMap);
+
+            SinkRecord sr = new SinkRecord(
+                    topic,
+                    partition,
+                    null,
+                    null, null,
+                    value_struct,
+                    n,
+                    System.currentTimeMillis(),
+                    TimestampType.CREATE_TIME
+            );
+
+            array.add(sr);
+        });
+        return array;
+    }
+
+    public static Collection<SinkRecord> createJSONType(String topic, int partition, int totalRecords) {
+        List<SinkRecord> array = new ArrayList<>();
+        LongStream.range(0, totalRecords).forEachOrdered(n -> {
+
+            Map<String,String> flatJson = Map.of(
+                    "k1", "v1" + n,
+                    "k2", "v2" + n
+            );
+
+            Schema STRUCT_SCHEMA = SchemaBuilder.struct()
+                    .field("k3", Schema.INT16_SCHEMA)
+                    .field("k4", Schema.STRING_SCHEMA)
+                    .build();
+
+            Struct struct = new Struct(STRUCT_SCHEMA)
+                    .put("k3", (short)n)
+                    .put("k4", "v4" + n);
+
+
+            Map<String, Object> value_struct = new HashMap<>();
+            value_struct.put("off16", (short)n);
+            value_struct.put("content", flatJson);
+            value_struct.put("struct", struct);
 
             SinkRecord sr = new SinkRecord(
                     topic,

--- a/src/test/proto/test1.proto
+++ b/src/test/proto/test1.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+
+package test;
+
+option java_package = "com.clickhouse.kafka.connect.test";
+option java_outer_classname = "TestProtos";
+
+// A simple message with primitive types
+message TestMessage {
+  int32 id = 1;
+  string name = 2;
+  bool is_active = 3;
+  double score = 4;
+  repeated string tags = 5;
+  
+  // A oneof field that can be one of two message types
+  oneof content {
+    UserInfo user_info = 6;
+    ProductInfo product_info = 7;
+  }
+}
+
+// First message type for the oneof field
+message UserInfo {
+  string email = 1;
+  int32 age = 2;
+  UserType user_type = 3;
+  
+  enum UserType {
+    REGULAR = 0;
+    PREMIUM = 1;
+    ADMIN = 2;
+  }
+}
+
+// Second message type for the oneof field
+message ProductInfo {
+  string sku = 1;
+  double price = 2;
+  bool in_stock = 3;
+  repeated string categories = 4;
+}


### PR DESCRIPTION
## Summary
- Adds JSON as a valid type
- Updates schema validation to react on `input_format_binary_read_json_as_string` 
- Updates write to encode JSON as string in case of binary format or write as a string if it is already one   


Closes: https://github.com/ClickHouse/clickhouse-kafka-connect/issues/543
## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
