### PR TITLE
[FEAT] buffer implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.3.6
+
+## New Features
+* Added internal record buffering support via `bufferCount` and `bufferFlushTime` configuration options. When enabled, records from multiple `poll()` calls are accumulated and flushed as a single large batch, reducing the number of insert operations to ClickHouse. Buffering is disabled by default (bufferCount=0) for full backward compatibility.
+
 # 1.3.5
 
 ## Improvements

--- a/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
@@ -51,6 +51,8 @@ public class ClickHouseSinkConfig {
     public static final String BYPASS_SCHEMA_VALIDATION = "bypassSchemaValidation";
     public static final String BYPASS_FIELD_CLEANUP = "bypassFieldCleanup";
     public static final String IGNORE_PARTITIONS_WHEN_BATCHING = "ignorePartitionsWhenBatching";
+    public static final String BUFFER_COUNT = "bufferCount";
+    public static final String BUFFER_FLUSH_TIME = "bufferFlushTime";
     public static final String ERROR_TOLERANCE_ALL = "all";
     public static final String ERROR_TOLERANCE_NONE = "none";
 
@@ -66,6 +68,8 @@ public class ClickHouseSinkConfig {
     public static final Integer tableRefreshIntervalDefault = 0;
     public static final Boolean exactlyOnceDefault = Boolean.FALSE;
     public static final Boolean customInsertFormatDefault = Boolean.FALSE;
+    public static final Integer bufferCountDefault = 0;
+    public static final Long bufferFlushTimeDefault = 0L;
 
     private final String hostname;
     private final int port;
@@ -96,6 +100,8 @@ public class ClickHouseSinkConfig {
     private final boolean bypassSchemaValidation;
     private final boolean bypassFieldCleanup;
     private final boolean ignorePartitionsWhenBatching;
+    private final int bufferCount;
+    private final long bufferFlushTime;
     private final boolean binaryFormatWrtiteJsonAsString;
 
     public enum InsertFormats {
@@ -272,7 +278,12 @@ public class ClickHouseSinkConfig {
         this.bypassSchemaValidation = Boolean.parseBoolean(props.getOrDefault(BYPASS_SCHEMA_VALIDATION, "false"));
         this.bypassFieldCleanup = Boolean.parseBoolean(props.getOrDefault(BYPASS_FIELD_CLEANUP, "false"));
         this.ignorePartitionsWhenBatching = Boolean.parseBoolean(props.getOrDefault(IGNORE_PARTITIONS_WHEN_BATCHING, "false"));
+        this.bufferCount = Integer.parseInt(props.getOrDefault(BUFFER_COUNT, bufferCountDefault.toString()));
+        this.bufferFlushTime = Long.parseLong(props.getOrDefault(BUFFER_FLUSH_TIME, bufferFlushTimeDefault.toString()));
 
+        if (this.bufferCount > 0) {
+            LOGGER.info("Internal buffering enabled: bufferCount={}, bufferFlushTime={}ms", this.bufferCount, this.bufferFlushTime);
+        }
 
         String jsonAsString = getClickhouseSettings().get("input_format_binary_read_json_as_string");
         this.binaryFormatWrtiteJsonAsString = jsonAsString != null && (jsonAsString.equalsIgnoreCase("true") || jsonAsString.equals("1"));
@@ -611,6 +622,28 @@ public class ClickHouseSinkConfig {
                 ++orderInGroup,
                 ConfigDef.Width.SHORT,
                 "Ignore partitions when batching."
+        );
+        configDef.define(BUFFER_COUNT,
+                ConfigDef.Type.INT,
+                bufferCountDefault,
+                ConfigDef.Importance.LOW,
+                "Number of records to buffer before flushing to ClickHouse. 0 means no buffering (default). " +
+                        "When enabled, records from multiple poll() calls are accumulated and flushed as a single large batch.",
+                group,
+                ++orderInGroup,
+                ConfigDef.Width.SHORT,
+                "Buffer record count."
+        );
+        configDef.define(BUFFER_FLUSH_TIME,
+                ConfigDef.Type.LONG,
+                bufferFlushTimeDefault,
+                ConfigDef.Importance.LOW,
+                "Maximum time in milliseconds to buffer records before flushing, regardless of buffer count. " +
+                        "0 means no time-based flushing (default). Only effective when bufferCount > 0.",
+                group,
+                ++orderInGroup,
+                ConfigDef.Width.SHORT,
+                "Buffer flush time in ms."
         );
         return configDef;
     }

--- a/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
@@ -626,6 +626,7 @@ public class ClickHouseSinkConfig {
         configDef.define(BUFFER_COUNT,
                 ConfigDef.Type.INT,
                 bufferCountDefault,
+                ConfigDef.Range.atLeast(0),
                 ConfigDef.Importance.LOW,
                 "Number of records to buffer before flushing to ClickHouse. 0 means no buffering (default). " +
                         "When enabled, records from multiple poll() calls are accumulated and flushed as a single large batch.",
@@ -637,6 +638,7 @@ public class ClickHouseSinkConfig {
         configDef.define(BUFFER_FLUSH_TIME,
                 ConfigDef.Type.LONG,
                 bufferFlushTimeDefault,
+                ConfigDef.Range.atLeast(0),
                 ConfigDef.Importance.LOW,
                 "Maximum time in milliseconds to buffer records before flushing, regardless of buffer count. " +
                         "0 means no time-based flushing (default). Only effective when bufferCount > 0.",

--- a/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTask.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTask.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -30,6 +31,7 @@ public class ClickHouseSinkTask extends SinkTask {
     private int bufferCount;
     private long bufferFlushTime;
     private boolean bufferingEnabled;
+    private Map<TopicPartition, OffsetAndMetadata> flushedOffsets;
 
     @Override
     public String version() {
@@ -48,18 +50,29 @@ public class ClickHouseSinkTask extends SinkTask {
             throw new ConnectException("Failed to start new task" , e);
         }
 
+        // Validate config before heavy initialization
+        int configBufferCount = clickHouseSinkConfig.getBufferCount();
+        if (configBufferCount > 0 && clickHouseSinkConfig.isExactlyOnce()) {
+            throw new ConnectException(
+                    "Internal buffering (bufferCount > 0) is not compatible with exactly-once mode. " +
+                    "Buffering changes batch boundaries, which breaks ClickHouse block deduplication and the offset state machine. " +
+                    "To resolve this, either disable exactly-once mode by setting 'exactlyOnce=false' in your connector config, " +
+                    "or disable buffering by setting 'bufferCount=0'."
+            );
+        }
+
         this.proxySinkTask = new ProxySinkTask(clickHouseSinkConfig, errorReporter);
 
         // Initialize buffering
-        this.bufferCount = clickHouseSinkConfig.getBufferCount();
+        this.bufferCount = configBufferCount;
         this.bufferFlushTime = clickHouseSinkConfig.getBufferFlushTime();
         this.bufferingEnabled = this.bufferCount > 0;
-        this.buffer = new ArrayList<>();
+        this.buffer = this.bufferingEnabled ? new ArrayList<>(this.bufferCount) : new ArrayList<>();
         this.lastFlushTime = System.currentTimeMillis();
+        this.flushedOffsets = new HashMap<>();
 
-        if (bufferingEnabled) {
-            LOGGER.info("Internal buffering enabled: bufferCount={}, bufferFlushTime={}ms",
-                    bufferCount, bufferFlushTime);
+        if (this.bufferFlushTime > 0 && this.bufferCount == 0) {
+            LOGGER.warn("bufferFlushTime is set but will be ignored because bufferCount is 0");
         }
     }
 
@@ -85,7 +98,7 @@ public class ClickHouseSinkTask extends SinkTask {
                 && !buffer.isEmpty();
 
         if (sizeThreshold || timeThreshold) {
-            LOGGER.info("Buffer flush triggered: size={}, sizeThreshold={}, timeThreshold={}", buffer.size(), sizeThreshold, timeThreshold);
+            LOGGER.debug("Buffer flush triggered: size={}, sizeThreshold={}, timeThreshold={}, lastFlushTime={}", buffer.size(), sizeThreshold, timeThreshold, lastFlushTime);
             flushBuffer();
         }
     }
@@ -96,7 +109,16 @@ public class ClickHouseSinkTask extends SinkTask {
         }
         List<SinkRecord> toFlush = new ArrayList<>(buffer);
         putDirect(toFlush);
-        // Clear buffer only after successful flush to prevent data loss on failure
+        // Track the max flushed offset per topic/partition so preCommit() only
+        // allows the framework to commit offsets for data written to ClickHouse
+        for (SinkRecord record : toFlush) {
+            TopicPartition tp = new TopicPartition(record.topic(), record.kafkaPartition());
+            long offset = record.kafkaOffset() + 1; // +1 because committed offset = next offset to consume
+            OffsetAndMetadata current = flushedOffsets.get(tp);
+            if (current == null || offset > current.offset()) {
+                flushedOffsets.put(tp, new OffsetAndMetadata(offset));
+            }
+        }
         buffer.clear();
         lastFlushTime = System.currentTimeMillis();
     }
@@ -120,18 +142,58 @@ public class ClickHouseSinkTask extends SinkTask {
         }
     }
 
-    // TODO: can be removed ss
     @Override
-    public void flush(Map<TopicPartition, OffsetAndMetadata> offsets) {
-        LOGGER.trace("Test");
+    public Map<TopicPartition, OffsetAndMetadata> preCommit(Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
+        if (!bufferingEnabled) {
+            return currentOffsets;
+        }
+        // Only commit offsets for records that have been successfully written to ClickHouse.
+        // Records still in the buffer have NOT been written, so their offsets must not be committed.
+        // This guarantees at-least-once delivery: on crash/rebalance, Kafka redelivers buffered records.
+        // Pattern follows Confluent S3 Sink Connector: flush() is no-op, preCommit() manages offsets.
+        if (flushedOffsets.isEmpty()) {
+            LOGGER.info("preCommit: no offsets to commit (all records still buffered)");
+            return new HashMap<>();
+        }
+        Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = new HashMap<>(flushedOffsets);
+        flushedOffsets.clear();
+        LOGGER.debug("preCommit: committing offsets for flushed data: {}", offsetsToCommit);
+        return offsetsToCommit;
+    }
+
+    @Override
+    public void close(Collection<TopicPartition> partitions) {
+        if (!bufferingEnabled) {
+            return;
+        }
+        // Remove buffered records for revoked partitions to prevent duplicates.
+        // Their offsets were never committed via preCommit(), so the new owner
+        // will redeliver them — no data loss.
+        if (!buffer.isEmpty()) {
+            int before = buffer.size();
+            buffer.removeIf(record -> {
+                TopicPartition tp = new TopicPartition(record.topic(), record.kafkaPartition());
+                return partitions.contains(tp);
+            });
+            if (buffer.size() != before) {
+                LOGGER.info("Rebalance: removed {} buffered records for revoked partitions {}",
+                        before - buffer.size(), partitions);
+            }
+        }
+        // Always clean up flushed offsets for revoked partitions so preCommit()
+        // doesn't return offsets that this task no longer owns.
+        flushedOffsets.keySet().removeAll(partitions);
     }
 
     @Override
     public void stop() {
-        // Flush remaining buffered records before stopping
+        // Note: close() is called before stop() by the framework, which already
+        // removes buffered records. Unflushed records' offsets were never committed
+        // via preCommit(), so Kafka will redeliver them on restart (at-least-once).
         if (bufferingEnabled && buffer != null && !buffer.isEmpty()) {
-            LOGGER.info("Stop called with {} buffered records - flushing", buffer.size());
-            flushBuffer();
+            LOGGER.warn("Stop called with {} buffered records still in buffer — " +
+                    "these will be redelivered on restart since offsets were not committed", buffer.size());
+            buffer.clear();
         }
         if (this.proxySinkTask != null) {
             this.proxySinkTask.stop();

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskBufferTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskBufferTest.java
@@ -1,0 +1,213 @@
+package com.clickhouse.kafka.connect.sink;
+
+import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
+import com.clickhouse.kafka.connect.sink.helper.SchemalessTestData;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClickHouseSinkTaskBufferTest.class);
+
+    private static final String TABLE_CREATE_SQL = "CREATE TABLE %s ( `off16` Int16, `str` String, `p_int8` Int8, " +
+            "`p_int16` Int16, `p_int32` Int32, `p_int64` Int64, `p_float32` Float32, `p_float64` Float64, `p_bool` Bool) " +
+            "Engine = MergeTree ORDER BY off16";
+
+    @Test
+    public void bufferingDisabledByDefault() {
+        Map<String, String> props = createProps();
+        ClickHouseHelperClient chc = createClient(props);
+        String topic = createTopicName("buffer_disabled_test");
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.createTable(chc, topic, TABLE_CREATE_SQL);
+
+        Collection<SinkRecord> sr = SchemalessTestData.createPrimitiveTypes(topic, 1);
+
+        ClickHouseSinkTask task = new ClickHouseSinkTask();
+        task.start(props);
+        task.put(sr);
+        task.stop();
+
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+    }
+
+    @Test
+    public void bufferFlushOnSizeThreshold() {
+        Map<String, String> props = createProps();
+        props.put(ClickHouseSinkConfig.BUFFER_COUNT, "500");
+        ClickHouseHelperClient chc = createClient(props);
+        String topic = createTopicName("buffer_size_flush_test");
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.createTable(chc, topic, TABLE_CREATE_SQL);
+
+        // Send 300 records (below threshold of 500) - should NOT be flushed yet
+        List<SinkRecord> batch1 = SchemalessTestData.createPrimitiveTypes(topic, 1, 300);
+        ClickHouseSinkTask task = new ClickHouseSinkTask();
+        task.start(props);
+        task.put(batch1);
+
+        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic),
+                "Records should be buffered, not flushed yet");
+
+        // Send 300 more records (total 600 > threshold 500) - should trigger flush
+        List<SinkRecord> batch2 = SchemalessTestData.createPrimitiveTypes(topic, 1, 300);
+        task.put(batch2);
+
+        assertEquals(600, ClickHouseTestHelpers.countRows(chc, topic),
+                "Buffer should have been flushed after reaching threshold");
+
+        task.stop();
+    }
+
+    @Test
+    public void bufferFlushOnStop() {
+        Map<String, String> props = createProps();
+        props.put(ClickHouseSinkConfig.BUFFER_COUNT, "5000");
+        ClickHouseHelperClient chc = createClient(props);
+        String topic = createTopicName("buffer_stop_flush_test");
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.createTable(chc, topic, TABLE_CREATE_SQL);
+
+        // Send records below threshold - should be buffered
+        List<SinkRecord> records = SchemalessTestData.createPrimitiveTypes(topic, 1, 100);
+        ClickHouseSinkTask task = new ClickHouseSinkTask();
+        task.start(props);
+        task.put(records);
+
+        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic),
+                "Records should be buffered, not flushed yet");
+
+        // Stop should flush remaining buffered records
+        task.stop();
+
+        assertEquals(100, ClickHouseTestHelpers.countRows(chc, topic),
+                "All buffered records should be flushed on stop");
+    }
+
+    @Test
+    public void bufferFlushOnFrameworkFlush() {
+        Map<String, String> props = createProps();
+        props.put(ClickHouseSinkConfig.BUFFER_COUNT, "5000");
+        ClickHouseHelperClient chc = createClient(props);
+        String topic = createTopicName("buffer_framework_flush_test");
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.createTable(chc, topic, TABLE_CREATE_SQL);
+
+        List<SinkRecord> records = SchemalessTestData.createPrimitiveTypes(topic, 1, 100);
+        ClickHouseSinkTask task = new ClickHouseSinkTask();
+        task.start(props);
+        task.put(records);
+
+        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic),
+                "Records should be buffered, not flushed yet");
+
+        // Framework flush() should flush buffered records to prevent data loss before offset commit
+        task.flush(null);
+
+        assertEquals(100, ClickHouseTestHelpers.countRows(chc, topic),
+                "All buffered records should be flushed on framework flush");
+
+        task.stop();
+    }
+
+    @Test
+    public void bufferFlushOnTimeThreshold() throws InterruptedException {
+        Map<String, String> props = createProps();
+        props.put(ClickHouseSinkConfig.BUFFER_COUNT, "50000");
+        props.put(ClickHouseSinkConfig.BUFFER_FLUSH_TIME, "2000");
+        ClickHouseHelperClient chc = createClient(props);
+        String topic = createTopicName("buffer_time_flush_test");
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.createTable(chc, topic, TABLE_CREATE_SQL);
+
+        List<SinkRecord> records = SchemalessTestData.createPrimitiveTypes(topic, 1, 100);
+        ClickHouseSinkTask task = new ClickHouseSinkTask();
+        task.start(props);
+        task.put(records);
+
+        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic),
+                "Records should be buffered, not flushed yet");
+
+        // Wait for the time threshold to pass
+        Thread.sleep(2500);
+
+        // Next put (even empty) should trigger time-based flush
+        task.put(new ArrayList<>());
+
+        assertEquals(100, ClickHouseTestHelpers.countRows(chc, topic),
+                "Buffered records should be flushed after time threshold");
+
+        task.stop();
+    }
+
+    @Test
+    public void bufferAccumulatesMultipleBatches() {
+        Map<String, String> props = createProps();
+        props.put(ClickHouseSinkConfig.BUFFER_COUNT, "2500");
+        ClickHouseHelperClient chc = createClient(props);
+        String topic = createTopicName("buffer_multi_batch_test");
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.createTable(chc, topic, TABLE_CREATE_SQL);
+
+        ClickHouseSinkTask task = new ClickHouseSinkTask();
+        task.start(props);
+
+        // Simulate multiple poll() calls each delivering a small batch
+        int totalRecords = 0;
+        for (int i = 0; i < 5; i++) {
+            List<SinkRecord> batch = SchemalessTestData.createPrimitiveTypes(topic, 1, 400);
+            task.put(batch);
+            totalRecords += batch.size();
+        }
+
+        // 5 * 400 = 2000, still below 2500 threshold
+        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic),
+                "Records should still be buffered (2000 < 2500)");
+
+        // One more batch to push over threshold
+        List<SinkRecord> finalBatch = SchemalessTestData.createPrimitiveTypes(topic, 1, 600);
+        task.put(finalBatch);
+        totalRecords += finalBatch.size();
+
+        assertEquals(totalRecords, ClickHouseTestHelpers.countRows(chc, topic),
+                "All accumulated records should be flushed after crossing threshold");
+
+        task.stop();
+    }
+
+    @Test
+    public void bufferMultiplePartitions() {
+        Map<String, String> props = createProps();
+        props.put(ClickHouseSinkConfig.BUFFER_COUNT, "500");
+        ClickHouseHelperClient chc = createClient(props);
+        String topic = createTopicName("buffer_multi_partition_test");
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.createTable(chc, topic, TABLE_CREATE_SQL);
+
+        ClickHouseSinkTask task = new ClickHouseSinkTask();
+        task.start(props);
+
+        // Records from different partitions should all be buffered together
+        List<SinkRecord> allRecords = new ArrayList<>();
+        allRecords.addAll(SchemalessTestData.createPrimitiveTypes(topic, 0, 200));
+        allRecords.addAll(SchemalessTestData.createPrimitiveTypes(topic, 1, 200));
+        allRecords.addAll(SchemalessTestData.createPrimitiveTypes(topic, 2, 200));
+
+        task.put(allRecords);
+
+        // 600 > 500 threshold, should be flushed
+        assertEquals(600, ClickHouseTestHelpers.countRows(chc, topic),
+                "Records from all partitions should be flushed together");
+
+        task.stop();
+    }
+}

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskBufferTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskBufferTest.java
@@ -8,12 +8,22 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.ConnectException;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClickHouseSinkTaskBufferTest.class);
@@ -69,15 +79,14 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
     }
 
     @Test
