### PR TITLE
Update ClickHouse version coverage

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         client: ["V1", "V2"]
-        clickhouse: ["23.7", "24.3", "latest", "cloud"]
+        clickhouse: ["25.3", "25.8", "25.10", "25.11", "25.12", "latest", "cloud"]
     name: ClickHouse ${{ matrix.clickhouse }} Client version ${{ matrix.client }} tests
     steps:
       - name: Check for Cloud Credentials


### PR DESCRIPTION
## Summary

Updated ClickHouse version test `["25.3", "25.8", "25.10", "25.11", "25.12", "latest", "cloud"]`
## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
