### PR TITLE
fixed splitting records by database from topic name

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
@@ -427,11 +427,11 @@ public class ClickHouseHelperClient {
         }
         return table;
     }
-    public List<Table> extractTablesMapping(String database, Map<String, Table> cache) {
+    public List<Table> extractTablesMapping(String tableDatabase, Map<String, Table> cache) {
         List<Table> tableList =  new ArrayList<>();
-        for (Table table : showTables(database) ) {
+        for (Table table : showTables(tableDatabase) ) {
             // (Full) Table names are escaped in the cache
-            String escapedTableName = Utils.escapeTableName(database, table.getCleanName());
+            String escapedTableName = Utils.escapeTableName(tableDatabase, table.getCleanName());
 
             // Read from cache if we already described this table before
             // This means we won't pick up edited table configs until the connector is restarted
@@ -444,7 +444,7 @@ public class ClickHouseHelperClient {
                     continue;
                 }
             }
-            Table tableDescribed = describeTable(this.database, table.getCleanName());
+            Table tableDescribed = describeTable(tableDatabase, table.getCleanName());
             if (tableDescribed != null) {
                 tableDescribed.setNumColumns(table.getNumColumns());
                 tableList.add(tableDescribed);

--- a/src/test/java/com/clickhouse/kafka/connect/sink/data/convert/RecordConvertorTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/data/convert/RecordConvertorTest.java
@@ -1,0 +1,30 @@
+package com.clickhouse.kafka.connect.sink.data.convert;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+
+class RecordConvertorTest {
+
+    @ParameterizedTest
+    @MethodSource("splitDBTopicProvider")
+    void splitDBTopic(String topic, String dbTopicSeparatorChar, String database) {
+
+        String[] parts = topic.split(Pattern.quote(dbTopicSeparatorChar));
+        String actualDatabase = parts[0];
+        String actualTopic = parts[1];
+        System.out.println("actual_topic: " + actualTopic);
+
+        assertEquals(database, actualDatabase);
+    }
+
+    static Object[][] splitDBTopicProvider() {
+        return new Object[][] {
+            { "tenant_A__telemetry", "__", "tenant_A" },
+        };
+    }
+
+}


### PR DESCRIPTION
## Summary
- Fixes grouping by database when db topic split enabled
- Fixes recording correct database in RecordConverter
- Adds integration test for the feature 


Closes: https://github.com/ClickHouse/clickhouse-kafka-connect/issues/580

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
