### PR TITLE
Lowered log message level from error to warn as it is not an error

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/mapping/Table.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/mapping/Table.java
@@ -82,7 +82,7 @@ public class Table {
         String parentName = column.getName().substring(0, column.getName().lastIndexOf("."));
         Column parent = allColumnsMap.getOrDefault(parentName, null);
         if (parent == null) {
-            LOGGER.error("Got non-root column, but its parent was not found to be updated. {}", column);
+            LOGGER.warn("Got non-root column, but its parent was not found to be updated. {}", column);
             return;
         }
 


### PR DESCRIPTION
## Summary
There is a message `Got non-root column, but its parent was not found to be updated.` when processing ephemeral columns. This happens because only `.null` is present for the column but not itself. This doesn't affect processing but floods logs. Thus we lower log level for this message and will revisit this part of code later.  


## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