-    public void bufferFlushOnStop() {
+    public void bufferGracefulShutdownRedelivers() {
         Map<String, String> props = createProps();
         props.put(ClickHouseSinkConfig.BUFFER_COUNT, "5000");
         ClickHouseHelperClient chc = createClient(props);
-        String topic = createTopicName("buffer_stop_flush_test");
+        String topic = createTopicName("buffer_shutdown_test");
         ClickHouseTestHelpers.dropTable(chc, topic);
         ClickHouseTestHelpers.createTable(chc, topic, TABLE_CREATE_SQL);
 
-        // Send records below threshold - should be buffered
         List<SinkRecord> records = SchemalessTestData.createPrimitiveTypes(topic, 1, 100);
         ClickHouseSinkTask task = new ClickHouseSinkTask();
         task.start(props);
@@ -86,35 +95,53 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic),
                 "Records should be buffered, not flushed yet");
 
-        // Stop should flush remaining buffered records
+        // Simulate real framework shutdown: close(all) then stop()
+        // Buffered records are discarded — their offsets were never committed,
+        // so Kafka redelivers them on restart (at-least-once guarantee).
+        TopicPartition tp = new TopicPartition(topic, 1);
+        task.close(Collections.singletonList(tp));
         task.stop();
 
-        assertEquals(100, ClickHouseTestHelpers.countRows(chc, topic),
-                "All buffered records should be flushed on stop");
+        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic),
+                "Unflushed records should NOT be written — they'll be redelivered on restart");
     }
 
     @Test
