### PR TITLE
Fix concurrency bugs and non-threadsafe behaviour of ClickHouseWriter table mapping

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -62,6 +62,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -76,11 +77,11 @@ public class ClickHouseWriter implements DBWriter {
     private ClickHouseHelperClient chc = null;
     private ClickHouseSinkConfig csc = null;
 
-    private Map<String, Table> mapping = null;
-    private AtomicBoolean isUpdateMappingRunning = new AtomicBoolean(false);
+    private final Map<String, Table> mapping;
+    private final AtomicBoolean isUpdateMappingRunning = new AtomicBoolean(false);
     private final SinkTaskStatistics statistics;
     public ClickHouseWriter(SinkTaskStatistics statistics) {
-        this.mapping = new HashMap<String, Table>();
+        this.mapping = new ConcurrentHashMap<>();
         this.statistics = statistics;
     }
 
@@ -152,10 +153,10 @@ public class ClickHouseWriter implements DBWriter {
 
     public void updateMapping(String database) {
         // Do not start a new update cycle if one is already in progress
-        if (this.isUpdateMappingRunning.get()) {
+        // Atomically compare and set isUpdateMappingRunning
+        if (!this.isUpdateMappingRunning.compareAndSet(false, true)) {
             return;
         }
-        this.isUpdateMappingRunning.set(true);
 
         LOGGER.debug("Update table mapping.");
 
@@ -170,7 +171,7 @@ public class ClickHouseWriter implements DBWriter {
             // TODO: check Kafka Connect's topics name or topics regex config and
             // only add tables to in-memory mapping that matches the topics we consume.
             for (Table table : tableList) {
-                mapping.put(table.getFullName(), table);
+                this.mapping.put(table.getFullName(), table);
             }
         } finally {
             this.isUpdateMappingRunning.set(false);


### PR DESCRIPTION
## Summary
This change fixes a race in `ClickHouseWriter.updateMapping()` and makes the in-memory table mapping safe for concurrent access.

Previously, updateMapping() used a non-atomic `.get()` / `.set(true)` pattern on isUpdateMappingRunning, which allowed multiple threads to enter the refresh path at the same time. At the same time, mapping was a plain `HashMap`, even though it can be read from the task thread while being refreshed by the background table refresh thread. Using `HashMap` across multiple threads has potential to cause infinite loops in the refresh thread, which would explain issues i've observed in production requiring a connector restart after schema migrations.

This PR updates the refresh guard to use the atomic `compareAndSet(false, true)` and switches mapping to a ConcurrentHashMap. That makes concurrent reads/writes safe and prevents overlapping mapping refreshes within a single writer instance.

This is intentionally a minimal fix to achieve thread safety and eliminate undefined behaviour. Note the main task thread will still see a partially updated mapping while the refresh thread updates it in-place, which has potential to cause unexpected behaviour depending how it's used. This should likely be addressed in a followup.