### PR TITLE
[security] Upgrade Jakson-core to 2.21.2 to address CVE  

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,7 @@ extra.apply {
     set("kafkaVersion", "2.7.0")
     set("gson", "2.13.1")
     set("jackson", "2.21.2")
+    set("jackson-annotations", "2.21")
 
     // Testing dependencies
     set("junitJupiterVersion", "5.9.2")
@@ -95,7 +96,7 @@ dependencies {
     // To parse JSON response from ClickHouse to parse complex data types correctly
     implementation("com.fasterxml.jackson.core:jackson-core:${project.extra["jackson"]}")
     implementation("com.fasterxml.jackson.core:jackson-databind:${project.extra["jackson"]}")
-    implementation("com.fasterxml.jackson.core:jackson-annotations:2.21}")
+    implementation("com.fasterxml.jackson.core:jackson-annotations:${project.extra["jackson-annotations"]}}")
 
     /*
         Will in side the Confluent Archive
@@ -107,7 +108,7 @@ dependencies {
     clickhouseDependencies("com.google.code.gson:gson:${project.extra["gson"]}")
     clickhouseDependencies("com.fasterxml.jackson.core:jackson-core:${project.extra["jackson"]}")
     clickhouseDependencies("com.fasterxml.jackson.core:jackson-databind:${project.extra["jackson"]}")
-    clickhouseDependencies("com.fasterxml.jackson.core:jackson-annotations:2.21}")
+    clickhouseDependencies("com.fasterxml.jackson.core:jackson-annotations:${project.extra["jackson-annotations"]}}")
 
     // Unit Tests
     testImplementation(platform("org.junit:junit-bom:${project.extra["junitJupiterVersion"]}"))


### PR DESCRIPTION
## Summary
There is a CVE in the version of `jakson-core` we currently use.  
Here is description https://github.com/advisories/GHSA-72hv-8253-57qq

This upgrade version of the package to a latest compatible one within same major version of `jakson` library. 
The library will be upgrade to `3.+` version later after testing. 


## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