-    public void bufferFlushOnFrameworkFlush() {
+    public void bufferRebalanceRemovesRevokedPartitions() {
         Map<String, String> props = createProps();
         props.put(ClickHouseSinkConfig.BUFFER_COUNT, "5000");
         ClickHouseHelperClient chc = createClient(props);
-        String topic = createTopicName("buffer_framework_flush_test");
+        String topic = createTopicName("buffer_rebalance_test");
         ClickHouseTestHelpers.dropTable(chc, topic);
         ClickHouseTestHelpers.createTable(chc, topic, TABLE_CREATE_SQL);
 
-        List<SinkRecord> records = SchemalessTestData.createPrimitiveTypes(topic, 1, 100);
         ClickHouseSinkTask task = new ClickHouseSinkTask();
         task.start(props);
-        task.put(records);
+
+        // Buffer records from P0, P1, P2
+        List<SinkRecord> allRecords = new ArrayList<>();
+        allRecords.addAll(SchemalessTestData.createPrimitiveTypes(topic, 0, 100));
+        allRecords.addAll(SchemalessTestData.createPrimitiveTypes(topic, 1, 100));
+        allRecords.addAll(SchemalessTestData.createPrimitiveTypes(topic, 2, 100));
+        task.put(allRecords);
 
         assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic),
-                "Records should be buffered, not flushed yet");
+                "All 300 records should be buffered");
 
-        // Framework flush() should flush buffered records to prevent data loss before offset commit
-        task.flush(null);
+        // Simulate cooperative rebalance: P2 revoked
+        TopicPartition revokedTp = new TopicPartition(topic, 2);
+        task.close(Collections.singletonList(revokedTp));
 
-        assertEquals(100, ClickHouseTestHelpers.countRows(chc, topic),
-                "All buffered records should be flushed on framework flush");
+        // Now add more records for P0 and P1 to push over threshold (200 remaining + 4900 new > 5000)
+        List<SinkRecord> moreRecords = new ArrayList<>();
+        moreRecords.addAll(SchemalessTestData.createPrimitiveTypes(topic, 0, 2500));
+        moreRecords.addAll(SchemalessTestData.createPrimitiveTypes(topic, 1, 2500));
+        task.put(moreRecords);
+
+        // Only P0 and P1 records should have been written — P2 records were removed by close()
+        int totalRows = ClickHouseTestHelpers.countRows(chc, topic);
+        assertEquals(5200, totalRows,
+                "Only P0 (2600) + P1 (2600) records should be written, P2 records removed by rebalance");
 
         task.stop();
     }
@@ -183,6 +210,275 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
 
         task.stop();
     }
+
+    @Test
+    public void bufferIncompatibleWithExactlyOnce() {
+        Map<String, String> props = createProps();
+        props.put(ClickHouseSinkConfig.BUFFER_COUNT, "500");
+        props.put(ClickHouseSinkConfig.EXACTLY_ONCE, "true");
+
+        ClickHouseSinkTask task = new ClickHouseSinkTask();
+        assertThrows(ConnectException.class, () -> task.start(props),
+                "Buffering should not be allowed with exactly-once mode");
+    }
+
+    // ==================== Offset management tests (crash & rebalance safety) ====================
+
+    @Test
+    public void preCommitReturnsEmptyWhenAllBuffered() {
+        // Simulates crash safety: if records are only buffered (not flushed to CH),
+        // preCommit() must return empty so offsets are NOT committed.
+        // On crash/restart, Kafka redelivers these records.
+        Map<String, String> props = createProps();
+        props.put(ClickHouseSinkConfig.BUFFER_COUNT, "5000");
+        ClickHouseHelperClient chc = createClient(props);
+        String topic = createTopicName("precommit_empty_test");
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.createTable(chc, topic, TABLE_CREATE_SQL);
+
+        ClickHouseSinkTask task = new ClickHouseSinkTask();
+        task.start(props);
+
+        List<SinkRecord> records = SchemalessTestData.createPrimitiveTypes(topic, 1, 100);
+        task.put(records);
+
+        // All records are buffered, nothing flushed to CH
+        Map<TopicPartition, OffsetAndMetadata> currentOffsets = new java.util.HashMap<>();
+        currentOffsets.put(new TopicPartition(topic, 1), new OffsetAndMetadata(100));
+
+        Map<TopicPartition, OffsetAndMetadata> result = task.preCommit(currentOffsets);
+        assertTrue(result.isEmpty(),
+                "preCommit must return empty when all records are still buffered — " +
+                "crash at this point means Kafka redelivers from last committed offset");
+
+        task.close(Collections.singletonList(new TopicPartition(topic, 1)));
+        task.stop();
+    }
+
+    @Test
+    public void preCommitReturnsCorrectOffsetsAfterFlush() {
+        // After buffer flushes to ClickHouse, preCommit() must return the correct
+        // offsets so the framework commits them.
+        Map<String, String> props = createProps();
+        props.put(ClickHouseSinkConfig.BUFFER_COUNT, "500");
+        ClickHouseHelperClient chc = createClient(props);
+        String topic = createTopicName("precommit_offset_test");
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.createTable(chc, topic, TABLE_CREATE_SQL);
+
+        ClickHouseSinkTask task = new ClickHouseSinkTask();
+        task.start(props);
+
+        // Put 600 records across P0 and P1 → exceeds 500 threshold → flush
+        List<SinkRecord> allRecords = new ArrayList<>();
+        allRecords.addAll(SchemalessTestData.createPrimitiveTypes(topic, 0, 300));
+        allRecords.addAll(SchemalessTestData.createPrimitiveTypes(topic, 1, 300));
+        task.put(allRecords);
+
+        // Verify data reached ClickHouse
+        assertEquals(600, ClickHouseTestHelpers.countRows(chc, topic));
+
+        // preCommit should return offsets for both partitions
+        Map<TopicPartition, OffsetAndMetadata> currentOffsets = new java.util.HashMap<>();
+        Map<TopicPartition, OffsetAndMetadata> result = task.preCommit(currentOffsets);
+
+        assertEquals(2, result.size(), "Should have offsets for 2 partitions");
+        // SchemalessTestData creates records with offsets 0..299, so committed offset = 300
+        assertEquals(300, result.get(new TopicPartition(topic, 0)).offset(),
+                "P0 committed offset should be 300 (last offset 299 + 1)");
+        assertEquals(300, result.get(new TopicPartition(topic, 1)).offset(),
+                "P1 committed offset should be 300 (last offset 299 + 1)");
+
+        task.stop();
+    }
+
+    @Test
+    public void preCommitClearsAfterReturning() {
+        // After preCommit() returns offsets, the next call should return empty
+        // if no new data was flushed (matches S3's getOffsetToCommitAndReset pattern).
+        Map<String, String> props = createProps();
+        props.put(ClickHouseSinkConfig.BUFFER_COUNT, "500");
+        ClickHouseHelperClient chc = createClient(props);
+        String topic = createTopicName("precommit_reset_test");
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.createTable(chc, topic, TABLE_CREATE_SQL);
+
+        ClickHouseSinkTask task = new ClickHouseSinkTask();
+        task.start(props);
+
+        List<SinkRecord> records = SchemalessTestData.createPrimitiveTypes(topic, 1, 600);
+        task.put(records);
+
+        // First preCommit: returns flushed offsets
+        Map<TopicPartition, OffsetAndMetadata> result1 = task.preCommit(new java.util.HashMap<>());
+        assertFalse(result1.isEmpty(), "First preCommit should return flushed offsets");
+
+        // Second preCommit without new flushes: should be empty
+        Map<TopicPartition, OffsetAndMetadata> result2 = task.preCommit(new java.util.HashMap<>());
+        assertTrue(result2.isEmpty(), "Second preCommit should return empty — no new data flushed");
+
+        task.stop();
+    }
+
+    @Test
+    public void preCommitExcludesRevokedPartitionsAfterRebalance() {
+        // After close() revokes a partition, preCommit() must NOT return offsets
+        // for that partition, even if data was previously flushed for it.
+        Map<String, String> props = createProps();
+        props.put(ClickHouseSinkConfig.BUFFER_COUNT, "500");
+        ClickHouseHelperClient chc = createClient(props);
+        String topic = createTopicName("precommit_rebalance_test");
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.createTable(chc, topic, TABLE_CREATE_SQL);
+
+        ClickHouseSinkTask task = new ClickHouseSinkTask();
+        task.start(props);
+
+        // Flush records from P0, P1, P2 (600 > 500 threshold)
+        List<SinkRecord> allRecords = new ArrayList<>();
+        allRecords.addAll(SchemalessTestData.createPrimitiveTypes(topic, 0, 200));
+        allRecords.addAll(SchemalessTestData.createPrimitiveTypes(topic, 1, 200));
+        allRecords.addAll(SchemalessTestData.createPrimitiveTypes(topic, 2, 200));
+        task.put(allRecords);
+
+        assertEquals(600, ClickHouseTestHelpers.countRows(chc, topic));
+
+        // Simulate rebalance: revoke P2
+        task.close(Collections.singletonList(new TopicPartition(topic, 2)));
+
+        // preCommit should only return offsets for P0 and P1
+        Map<TopicPartition, OffsetAndMetadata> result = task.preCommit(new java.util.HashMap<>());
+        assertEquals(2, result.size(), "Should only have offsets for P0 and P1");
+        assertTrue(result.containsKey(new TopicPartition(topic, 0)), "Should contain P0");
+        assertTrue(result.containsKey(new TopicPartition(topic, 1)), "Should contain P1");
+        assertFalse(result.containsKey(new TopicPartition(topic, 2)),
+                "Should NOT contain revoked P2 — new owner manages its offsets");
+
+        task.stop();
+    }
+
+    @Test
+    public void crashAfterFlushIsIdempotent() {
+        // Verifies that if ClickHouse receives data and then a crash happens
+        // AFTER preCommit but BEFORE the framework commits, the data is safe:
+        // Kafka will redeliver, and ClickHouse gets duplicates (at-least-once).
+        // This test ensures the offsets returned by preCommit are correct.
+        Map<String, String> props = createProps();
+        props.put(ClickHouseSinkConfig.BUFFER_COUNT, "500");
+        ClickHouseHelperClient chc = createClient(props);
+        String topic = createTopicName("crash_after_flush_test");
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.createTable(chc, topic, TABLE_CREATE_SQL);
+
+        ClickHouseSinkTask task = new ClickHouseSinkTask();
+        task.start(props);
+
+        // Batch 1: flush 600 records
+        List<SinkRecord> batch1 = SchemalessTestData.createPrimitiveTypes(topic, 1, 600);
+        task.put(batch1);
+        assertEquals(600, ClickHouseTestHelpers.countRows(chc, topic));
+
+        Map<TopicPartition, OffsetAndMetadata> offsets1 = task.preCommit(new java.util.HashMap<>());
+        assertEquals(600, offsets1.get(new TopicPartition(topic, 1)).offset());
+
+        // Batch 2: buffer 200 records (below threshold, not flushed)
+        List<SinkRecord> batch2 = SchemalessTestData.createPrimitiveTypes(topic, 1, 200);
+        task.put(batch2);
+        assertEquals(600, ClickHouseTestHelpers.countRows(chc, topic),
+                "Batch 2 should still be buffered");
+
+        // preCommit returns empty — batch 2 not flushed
+        Map<TopicPartition, OffsetAndMetadata> offsets2 = task.preCommit(new java.util.HashMap<>());
+        assertTrue(offsets2.isEmpty(),
+                "preCommit should be empty — only batch 2 is pending and it's still buffered");
+
+        // CRASH HERE: Kafka committed offset 600 from offsets1.
+        // On restart, Kafka redelivers from offset 600 → batch 2's records are redelivered.
+        // Batch 1 is NOT redelivered. No data loss.
+
+        task.close(Collections.singletonList(new TopicPartition(topic, 1)));
+        task.stop();
+    }
+
+    // ==================== Insert failure edge cases (putDirect fails) ====================
+
+    @Test
+    public void putDirectFailsNoErrorTolerance_offsetsNotCommitted() {
+        // Edge case: buffer flush triggers putDirect → insert fails → exception propagates.
+        // Offsets must NOT be committed so Kafka redelivers on restart (at-least-once).
+        Map<String, String> props = createProps();
+        props.put(ClickHouseSinkConfig.BUFFER_COUNT, "500");
+        ClickHouseHelperClient chc = createClient(props);
+        String topic = createTopicName("insert_fail_no_tolerance_test");
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.createTable(chc, topic, TABLE_CREATE_SQL);
+
+        ClickHouseSinkTask task = new ClickHouseSinkTask();
+        task.start(props);
+
+        // Buffer 300 records (below 500 threshold)
+        List<SinkRecord> batch1 = SchemalessTestData.createPrimitiveTypes(topic, 1, 300);
+        task.put(batch1);
+
+        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic),
+                "Records should be buffered, not flushed yet");
+
+        // Drop the table to make the next insert fail
+        ClickHouseTestHelpers.dropTable(chc, topic);
+
+        // Add 300 more records to cross threshold → triggers flush → insert fails
+        List<SinkRecord> batch2 = SchemalessTestData.createPrimitiveTypes(topic, 1, 300);
+        assertThrows(RuntimeException.class, () -> task.put(batch2),
+                "put() should propagate the exception when insert fails and errorsTolerance=false");
+
+        // preCommit must return empty — no offsets should be committed for failed data
+        Map<TopicPartition, OffsetAndMetadata> result = task.preCommit(new java.util.HashMap<>());
+        assertTrue(result.isEmpty(),
+                "preCommit must return empty when putDirect fails — " +
+                "offsets for failed records must not be committed so Kafka redelivers them");
+
+        task.stop();
+    }
+
+    @Test
+    public void putDirectFailsWithErrorTolerance_offsetsCommitted() {
+        // Edge case: buffer flush triggers putDirect → insert fails → error tolerance swallows it.
+        // With error tolerance, records go to DLQ and offsets ARE committed (same as non-buffered behavior).
+        Map<String, String> props = createProps();
+        props.put(ClickHouseSinkConfig.BUFFER_COUNT, "500");
+        props.put(ClickHouseSinkConfig.ERRORS_TOLERANCE, ClickHouseSinkConfig.ERROR_TOLERANCE_ALL);
+        ClickHouseHelperClient chc = createClient(props);
+        String topic = createTopicName("insert_fail_tolerance_test");
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.createTable(chc, topic, TABLE_CREATE_SQL);
+
+        ClickHouseSinkTask task = new ClickHouseSinkTask();
+        task.start(props);
+
+        // Buffer 300 records (below 500 threshold)
+        List<SinkRecord> batch1 = SchemalessTestData.createPrimitiveTypes(topic, 1, 300);
+        task.put(batch1);
+
+        // Drop the table to make the next insert fail
+        ClickHouseTestHelpers.dropTable(chc, topic);
+
+        // Add 300 more records to cross threshold → triggers flush → insert fails but is tolerated
+        List<SinkRecord> batch2 = SchemalessTestData.createPrimitiveTypes(topic, 1, 300);
+        task.put(batch2);
+
+        // With error tolerance, flushBuffer() continues after putDirect catches the exception.
+        // Offsets should be committed because records were "handled" (sent to DLQ).
+        Map<TopicPartition, OffsetAndMetadata> result = task.preCommit(new java.util.HashMap<>());
+        assertFalse(result.isEmpty(),
+                "preCommit should return offsets — error tolerance means records were handled (DLQ), " +
+                "and offsets must advance to prevent infinite redelivery of bad records");
+        assertEquals(300, result.get(new TopicPartition(topic, 1)).offset(),
+                "Committed offset should be 300 (last offset 299 + 1) for the tolerated batch");
+
+        task.stop();
+    }
+
+    // ==================== Partition tests ====================
 
     @Test
     public void bufferMultiplePartitions() {


### PR DESCRIPTION
## Summary
• Buffer implementation: Adds internal record buffering to ClickHouseSinkTask so that records from multiple poll() calls are accumulated and flushed as a single large batch, reducing the number of
    inserts to ClickHouse.
  • Two new config options: bufferCount (number of records to accumulate before flushing) and bufferFlushTime (max time in ms before flushing regardless of count). Both default to 0 (disabled), preserving
    backward compatibility.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
