### PR TITLE
Extend avro test coverage + identify compatible/incompatible schemas

### DIFF
--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConnectorIntegrationTest.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConnectorIntegrationTest.java
@@ -262,6 +262,19 @@ public class ClickHouseSinkConnectorIntegrationTest {
         return Stream.of(Objects.requireNonNull(new File(schemaDir).listFiles())).map(file -> schemaDir + "/" + file.getName());
     }
 
+
+    /*
+        Test sinking Avro records with various schemas that the connector currently supports.
+
+        To add a new compatible schema to test:
+        1. create a new JSON file in `src/testFixtures/avro/schemas/compatible`
+        2. copy the structure from another schema file - ensure the following fields exists: [description, schema, clickhouse_columns, clickhouse_order_by, records, expected_row_count]
+
+        The test will pick up the new schema automatically.
+
+        To add a new incompatible schema, follow the same instructions as above but add the schema to `src/testFixtures/avro/schemas/incompatible`.
+        Over time, the goal is to fix the connector to make previously incompatible schemas compatible.
+     */
     @ParameterizedTest
     @MethodSource("getCompatibleAvroSchemaPaths")
     public void avroSchemaTest(String path) throws Exception {

--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConnectorIntegrationTest.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConnectorIntegrationTest.java
@@ -22,7 +22,6 @@ import org.json.JSONObject;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -204,31 +203,14 @@ public class ClickHouseSinkConnectorIntegrationTest {
         Thread.sleep(1000);
     }
 
-    private void setupAvroConnector(String topicName, int taskCount) throws IOException, InterruptedException {
+    private void setupAvroConnector(String topicName) throws IOException, InterruptedException {
         LOGGER.info("Setting up Avro connector for topic {}...", topicName);
         confluentPlatform.deleteConnectors(SINK_CONNECTOR_NAME);
 
-        // TODO: extract this into a json file
-        JSONObject config = new JSONObject();
-        config.put("name", SINK_CONNECTOR_NAME);
-        config.put("connector.class", "com.clickhouse.kafka.connect.ClickHouseSinkConnector");
-        config.put("tasks.max", String.valueOf(taskCount));
-        config.put("topics", topicName);
-        config.put("hostname", CLICKHOUSE_DB_NETWORK_ALIAS);
-        config.put("port", "8123");
-        config.put("database", "default");
-        config.put("username", db.getUsername());
-        config.put("password", db.getPassword());
-        config.put("ssl", "false");
-        config.put("exactlyOnce", "false");
-        config.put("value.converter", "io.confluent.connect.avro.AvroConverter");
-        config.put("value.converter.schema.registry.url", "http://schema-registry:8081");
+        String payloadClickHouseSink = String.join("", Files.readAllLines(Paths.get("src/integrationTest/resources/clickhouse_sink_avro.json")));
+        String connectorConfig = String.format(payloadClickHouseSink, SINK_CONNECTOR_NAME, SINK_CONNECTOR_NAME, 1 /* tasks.max=1 for ease of error parsing */, topicName, "toxiproxy", 8666, db.getUsername(), db.getPassword());
 
-        JSONObject payload = new JSONObject();
-        payload.put("name", SINK_CONNECTOR_NAME);
-        payload.put("config", config);
-
-        confluentPlatform.createConnect(payload.toString());
+        confluentPlatform.createConnect(connectorConfig);
         Thread.sleep(1000);
     }
 
@@ -275,29 +257,32 @@ public class ClickHouseSinkConnectorIntegrationTest {
         assertTrue(dataCount <= ClickHouseTestHelpers.countRows(chcNoProxy, topicName));
     }
 
-    private static Stream<String> lsAvroSchemas() {
-        String schemaDir = "src/testFixtures/avro/schemas/breaking";
+    private static Stream<String> getCompatibleAvroSchemaPaths() {
+        final String schemaDir = "src/testFixtures/avro/schemas/incompatible";
         return Stream.of(Objects.requireNonNull(new File(schemaDir).listFiles())).map(file -> schemaDir + "/" + file.getName());
     }
 
     @ParameterizedTest
-    @MethodSource("lsAvroSchemas")
-    public void avroSchemaTest(String fixtureFilePath) throws Exception {
-        String fixtureContent = String.join("", Files.readAllLines(Paths.get(fixtureFilePath)));
-        JSONObject fixture = new JSONObject(fixtureContent);
+    @MethodSource("getCompatibleAvroSchemaPaths")
+    public void avroSchemaTest(String path) throws Exception {
+        Path schemaPath = Paths.get(path);
+        JSONObject fixture = new JSONObject(String.join("", Files.readAllLines(schemaPath)));
 
-        String description = fixture.getString("description");
-        JSONObject schema = fixture.getJSONObject("schema");
-        JSONObject clickhouseColumns = fixture.getJSONObject("clickhouse_columns");
-        String orderBy = fixture.getString("clickhouse_order_by");
-        JSONArray records = fixture.getJSONArray("records");
-        int expectedRowCount = fixture.getInt("expected_row_count");
+        // fixture JSON keys
+        final String descriptionKey = "description";
+        final String schemaKey = "schema";
+        final String clickhouseColumnsKey = "clickhouse_columns";
+        final String clickhouseOrderByKey = "clickhouse_order_by";
+        final String recordsKey = "records";
+        final String expectedRowCountKey = "expected_row_count";
+
+        int expectedRowCount = fixture.getInt(expectedRowCountKey);
 
         // Derive topic name from fixture filename (remove .json extension)
-        String fileName = Paths.get(fixtureFilePath).getFileName().toString();
-        String topicName = "chaos_" + fileName.replace(".json", "").replace("-", "_");
+        String fileName = schemaPath.getFileName().toString();
+        String topicName = "avro_test_" + fileName.replace(".json", "").replace("-", "_");
 
-        LOGGER.info("Running chaos test: {} (topic: {}, expected rows: {})", description, topicName, expectedRowCount);
+        LOGGER.info("Running avro integration test: {} (topic: {}, expected rows: {})", fixture.getString(descriptionKey), topicName, expectedRowCount);
 
         // 1. Create topic
         confluentPlatform.createTopic(topicName, 1);
@@ -307,7 +292,8 @@ public class ClickHouseSinkConnectorIntegrationTest {
         CreateTableStatement tableStmt = new CreateTableStatement()
                 .tableName(topicName)
                 .engine("MergeTree")
-                .orderByColumn(orderBy);
+                .orderByColumn(fixture.getString(clickhouseOrderByKey));
+        JSONObject clickhouseColumns = fixture.getJSONObject(clickhouseColumnsKey);
         for (String colName : clickhouseColumns.keySet()) {
             tableStmt.column(colName, clickhouseColumns.getString(colName));
         }
@@ -316,13 +302,13 @@ public class ClickHouseSinkConnectorIntegrationTest {
         // 3. Produce Avro records via REST proxy
         int producedCount = confluentPlatform.produceAvroRecords(
                 topicName,
-                schema.toString(),
-                records
+                fixture.getJSONObject(schemaKey).toString(),
+                fixture.getJSONArray(recordsKey)
         );
         LOGGER.info("Produced {} records to topic {}", producedCount, topicName);
 
         // 4. Setup sink connector with Avro converter
-        setupAvroConnector(topicName, 1);
+        setupAvroConnector(topicName);
 
         // 5. Wait for data to flow through
         waitWhileCounting(chcNoProxy, topicName, 3);
@@ -330,15 +316,10 @@ public class ClickHouseSinkConnectorIntegrationTest {
         // 6. Check for connector task failure
         Optional<String> taskFailure = confluentPlatform.getFirstTaskFailureOpt(SINK_CONNECTOR_NAME);
         if (taskFailure.isPresent()) {
-            throw new Exception(String.format("Connector task failed for %s: %s", fileName, taskFailure.get()));
+            Assertions.fail(String.format("Connector task failed for %s: %s", fileName, taskFailure.orElseThrow()));
         }
 
         // 7. Check row count
-        int rowCount = countRows(chcNoProxy, topicName);
-        LOGGER.info("ClickHouse row count for {}: {} (expected: {})", topicName, rowCount, expectedRowCount);
-
-        if (rowCount < expectedRowCount) {
-            throw new Exception(String.format("Data loss detected for %s: got %d rows, expected %d", fileName, rowCount, expectedRowCount));
-        }
+        Assertions.assertEquals(expectedRowCount, countRows(chcNoProxy, topicName));
     }
 }

--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConnectorIntegrationTest.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConnectorIntegrationTest.java
@@ -8,24 +8,26 @@ import com.clickhouse.kafka.connect.sink.helper.ConfluentPlatform;
 import com.clickhouse.kafka.connect.sink.helper.CreateTableStatement;
 import eu.rekawek.toxiproxy.Proxy;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.toxiproxy.ToxiproxyContainer;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
+
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -202,6 +204,34 @@ public class ClickHouseSinkConnectorIntegrationTest {
         Thread.sleep(1000);
     }
 
+    private void setupAvroConnector(String topicName, int taskCount) throws IOException, InterruptedException {
+        LOGGER.info("Setting up Avro connector for topic {}...", topicName);
+        confluentPlatform.deleteConnectors(SINK_CONNECTOR_NAME);
+
+        // TODO: extract this into a json file
+        JSONObject config = new JSONObject();
+        config.put("name", SINK_CONNECTOR_NAME);
+        config.put("connector.class", "com.clickhouse.kafka.connect.ClickHouseSinkConnector");
+        config.put("tasks.max", String.valueOf(taskCount));
+        config.put("topics", topicName);
+        config.put("hostname", CLICKHOUSE_DB_NETWORK_ALIAS);
+        config.put("port", "8123");
+        config.put("database", "default");
+        config.put("username", db.getUsername());
+        config.put("password", db.getPassword());
+        config.put("ssl", "false");
+        config.put("exactlyOnce", "false");
+        config.put("value.converter", "io.confluent.connect.avro.AvroConverter");
+        config.put("value.converter.schema.registry.url", "http://schema-registry:8081");
+
+        JSONObject payload = new JSONObject();
+        payload.put("name", SINK_CONNECTOR_NAME);
+        payload.put("config", config);
+
+        confluentPlatform.createConnect(payload.toString());
+        Thread.sleep(1000);
+    }
+
     private void setupConnectorWithJdbcProperties(String topicName, int taskCount) throws IOException, InterruptedException {
         LOGGER.info("Setting up connector with jdbc properties...");
         confluentPlatform.deleteConnectors(SINK_CONNECTOR_NAME);
@@ -243,5 +273,72 @@ public class ClickHouseSinkConnectorIntegrationTest {
         }
 
         assertTrue(dataCount <= ClickHouseTestHelpers.countRows(chcNoProxy, topicName));
+    }
+
+    private static Stream<String> lsAvroSchemas() {
+        String schemaDir = "src/testFixtures/avro/schemas/breaking";
+        return Stream.of(Objects.requireNonNull(new File(schemaDir).listFiles())).map(file -> schemaDir + "/" + file.getName());
+    }
+
+    @ParameterizedTest
+    @MethodSource("lsAvroSchemas")
+    public void avroSchemaTest(String fixtureFilePath) throws Exception {
+        String fixtureContent = String.join("", Files.readAllLines(Paths.get(fixtureFilePath)));
+        JSONObject fixture = new JSONObject(fixtureContent);
+
+        String description = fixture.getString("description");
+        JSONObject schema = fixture.getJSONObject("schema");
+        JSONObject clickhouseColumns = fixture.getJSONObject("clickhouse_columns");
+        String orderBy = fixture.getString("clickhouse_order_by");
+        JSONArray records = fixture.getJSONArray("records");
+        int expectedRowCount = fixture.getInt("expected_row_count");
+
+        // Derive topic name from fixture filename (remove .json extension)
+        String fileName = Paths.get(fixtureFilePath).getFileName().toString();
+        String topicName = "chaos_" + fileName.replace(".json", "").replace("-", "_");
+
+        LOGGER.info("Running chaos test: {} (topic: {}, expected rows: {})", description, topicName, expectedRowCount);
+
+        // 1. Create topic
+        confluentPlatform.createTopic(topicName, 1);
+
+        // 2. Create ClickHouse table
+        dropTable(chcNoProxy, topicName);
+        CreateTableStatement tableStmt = new CreateTableStatement()
+                .tableName(topicName)
+                .engine("MergeTree")
+                .orderByColumn(orderBy);
+        for (String colName : clickhouseColumns.keySet()) {
+            tableStmt.column(colName, clickhouseColumns.getString(colName));
+        }
+        tableStmt.execute(chcNoProxy);
+
+        // 3. Produce Avro records via REST proxy
+        int producedCount = confluentPlatform.produceAvroRecords(
+                topicName,
+                schema.toString(),
+                records
+        );
+        LOGGER.info("Produced {} records to topic {}", producedCount, topicName);
+
+        // 4. Setup sink connector with Avro converter
+        setupAvroConnector(topicName, 1);
+
+        // 5. Wait for data to flow through
+        waitWhileCounting(chcNoProxy, topicName, 3);
+
+        // 6. Check for connector task failure
+        Optional<String> taskFailure = confluentPlatform.getFirstTaskFailureOpt(SINK_CONNECTOR_NAME);
+        if (taskFailure.isPresent()) {
+            throw new Exception(String.format("Connector task failed for %s: %s", fileName, taskFailure.get()));
+        }
+
+        // 7. Check row count
+        int rowCount = countRows(chcNoProxy, topicName);
+        LOGGER.info("ClickHouse row count for {}: {} (expected: {})", topicName, rowCount, expectedRowCount);
+
+        if (rowCount < expectedRowCount) {
+            throw new Exception(String.format("Data loss detected for %s: got %d rows, expected %d", fileName, rowCount, expectedRowCount));
+        }
     }
 }

--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConnectorIntegrationTest.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConnectorIntegrationTest.java
@@ -16,8 +16,6 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.toxiproxy.ToxiproxyContainer;
-
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.File;
@@ -301,7 +299,7 @@ public class ClickHouseSinkConnectorIntegrationTest {
         confluentPlatform.createTopic(topicName, 1);
 
         // 2. Create ClickHouse table
-        dropTable(chcNoProxy, topicName);
+        ClickHouseTestHelpers.dropTable(chcNoProxy, topicName);
         CreateTableStatement tableStmt = new CreateTableStatement()
                 .tableName(topicName)
                 .engine("MergeTree")
@@ -324,7 +322,7 @@ public class ClickHouseSinkConnectorIntegrationTest {
         setupAvroConnector(topicName);
 
         // 5. Wait for data to flow through
-        waitWhileCounting(chcNoProxy, topicName, 3);
+        ClickHouseTestHelpers.waitWhileCounting(chcNoProxy, topicName, 3);
 
         // 6. Check for connector task failure
         Optional<String> taskFailure = confluentPlatform.getFirstTaskFailureOpt(SINK_CONNECTOR_NAME);
@@ -333,6 +331,6 @@ public class ClickHouseSinkConnectorIntegrationTest {
         }
 
         // 7. Check row count
-        Assertions.assertEquals(expectedRowCount, countRows(chcNoProxy, topicName));
+        Assertions.assertEquals(expectedRowCount, ClickHouseTestHelpers.countRows(chcNoProxy, topicName));
     }
 }

--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConnectorIntegrationTest.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConnectorIntegrationTest.java
@@ -258,7 +258,7 @@ public class ClickHouseSinkConnectorIntegrationTest {
     }
 
     private static Stream<String> getCompatibleAvroSchemaPaths() {
-        final String schemaDir = "src/testFixtures/avro/schemas/incompatible";
+        final String schemaDir = "src/testFixtures/avro/schemas/compatible";
         return Stream.of(Objects.requireNonNull(new File(schemaDir).listFiles())).map(file -> schemaDir + "/" + file.getName());
     }
 

--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/helper/ConfluentPlatform.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/helper/ConfluentPlatform.java
@@ -1,35 +1,29 @@
 package com.clickhouse.kafka.connect.sink.helper;
 
 
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
+import okhttp3.*;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
+
+import org.json.JSONArray;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.regex.Pattern;
 
 
 public class ConfluentPlatform {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfluentPlatform.class);
 
-    private static final String CONFLUENT_VERSION = "7.5.0";
+    private static final String CONFLUENT_VERSION = "7.5.0"; // TODO: this is >2 years outdated and should be upgraded or removed outright
     private static final DockerImageName KAFKA_REST_IMAGE = DockerImageName.parse(
             "confluentinc/cp-kafka-rest:" + CONFLUENT_VERSION
     );
@@ -67,6 +61,14 @@ public class ConfluentPlatform {
     private String restProxyEndpoint = null;
     private String connectRestEndPoint = null;
     private String ksqlRestEndPoint = null;
+
+    // ref: https://docs.confluent.io/platform/current/kafka-rest/api.html#post--topics-(string-topic_name)
+    // NOTE: the below keys are constants in Confluent rest proxy API v2.
+    private static final String AVRO_V2_APPLICATION_TYPE = "application/vnd.kafka.avro.v2+json";
+    private static final String TOPIC_ENDPOINT_RESPONSE_OFFSETS_KEY = "offsets";
+    private static final String TOPIC_ENDPOINT_RESPONSE_OFFSETS_ERROR_KEY = "error";
+    private static final String CONNECTORS_ENDPOINT_RESPONSE_TASKS_KEY = "tasks";
+    private static final String CONNECTORS_ENDPOINT_RESPONSE_TASKS_STATE_KEY = "state";
 
     GenericContainer<?> zookeeper;
     GenericContainer<?> cp_server;
@@ -263,8 +265,8 @@ public class ConfluentPlatform {
         Request request = new Request.Builder()
                 .url(clusterIDurl)
                 .build();
-        try (Response response = client.newCall(request).execute()) {
-            JSONObject obj = new JSONObject(response.body().string());
+        try (Response response = client.newCall(request).execute(); ResponseBody responseBody = response.body()) {
+            JSONObject obj = new JSONObject(responseBody.string());
             return obj.getJSONArray("data").getJSONObject(0).getString("cluster_id").toString();
         } catch (IOException ioe) {
             return null;
@@ -285,12 +287,9 @@ public class ConfluentPlatform {
                 .url(kafkaTopicEndpoint)
                 .post(body)
                 .build();
-        try (Response response = client.newCall(request).execute()) {
+        try (Response response = client.newCall(request).execute(); ResponseBody responseBody = response.body()) {
             LOGGER.debug("Create topic response code: {}", response.code());
-            assert response.body() != null;
-            String responseBody = response.body().string();
-            LOGGER.debug("Create topic response body: {}", responseBody);
-            return responseBody;
+            return responseBody.string();
         }
     }
 
@@ -302,12 +301,9 @@ public class ConfluentPlatform {
                 .url(kafkaTopicEndpoint)
                 .delete()
                 .build();
-        try (Response response = client.newCall(request).execute()) {
+        try (Response response = client.newCall(request).execute(); ResponseBody responseBody = response.body()) {
             LOGGER.debug("Delete topic response code: {}", response.code());
-            assert response.body() != null;
-            String responseBody = response.body().string();
-            LOGGER.debug("Delete topic response body: {}", responseBody);
-            return responseBody;
+            return responseBody.string();
         }
     }
 
@@ -340,11 +336,8 @@ public class ConfluentPlatform {
                 .addHeader("Content-Type","application/json")
                 .post(body)
                 .build();
-        try (Response response = client.newCall(request).execute()) {
+        try (Response response = client.newCall(request).execute(); ResponseBody responseBody = response.body()) {
             LOGGER.info("Create connectors response code: {}", response.code());
-            assert response.body() != null;
-            String responseBody = response.body().string();
-            LOGGER.debug("Create connectors response body: {}", responseBody);
         }
     }
 
@@ -359,17 +352,11 @@ public class ConfluentPlatform {
                 .url(connectorsEndpoint)
                 .delete()
                 .build();
-        try (Response response = client.newCall(request).execute()) {
+        try (Response response = client.newCall(request).execute(); ResponseBody responseBody = response.body()) {
             LOGGER.info("Delete connectors response code: {}", response.code());
-            assert response.body() != null;
-            String responseBody = response.body().string();
-            LOGGER.debug("Delete connectors response body: {}", responseBody);
         }
     }
 
-    public void printConnectors() {
-        LOGGER.info(getConnectors());
-    }
 
     public String getConnectors() {
         String connectRestEndpoint = getConnectRestEndPoint();
@@ -379,12 +366,9 @@ public class ConfluentPlatform {
                 .url(connectorsEndpoint)
                 .get()
                 .build();
-        try (Response response = client.newCall(request).execute()) {
+        try (Response response = client.newCall(request).execute(); ResponseBody responseBody = response.body()) {
             LOGGER.debug("Get connectors response code: {}", response.code());
-            assert response.body() != null;
-            String responseBody = response.body().string();
-            LOGGER.debug("Get connectors response body: {}", responseBody);
-            return responseBody;
+            return responseBody.string();
         } catch (IOException ioe) {
             return "";
         }
@@ -400,7 +384,6 @@ public class ConfluentPlatform {
                 .post(RequestBody.create("", null))
                 .build();
         try (Response response = client.newCall(request).execute()) {
-            assert response.body() != null;
             if (response.code() == 200) {
                 LOGGER.info("Waiting for connector to finish restarting...");
                 int loopCount = 0;
@@ -442,10 +425,10 @@ public class ConfluentPlatform {
                 .url(kafkaTopicOffsetEndpoint)
                 .get()
                 .build();
-        try (Response response = client.newCall(request).execute()) {
+        try (Response response = client.newCall(request).execute(); ResponseBody responseBody = response.body()) {
             LOGGER.info("Get offset response code: {}", response.code());
             if (response.code() == 200) {
-                JSONObject obj = new JSONObject(response.body().string());
+                JSONObject obj = new JSONObject(responseBody.string());
 //                long beginningOffset = obj.getLong("beginning_offset");
                 return obj.getLong("end_offset");
             }
@@ -490,16 +473,101 @@ public class ConfluentPlatform {
         return (int) offsetTotal;
     }
 
+    public int produceAvroRecords(String topicName, String avroSchemaJson, JSONArray records) throws IOException {
+        String restProxyURL = getRestProxyEndpoint();
+        String produceEndpoint = String.format("%s/topics/%s", restProxyURL, topicName);
 
-    public boolean isConnectorRunning(String connectorName) throws IOException {
-        String connectors = getConnectors();
-        HashMap<String, Map> map = (new ObjectMapper()).readValue(connectors, HashMap.class);
-        Map connector = map.get(connectorName);
-        Map status = (Map) connector.get("status");
-        Map connectorStatus = (Map) status.get("connector");
-        String connectorState = String.valueOf(connectorStatus.get("state"));
+        JSONArray wrappedRecords = new JSONArray();
+        for (int i = 0; i < records.length(); i++) {
+            JSONObject wrapper = new JSONObject();
+            wrapper.put("value", records.getJSONObject(i));
+            wrappedRecords.put(wrapper);
+        }
 
-        return "RUNNING".equalsIgnoreCase(connectorState);
+        JSONObject payload = new JSONObject();
+        payload.put("value_schema", avroSchemaJson);
+        payload.put("records", wrappedRecords);
+
+        OkHttpClient client = new OkHttpClient();
+        MediaType AVRO_V2 = MediaType.get(AVRO_V2_APPLICATION_TYPE);
+        RequestBody body = RequestBody.create(payload.toString(), AVRO_V2);
+        Request request = new Request.Builder()
+                .url(produceEndpoint)
+                .addHeader("Content-Type", AVRO_V2_APPLICATION_TYPE)
+                .post(body)
+                .build();
+
+        try (Response response = client.newCall(request).execute(); ResponseBody responseBody = response.body()) {
+            String responseBodyString = responseBody.string();
+            LOGGER.info("Produce Avro records response code: {} for topic: {}", response.code(), topicName);
+
+            if (response.code() != 200) {
+                throw new IOException("Failed to produce Avro records to topic " + topicName + ": " + responseBodyString);
+            }
+
+            JSONObject responseObj = new JSONObject(responseBodyString);
+            JSONArray offsets = responseObj.getJSONArray(TOPIC_ENDPOINT_RESPONSE_OFFSETS_KEY);
+            int successCount = 0;
+            for (int i = 0; i < offsets.length(); i++) {
+                JSONObject offset = offsets.getJSONObject(i);
+                if (!offset.has(TOPIC_ENDPOINT_RESPONSE_OFFSETS_ERROR_KEY) || offset.isNull(TOPIC_ENDPOINT_RESPONSE_OFFSETS_ERROR_KEY)) {
+                    successCount++;
+                } else {
+                    LOGGER.warn("Record {} failed: {}", i, offset.get(TOPIC_ENDPOINT_RESPONSE_OFFSETS_ERROR_KEY));
+                }
+            }
+            LOGGER.info("Successfully produced {} of {} records to topic {}", successCount, records.length(), topicName);
+            return successCount;
+        }
     }
 
+    /**
+     * Check if a connector's tasks are all running (not FAILED).
+     * Returns the FIRST error trace encountered if any task has failed, or empty optional if all tasks are running.
+     */
+    public Optional<String> getFirstTaskFailureOpt(String connectorName) throws IOException {
+        String connectRestEndpoint = getConnectRestEndPoint();
+        OkHttpClient client = new OkHttpClient();
+        String connectorsEndpoint = String.format("%s/connectors/%s/status", connectRestEndpoint, connectorName);
+        Request request = new Request.Builder()
+                .url(connectorsEndpoint)
+                .get()
+                .build();
+        try (Response response = client.newCall(request).execute(); ResponseBody responseBody = response.body()) {
+            if (response.code() != 200) {
+                throw new IOException(String.format("Request failed - endpoint: '%s', response: '%s'", connectorsEndpoint, response.code()));
+            }
+            JSONArray tasks = new JSONObject(responseBody.string()).getJSONArray(CONNECTORS_ENDPOINT_RESPONSE_TASKS_KEY);
+            if (tasks == null || tasks.isEmpty()) {
+                return Optional.empty();
+            }
+            for (Object task : tasks) {
+                JSONObject jsonTaskObj = (JSONObject) task;
+                String state = String.valueOf(jsonTaskObj.get(CONNECTORS_ENDPOINT_RESPONSE_TASKS_STATE_KEY));
+                if ("FAILED".equalsIgnoreCase(state)) {
+                    return Optional.of(jsonTaskObj.has("trace") ? String.valueOf(jsonTaskObj.get("trace")) : "No trace available");
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+
+    public boolean isConnectorRunning(String connectorName) throws IOException {
+        String connectRestEndpoint = getConnectRestEndPoint();
+        OkHttpClient client = new OkHttpClient();
+        String connectorsEndpoint = String.format("%s/connectors/%s/status", connectRestEndpoint, connectorName);
+        Request request = new Request.Builder()
+                .url(connectorsEndpoint)
+                .get()
+                .build();
+        try (Response response = client.newCall(request).execute(); ResponseBody responseBody = response.body()) {
+            if (response.code() != 200) {
+                throw new IOException(String.format("Request failed - endpoint: '%s', response: '%s'", connectorsEndpoint, response.code()));
+            }
+            JSONObject connector = (JSONObject) new JSONObject(responseBody.string()).get("connector");
+            return "RUNNING".equalsIgnoreCase((String) connector.get(CONNECTORS_ENDPOINT_RESPONSE_TASKS_STATE_KEY));
+        }
+    }
 }

--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/helper/ConfluentPlatform.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/helper/ConfluentPlatform.java
@@ -288,8 +288,10 @@ public class ConfluentPlatform {
                 .post(body)
                 .build();
         try (Response response = client.newCall(request).execute(); ResponseBody responseBody = response.body()) {
+            String responseBodyString = responseBody.string();
             LOGGER.debug("Create topic response code: {}", response.code());
-            return responseBody.string();
+            LOGGER.debug("Create topic response body: {}", responseBodyString);
+            return responseBodyString;
         }
     }
 
@@ -302,8 +304,10 @@ public class ConfluentPlatform {
                 .delete()
                 .build();
         try (Response response = client.newCall(request).execute(); ResponseBody responseBody = response.body()) {
+            String responseBodyString = responseBody.string();
             LOGGER.debug("Delete topic response code: {}", response.code());
-            return responseBody.string();
+            LOGGER.debug("Delete topic response body: {}", responseBodyString);
+            return responseBodyString;
         }
     }
 
@@ -337,7 +341,9 @@ public class ConfluentPlatform {
                 .post(body)
                 .build();
         try (Response response = client.newCall(request).execute(); ResponseBody responseBody = response.body()) {
+            String responseBodyString = responseBody.string();
             LOGGER.info("Create connectors response code: {}", response.code());
+            LOGGER.debug("Create connectors response body: {}", responseBodyString);
         }
     }
 
@@ -353,7 +359,9 @@ public class ConfluentPlatform {
                 .delete()
                 .build();
         try (Response response = client.newCall(request).execute(); ResponseBody responseBody = response.body()) {
+            String responseBodyString = responseBody.string();
             LOGGER.info("Delete connectors response code: {}", response.code());
+            LOGGER.debug("Delete connectors response body: {}", responseBodyString);
         }
     }
 
@@ -367,8 +375,10 @@ public class ConfluentPlatform {
                 .get()
                 .build();
         try (Response response = client.newCall(request).execute(); ResponseBody responseBody = response.body()) {
+            String responseBodyString = responseBody.string();
             LOGGER.debug("Get connectors response code: {}", response.code());
-            return responseBody.string();
+            LOGGER.debug("Get connectors response body: {}", responseBodyString);
+            return responseBodyString;
         } catch (IOException ioe) {
             return "";
         }

--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/helper/ConfluentPlatform.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/helper/ConfluentPlatform.java
@@ -473,9 +473,25 @@ public class ConfluentPlatform {
         return (int) offsetTotal;
     }
 
+    public boolean isConnectorRunning(String connectorName) throws IOException {
+        String connectRestEndpoint = getConnectRestEndPoint();
+        OkHttpClient client = new OkHttpClient();
+        String connectorsEndpoint = String.format("%s/connectors/%s/status", connectRestEndpoint, connectorName);
+        Request request = new Request.Builder()
+                .url(connectorsEndpoint)
+                .get()
+                .build();
+        try (Response response = client.newCall(request).execute(); ResponseBody responseBody = response.body()) {
+            if (response.code() != 200) {
+                throw new IOException(String.format("Request failed - endpoint: '%s', response: '%s'", connectorsEndpoint, response.code()));
+            }
+            JSONObject connector = (JSONObject) new JSONObject(responseBody.string()).get("connector");
+            return "RUNNING".equalsIgnoreCase((String) connector.get(CONNECTORS_ENDPOINT_RESPONSE_TASKS_STATE_KEY));
+        }
+    }
+
     public int produceAvroRecords(String topicName, String avroSchemaJson, JSONArray records) throws IOException {
-        String restProxyURL = getRestProxyEndpoint();
-        String produceEndpoint = String.format("%s/topics/%s", restProxyURL, topicName);
+        final String produceEndpoint = String.format("%s/topics/%s", getRestProxyEndpoint(), topicName);
 
         JSONArray wrappedRecords = new JSONArray();
         for (int i = 0; i < records.length(); i++) {
@@ -498,7 +514,7 @@ public class ConfluentPlatform {
                 .build();
 
         try (Response response = client.newCall(request).execute(); ResponseBody responseBody = response.body()) {
-            String responseBodyString = responseBody.string();
+            final String responseBodyString = responseBody.string();
             LOGGER.info("Produce Avro records response code: {} for topic: {}", response.code(), topicName);
 
             if (response.code() != 200) {
@@ -551,23 +567,5 @@ public class ConfluentPlatform {
         }
 
         return Optional.empty();
-    }
-
-
-    public boolean isConnectorRunning(String connectorName) throws IOException {
-        String connectRestEndpoint = getConnectRestEndPoint();
-        OkHttpClient client = new OkHttpClient();
-        String connectorsEndpoint = String.format("%s/connectors/%s/status", connectRestEndpoint, connectorName);
-        Request request = new Request.Builder()
-                .url(connectorsEndpoint)
-                .get()
-                .build();
-        try (Response response = client.newCall(request).execute(); ResponseBody responseBody = response.body()) {
-            if (response.code() != 200) {
-                throw new IOException(String.format("Request failed - endpoint: '%s', response: '%s'", connectorsEndpoint, response.code()));
-            }
-            JSONObject connector = (JSONObject) new JSONObject(responseBody.string()).get("connector");
-            return "RUNNING".equalsIgnoreCase((String) connector.get(CONNECTORS_ENDPOINT_RESPONSE_TASKS_STATE_KEY));
-        }
     }
 }

--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/helper/ConfluentPlatform.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/helper/ConfluentPlatform.java
@@ -23,7 +23,9 @@ import java.util.regex.Pattern;
 public class ConfluentPlatform {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfluentPlatform.class);
 
-    private static final String CONFLUENT_VERSION = "7.5.0"; // TODO: this is >2 years outdated and should be upgraded or removed outright
+    private static final String CONFLUENT_VERSION = "7.9.6";
+    private static final String DATAGEN_VERSION = "0.6.4-7.6.0";
+
     private static final DockerImageName KAFKA_REST_IMAGE = DockerImageName.parse(
             "confluentinc/cp-kafka-rest:" + CONFLUENT_VERSION
     );
@@ -39,9 +41,9 @@ public class ConfluentPlatform {
     private static final DockerImageName CP_SCHEMA_REGISTRY = DockerImageName.parse(
             "confluentinc/cp-schema-registry:" + CONFLUENT_VERSION
     );
-    // 0.4.0-6.0.1
+
     private static final DockerImageName CP_DATA_GEN = DockerImageName.parse(
-            "cnfldemos/cp-server-connect-datagen:0.6.2-7.5.0"
+            "cnfldemos/cp-server-connect-datagen:" + DATAGEN_VERSION
     );
 
     private static final DockerImageName CP_CONTROL_CENTER = DockerImageName.parse(

--- a/src/integrationTest/resources/clickhouse_sink_avro.json
+++ b/src/integrationTest/resources/clickhouse_sink_avro.json
@@ -1,0 +1,19 @@
+{
+  "name": "%s",
+  "config": {
+    "name": "%s",
+    "connector.class": "com.clickhouse.kafka.connect.ClickHouseSinkConnector",
+    "tasks.max": "%d",
+    "topics": "%s",
+    "hostname": "%s",
+    "port": "%s",
+    "database": "default",
+    "username": "%s",
+    "password": "%s",
+    "ssl": "false",
+    "exactlyOnce" : "false",
+    "value.converter": "io.confluent.connect.avro.AvroConverter",
+    "value.converter.schema.registry.url": "http://schema-registry:8081",
+    "client_version": "V2"
+  }
+}

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -301,6 +301,10 @@ public class ClickHouseWriter implements DBWriter {
                                     }
                                 }
 
+                                if ("VARIANT".equalsIgnoreCase(colTypeName) && Schema.Type.STRUCT.getName().equalsIgnoreCase(dataTypeName)) {
+                                    continue;
+                                }
+
                                 validSchema = false;
                                 LOGGER.error(String.format("Table column name [%s] type [%s] is not matching data column type [%s]", col.getName(), colTypeName, dataTypeName));
                             }
@@ -840,7 +844,7 @@ public class ClickHouseWriter implements DBWriter {
         } catch (Exception e) {
             // Note: this part will be removed once V1 is deprecated
             LOGGER.error("Error inserting records", e);
-            if (e.getMessage().indexOf("ClickHouseException: Code: 33") != -1 && retry == true) {
+            if (e.getMessage() != null && e.getMessage().contains("ClickHouseException: Code: 33") && retry) {
                 LOGGER.error("Error code 33: ClickHouse server error. Trying to update table mapping.");
                 Table tableTmp = urgentTableUpdate(table);
                 doInsertRawBinary(records, tableTmp, queryId, tableTmp.hasDefaults(), false);

--- a/src/testFixtures/avro/schemas/compatible/all_primitives.json
+++ b/src/testFixtures/avro/schemas/compatible/all_primitives.json
@@ -1,0 +1,40 @@
+{
+  "description": "Baseline: all non-null Avro primitive types",
+  "schema": {
+    "type": "record",
+    "name": "AllPrimitives",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "name", "type": "string"},
+      {"name": "amount", "type": "long"},
+      {"name": "rate", "type": "float"},
+      {"name": "score", "type": "double"},
+      {"name": "active", "type": "boolean"},
+      {"name": "serialized", "type": "bytes"}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "name": "String",
+    "amount": "Int64",
+    "rate": "Float32",
+    "score": "Float64",
+    "active": "Bool",
+    "serialized": "String"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "name": "Alice", "amount": 1000, "rate": 1.5, "score": 99.99, "active": true, "serialized": "\u0000"},
+    {"id": 2, "name": "Bob", "amount": 2000, "rate": 2.5, "score": 88.88, "active": false, "serialized": "\u0000"},
+    {"id": 3, "name": "Charlie", "amount": 3000, "rate": 3.5, "score": 77.77, "active": true, "serialized": "\u0000"},
+    {"id": 4, "name": "Diana", "amount": 4000, "rate": 4.5, "score": 66.66, "active": false, "serialized": "\u00FF"},
+    {"id": 5, "name": "Eve", "amount": 5000, "rate": 5.5, "score": 55.55, "active": true, "serialized": "\u00FF"},
+    {"id": 6, "name": "Frank", "amount": 6000, "rate": 6.5, "score": 44.44, "active": false, "serialized": "\u00FF"},
+    {"id": 7, "name": "Grace", "amount": 7000, "rate": 7.5, "score": 33.33, "active": true, "serialized": "\uFFFF"},
+    {"id": 8, "name": "Hank", "amount": 8000, "rate": 8.5, "score": 22.22, "active": false, "serialized": "\uFFFF"},
+    {"id": 9, "name": "Ivy", "amount": 9000, "rate": 9.5, "score": 11.11, "active": true, "serialized": "\uFFFF"},
+    {"id": 10, "name": "Jack", "amount": 10000, "rate": 10.5, "score": 0.01, "active": false, "serialized": "\uFFFF"}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/array_of_nullable_strings.json
+++ b/src/testFixtures/avro/schemas/compatible/array_of_nullable_strings.json
@@ -1,0 +1,30 @@
+{
+  "description": "Combination: array of nullable strings",
+  "schema": {
+    "type": "record",
+    "name": "ArrayNullableStrings",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "tags", "type": {"type": "array", "items": ["null", "string"]}}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "tags": "Array(Nullable(String))"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "tags": [{"string": "a"}, null, {"string": "b"}]},
+    {"id": 2, "tags": [null, null]},
+    {"id": 3, "tags": [{"string": "c"}]},
+    {"id": 4, "tags": []},
+    {"id": 5, "tags": [{"string": "d"}, {"string": "e"}, null]},
+    {"id": 6, "tags": [null]},
+    {"id": 7, "tags": [{"string": "f"}, {"string": "g"}]},
+    {"id": 8, "tags": []},
+    {"id": 9, "tags": [null, {"string": "h"}, null]},
+    {"id": 10, "tags": [{"string": "i"}]}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/date_logical.json
+++ b/src/testFixtures/avro/schemas/compatible/date_logical.json
@@ -1,0 +1,30 @@
+{
+  "description": "Timestamp: date logical type (days since epoch)",
+  "schema": {
+    "type": "record",
+    "name": "DateLogical",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "event_date", "type": {"type": "int", "logicalType": "date"}}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "event_date": "Date"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "event_date": 19000},
+    {"id": 2, "event_date": 19001},
+    {"id": 3, "event_date": 19002},
+    {"id": 4, "event_date": 19003},
+    {"id": 5, "event_date": 19004},
+    {"id": 6, "event_date": 19005},
+    {"id": 7, "event_date": 19006},
+    {"id": 8, "event_date": 19007},
+    {"id": 9, "event_date": 19008},
+    {"id": 10, "event_date": 19009}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/decimal_bytes.json
+++ b/src/testFixtures/avro/schemas/compatible/decimal_bytes.json
@@ -1,0 +1,30 @@
+{
+  "description": "Logical: decimal on bytes type (precision 10, scale 2)",
+  "schema": {
+    "type": "record",
+    "name": "DecimalBytes",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "amount", "type": {"type": "bytes", "logicalType": "decimal", "precision": 10, "scale": 2}}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "amount": "Decimal(10, 2)"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "amount": "d"},
+    {"id": 2, "amount": "y"},
+    {"id": 3, "amount": "\u0001,"},
+    {"id": 4, "amount": "\u0001\u0090"},
+    {"id": 5, "amount": "\u0001\u00f4"},
+    {"id": 6, "amount": "\u0002X"},
+    {"id": 7, "amount": "\u0002\u00bc"},
+    {"id": 8, "amount": "\u0003 "},
+    {"id": 9, "amount": "\u0003\u0084"},
+    {"id": 10, "amount": "\u0003\u00e8"}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/duration_logical.json
+++ b/src/testFixtures/avro/schemas/compatible/duration_logical.json
@@ -1,0 +1,23 @@
+{
+  "description": "Logical: duration logical type on fixed(12)",
+  "schema": {
+    "type": "record",
+    "name": "DurationLogical",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "duration", "type": {"type": "fixed", "name": "duration_fixed", "size": 12, "logicalType": "duration"}}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "duration": "String"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "duration": "123456789123"},
+    {"id": 2, "duration": "123456789123"},
+    {"id": 3, "duration": "123456789123"}
+  ],
+  "expected_row_count": 3
+}

--- a/src/testFixtures/avro/schemas/compatible/nested_array_of_records.json
+++ b/src/testFixtures/avro/schemas/compatible/nested_array_of_records.json
@@ -1,0 +1,40 @@
+{
+  "description": "Nested: array of records",
+  "schema": {
+    "type": "record",
+    "name": "ArrayOfRecords",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "items", "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "Item",
+          "fields": [
+            {"name": "name", "type": "string"},
+            {"name": "qty", "type": "int"}
+          ]
+        }
+      }}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "items": "Array(Tuple(name String, qty Int32))"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "items": [{"name": "a", "qty": 1}, {"name": "b", "qty": 2}]},
+    {"id": 2, "items": [{"name": "c", "qty": 3}]},
+    {"id": 3, "items": [{"name": "d", "qty": 4}, {"name": "e", "qty": 5}, {"name": "f", "qty": 6}]},
+    {"id": 4, "items": []},
+    {"id": 5, "items": [{"name": "g", "qty": 7}]},
+    {"id": 6, "items": [{"name": "h", "qty": 8}, {"name": "i", "qty": 9}]},
+    {"id": 7, "items": []},
+    {"id": 8, "items": [{"name": "j", "qty": 10}]},
+    {"id": 9, "items": [{"name": "k", "qty": 11}, {"name": "l", "qty": 12}]},
+    {"id": 10, "items": [{"name": "m", "qty": 13}]}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/nested_deep.json
+++ b/src/testFixtures/avro/schemas/compatible/nested_deep.json
@@ -1,0 +1,50 @@
+{
+  "description": "Nested: 3 levels deep (record in record in record)",
+  "schema": {
+    "type": "record",
+    "name": "NestedDeep",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "level1", "type": {
+        "type": "record",
+        "name": "Level1",
+        "fields": [
+          {"name": "name", "type": "string"},
+          {"name": "level2", "type": {
+            "type": "record",
+            "name": "Level2",
+            "fields": [
+              {"name": "value", "type": "int"},
+              {"name": "level3", "type": {
+                "type": "record",
+                "name": "Level3",
+                "fields": [
+                  {"name": "tag", "type": "string"}
+                ]
+              }}
+            ]
+          }}
+        ]
+      }}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "level1": "Tuple(name String, level2 Tuple(value Int32, level3 Tuple(tag String)))"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "level1": {"name": "a", "level2": {"value": 1, "level3": {"tag": "x"}}}},
+    {"id": 2, "level1": {"name": "b", "level2": {"value": 2, "level3": {"tag": "y"}}}},
+    {"id": 3, "level1": {"name": "c", "level2": {"value": 3, "level3": {"tag": "z"}}}},
+    {"id": 4, "level1": {"name": "d", "level2": {"value": 4, "level3": {"tag": "w"}}}},
+    {"id": 5, "level1": {"name": "e", "level2": {"value": 5, "level3": {"tag": "v"}}}},
+    {"id": 6, "level1": {"name": "f", "level2": {"value": 6, "level3": {"tag": "u"}}}},
+    {"id": 7, "level1": {"name": "g", "level2": {"value": 7, "level3": {"tag": "t"}}}},
+    {"id": 8, "level1": {"name": "h", "level2": {"value": 8, "level3": {"tag": "s"}}}},
+    {"id": 9, "level1": {"name": "i", "level2": {"value": 9, "level3": {"tag": "r"}}}},
+    {"id": 10, "level1": {"name": "j", "level2": {"value": 10, "level3": {"tag": "q"}}}}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/nested_map_string_record.json
+++ b/src/testFixtures/avro/schemas/compatible/nested_map_string_record.json
@@ -1,0 +1,40 @@
+{
+  "description": "Nested: map with string keys and record values",
+  "schema": {
+    "type": "record",
+    "name": "MapStringRecord",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "metadata", "type": {
+        "type": "map",
+        "values": {
+          "type": "record",
+          "name": "MetaValue",
+          "fields": [
+            {"name": "score", "type": "int"},
+            {"name": "label", "type": "string"}
+          ]
+        }
+      }}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "metadata": "Map(String, Tuple(score Int32, label String))"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "metadata": {"key1": {"score": 10, "label": "a"}}},
+    {"id": 2, "metadata": {"key2": {"score": 20, "label": "b"}, "key3": {"score": 30, "label": "c"}}},
+    {"id": 3, "metadata": {}},
+    {"id": 4, "metadata": {"key4": {"score": 40, "label": "d"}}},
+    {"id": 5, "metadata": {"key5": {"score": 50, "label": "e"}, "key6": {"score": 60, "label": "f"}}},
+    {"id": 6, "metadata": {}},
+    {"id": 7, "metadata": {"key7": {"score": 70, "label": "g"}}},
+    {"id": 8, "metadata": {"key8": {"score": 80, "label": "h"}}},
+    {"id": 9, "metadata": {}},
+    {"id": 10, "metadata": {"key9": {"score": 90, "label": "i"}, "key10": {"score": 100, "label": "j"}}}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/nested_record_with_nullable_fields.json
+++ b/src/testFixtures/avro/schemas/compatible/nested_record_with_nullable_fields.json
@@ -1,0 +1,37 @@
+{
+  "description": "Nested: record with nullable inner fields",
+  "schema": {
+    "type": "record",
+    "name": "RecordNullableFields",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "details", "type": {
+        "type": "record",
+        "name": "Details",
+        "fields": [
+          {"name": "name", "type": ["null", "string"], "default": null},
+          {"name": "age", "type": ["null", "int"], "default": null}
+        ]
+      }}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "details": "Tuple(name Nullable(String), age Nullable(Int32))"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "details": {"name": {"string": "Alice"}, "age": {"int": 30}}},
+    {"id": 2, "details": {"name": null, "age": {"int": 25}}},
+    {"id": 3, "details": {"name": {"string": "Charlie"}, "age": null}},
+    {"id": 4, "details": {"name": null, "age": null}},
+    {"id": 5, "details": {"name": {"string": "Eve"}, "age": {"int": 40}}},
+    {"id": 6, "details": {"name": null, "age": {"int": 35}}},
+    {"id": 7, "details": {"name": {"string": "Grace"}, "age": null}},
+    {"id": 8, "details": {"name": null, "age": null}},
+    {"id": 9, "details": {"name": {"string": "Ivy"}, "age": {"int": 50}}},
+    {"id": 10, "details": {"name": {"string": "Jack"}, "age": {"int": 55}}}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/nested_simple.json
+++ b/src/testFixtures/avro/schemas/compatible/nested_simple.json
@@ -1,0 +1,37 @@
+{
+  "description": "Nested: single-level nested record",
+  "schema": {
+    "type": "record",
+    "name": "NestedSimple",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "info", "type": {
+        "type": "record",
+        "name": "Info",
+        "fields": [
+          {"name": "label", "type": "string"},
+          {"name": "count", "type": "int"}
+        ]
+      }}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "info": "Tuple(label String, count Int32)"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "info": {"label": "a", "count": 10}},
+    {"id": 2, "info": {"label": "b", "count": 20}},
+    {"id": 3, "info": {"label": "c", "count": 30}},
+    {"id": 4, "info": {"label": "d", "count": 40}},
+    {"id": 5, "info": {"label": "e", "count": 50}},
+    {"id": 6, "info": {"label": "f", "count": 60}},
+    {"id": 7, "info": {"label": "g", "count": 70}},
+    {"id": 8, "info": {"label": "h", "count": 80}},
+    {"id": 9, "info": {"label": "i", "count": 90}},
+    {"id": 10, "info": {"label": "j", "count": 100}}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/nullable_timestamp_in_nested.json
+++ b/src/testFixtures/avro/schemas/compatible/nullable_timestamp_in_nested.json
@@ -1,0 +1,37 @@
+{
+  "description": "Combination: nullable timestamp-millis inside a nested record",
+  "schema": {
+    "type": "record",
+    "name": "NullableTimestampNested",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "event", "type": {
+        "type": "record",
+        "name": "EventInfo",
+        "fields": [
+          {"name": "name", "type": "string"},
+          {"name": "occurred_at", "type": ["null", {"type": "long", "logicalType": "timestamp-millis"}], "default": null}
+        ]
+      }}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "event": "Tuple(name String, occurred_at Nullable(DateTime64(3)))"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "event": {"name": "login", "occurred_at": {"long": 1700000000000}}},
+    {"id": 2, "event": {"name": "logout", "occurred_at": null}},
+    {"id": 3, "event": {"name": "click", "occurred_at": {"long": 1700000002000}}},
+    {"id": 4, "event": {"name": "view", "occurred_at": null}},
+    {"id": 5, "event": {"name": "submit", "occurred_at": {"long": 1700000004000}}},
+    {"id": 6, "event": {"name": "cancel", "occurred_at": {"long": 1700000005000}}},
+    {"id": 7, "event": {"name": "refresh", "occurred_at": null}},
+    {"id": 8, "event": {"name": "search", "occurred_at": {"long": 1700000007000}}},
+    {"id": 9, "event": {"name": "download", "occurred_at": {"long": 1700000008000}}},
+    {"id": 10, "event": {"name": "upload", "occurred_at": null}}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/time_micros.json
+++ b/src/testFixtures/avro/schemas/compatible/time_micros.json
@@ -1,0 +1,30 @@
+{
+  "description": "Timestamp: time-micros logical type",
+  "schema": {
+    "type": "record",
+    "name": "TimeMicros",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "event_time", "type": {"type": "long", "logicalType": "time-micros"}}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "event_time": "Int64"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "event_time": 0},
+    {"id": 2, "event_time": 3600000000},
+    {"id": 3, "event_time": 7200000000},
+    {"id": 4, "event_time": 10800000000},
+    {"id": 5, "event_time": 14400000000},
+    {"id": 6, "event_time": 18000000000},
+    {"id": 7, "event_time": 21600000000},
+    {"id": 8, "event_time": 25200000000},
+    {"id": 9, "event_time": 28800000000},
+    {"id": 10, "event_time": 32400000000}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/time_millis.json
+++ b/src/testFixtures/avro/schemas/compatible/time_millis.json
@@ -1,0 +1,30 @@
+{
+  "description": "Timestamp: time-millis logical type",
+  "schema": {
+    "type": "record",
+    "name": "TimeMillis",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "event_time", "type": {"type": "int", "logicalType": "time-millis"}}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "event_time": "Int32"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "event_time": 0},
+    {"id": 2, "event_time": 3600000},
+    {"id": 3, "event_time": 7200000},
+    {"id": 4, "event_time": 10800000},
+    {"id": 5, "event_time": 14400000},
+    {"id": 6, "event_time": 18000000},
+    {"id": 7, "event_time": 21600000},
+    {"id": 8, "event_time": 25200000},
+    {"id": 9, "event_time": 28800000},
+    {"id": 10, "event_time": 32400000}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/timestamp_micros.json
+++ b/src/testFixtures/avro/schemas/compatible/timestamp_micros.json
@@ -1,0 +1,30 @@
+{
+  "description": "Timestamp: timestamp-micros logical type",
+  "schema": {
+    "type": "record",
+    "name": "TimestampMicros",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "created_at", "type": {"type": "long", "logicalType": "timestamp-micros"}}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "created_at": "DateTime64(6)"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "created_at": 1700000000000000},
+    {"id": 2, "created_at": 1700000001000000},
+    {"id": 3, "created_at": 1700000002000000},
+    {"id": 4, "created_at": 1700000003000000},
+    {"id": 5, "created_at": 1700000004000000},
+    {"id": 6, "created_at": 1700000005000000},
+    {"id": 7, "created_at": 1700000006000000},
+    {"id": 8, "created_at": 1700000007000000},
+    {"id": 9, "created_at": 1700000008000000},
+    {"id": 10, "created_at": 1700000009000000}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/timestamp_millis.json
+++ b/src/testFixtures/avro/schemas/compatible/timestamp_millis.json
@@ -1,0 +1,30 @@
+{
+  "description": "Timestamp: timestamp-millis logical type",
+  "schema": {
+    "type": "record",
+    "name": "TimestampMillis",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "created_at", "type": {"type": "long", "logicalType": "timestamp-millis"}}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "created_at": "DateTime64(3)"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "created_at": 1700000000000},
+    {"id": 2, "created_at": 1700000001000},
+    {"id": 3, "created_at": 1700000002000},
+    {"id": 4, "created_at": 1700000003000},
+    {"id": 5, "created_at": 1700000004000},
+    {"id": 6, "created_at": 1700000005000},
+    {"id": 7, "created_at": 1700000006000},
+    {"id": 8, "created_at": 1700000007000},
+    {"id": 9, "created_at": 1700000008000},
+    {"id": 10, "created_at": 1700000009000}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/timestamp_millis_nullable.json
+++ b/src/testFixtures/avro/schemas/compatible/timestamp_millis_nullable.json
@@ -1,0 +1,30 @@
+{
+  "description": "Timestamp: nullable timestamp-millis [null, timestamp-millis]",
+  "schema": {
+    "type": "record",
+    "name": "NullableTimestampMillis",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "created_at", "type": ["null", {"type": "long", "logicalType": "timestamp-millis"}], "default": null}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "created_at": "Nullable(DateTime64(3))"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "created_at": {"long": 1700000000000}},
+    {"id": 2, "created_at": null},
+    {"id": 3, "created_at": {"long": 1700000002000}},
+    {"id": 4, "created_at": null},
+    {"id": 5, "created_at": {"long": 1700000004000}},
+    {"id": 6, "created_at": {"long": 1700000005000}},
+    {"id": 7, "created_at": null},
+    {"id": 8, "created_at": {"long": 1700000007000}},
+    {"id": 9, "created_at": {"long": 1700000008000}},
+    {"id": 10, "created_at": null}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/union_null_int.json
+++ b/src/testFixtures/avro/schemas/compatible/union_null_int.json
@@ -1,0 +1,30 @@
+{
+  "description": "Union: nullable int [null, int]",
+  "schema": {
+    "type": "record",
+    "name": "NullableInt",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "value", "type": ["null", "int"], "default": null}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "value": "Nullable(Int32)"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "value": {"int": 100}},
+    {"id": 2, "value": null},
+    {"id": 3, "value": {"int": 300}},
+    {"id": 4, "value": null},
+    {"id": 5, "value": {"int": 500}},
+    {"id": 6, "value": {"int": 600}},
+    {"id": 7, "value": null},
+    {"id": 8, "value": {"int": 800}},
+    {"id": 9, "value": {"int": 900}},
+    {"id": 10, "value": null}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/union_null_long.json
+++ b/src/testFixtures/avro/schemas/compatible/union_null_long.json
@@ -1,0 +1,30 @@
+{
+  "description": "Union: nullable long [null, long]",
+  "schema": {
+    "type": "record",
+    "name": "NullableLong",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "big_value", "type": ["null", "long"], "default": null}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "big_value": "Nullable(Int64)"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "big_value": {"long": 1000000000}},
+    {"id": 2, "big_value": null},
+    {"id": 3, "big_value": {"long": 3000000000}},
+    {"id": 4, "big_value": null},
+    {"id": 5, "big_value": {"long": 5000000000}},
+    {"id": 6, "big_value": {"long": 6000000000}},
+    {"id": 7, "big_value": null},
+    {"id": 8, "big_value": {"long": 8000000000}},
+    {"id": 9, "big_value": {"long": 9000000000}},
+    {"id": 10, "big_value": null}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/union_null_string.json
+++ b/src/testFixtures/avro/schemas/compatible/union_null_string.json
@@ -1,0 +1,30 @@
+{
+  "description": "Union: nullable string [null, string]",
+  "schema": {
+    "type": "record",
+    "name": "NullableString",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "name", "type": ["null", "string"], "default": null}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "name": "Nullable(String)"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "name": {"string": "Alice"}},
+    {"id": 2, "name": null},
+    {"id": 3, "name": {"string": "Charlie"}},
+    {"id": 4, "name": null},
+    {"id": 5, "name": {"string": "Eve"}},
+    {"id": 6, "name": {"string": "Frank"}},
+    {"id": 7, "name": null},
+    {"id": 8, "name": {"string": "Harriet"}},
+    {"id": 9, "name": {"string": "Ivan"}},
+    {"id": 10, "name": null}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/union_null_string_bytes.json
+++ b/src/testFixtures/avro/schemas/compatible/union_null_string_bytes.json
@@ -1,0 +1,30 @@
+{
+  "description": "Union: nullable string+bytes [null, string, bytes]",
+  "schema": {
+    "type": "record",
+    "name": "NullableStringBytes",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "content", "type": ["null", "string", "bytes"], "default": null}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "content": "Nullable(String)"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "content": {"string": "hello"}},
+    {"id": 2, "content": null},
+    {"id": 3, "content": {"string": "world"}},
+    {"id": 4, "content": null},
+    {"id": 5, "content": {"string": "test"}},
+    {"id": 6, "content": {"bytes": "\u0001"}},
+    {"id": 7, "content": null},
+    {"id": 8, "content": {"string": "more"}},
+    {"id": 9, "content": {"bytes": "\u0002"}},
+    {"id": 10, "content": null}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/union_string_int.json
+++ b/src/testFixtures/avro/schemas/compatible/union_string_int.json
@@ -1,0 +1,30 @@
+{
+  "description": "Union: non-nullable mixed types [string, int]",
+  "schema": {
+    "type": "record",
+    "name": "StringIntUnion",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "mixed", "type": ["string", "int"]}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "mixed": "Variant(\"String\", \"Int32\")"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "mixed": {"string": "hello"}},
+    {"id": 2, "mixed": {"int": 42}},
+    {"id": 3, "mixed": {"string": "world"}},
+    {"id": 4, "mixed": {"int": 99}},
+    {"id": 5, "mixed": {"string": "foo"}},
+    {"id": 6, "mixed": {"int": 7}},
+    {"id": 7, "mixed": {"string": "bar"}},
+    {"id": 8, "mixed": {"int": 123}},
+    {"id": 9, "mixed": {"string": "baz"}},
+    {"id": 10, "mixed": {"int": 0}}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/compatible/uuid_logical.json
+++ b/src/testFixtures/avro/schemas/compatible/uuid_logical.json
@@ -1,0 +1,30 @@
+{
+  "description": "Logical: uuid logical type on string",
+  "schema": {
+    "type": "record",
+    "name": "UuidLogical",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "uuid_field", "type": {"type": "string", "logicalType": "uuid"}}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "uuid_field": "UUID"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "uuid_field": "550e8400-e29b-41d4-a716-446655440001"},
+    {"id": 2, "uuid_field": "550e8400-e29b-41d4-a716-446655440002"},
+    {"id": 3, "uuid_field": "550e8400-e29b-41d4-a716-446655440003"},
+    {"id": 4, "uuid_field": "550e8400-e29b-41d4-a716-446655440004"},
+    {"id": 5, "uuid_field": "550e8400-e29b-41d4-a716-446655440005"},
+    {"id": 6, "uuid_field": "550e8400-e29b-41d4-a716-446655440006"},
+    {"id": 7, "uuid_field": "550e8400-e29b-41d4-a716-446655440007"},
+    {"id": 8, "uuid_field": "550e8400-e29b-41d4-a716-446655440008"},
+    {"id": 9, "uuid_field": "550e8400-e29b-41d4-a716-446655440009"},
+    {"id": 10, "uuid_field": "550e8400-e29b-41d4-a716-446655440010"}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/incompatible/decimal_fixed_logical.json
+++ b/src/testFixtures/avro/schemas/incompatible/decimal_fixed_logical.json
@@ -1,0 +1,30 @@
+{
+  "description": "Logical: decimal on fixed type (precision 18, scale 4)",
+  "schema": {
+    "type": "record",
+    "name": "DecimalFixed",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "amount", "type": {"type": "fixed", "name": "decimal_18_4", "size": 8, "logicalType": "decimal", "precision": 18, "scale": 4}}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "amount": "Decimal(18, 4)"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "amount": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000d"},
+    {"id": 2, "amount": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000y"},
+    {"id": 3, "amount": "\u0000\u0000\u0000\u0000\u0000\u0000\u0001,"},
+    {"id": 4, "amount": "\u0000\u0000\u0000\u0000\u0000\u0000\u0001\u0090"},
+    {"id": 5, "amount": "\u0000\u0000\u0000\u0000\u0000\u0000\u0001\u00f4"},
+    {"id": 6, "amount": "\u0000\u0000\u0000\u0000\u0000\u0000\u0002X"},
+    {"id": 7, "amount": "\u0000\u0000\u0000\u0000\u0000\u0000\u0002\u00bc"},
+    {"id": 8, "amount": "\u0000\u0000\u0000\u0000\u0000\u0000\u0003 "},
+    {"id": 9, "amount": "\u0000\u0000\u0000\u0000\u0000\u0000\u0003\u0084"},
+    {"id": 10, "amount": "\u0000\u0000\u0000\u0000\u0000\u0000\u0003\u00e8"}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/incompatible/union_null_string_int.json
+++ b/src/testFixtures/avro/schemas/incompatible/union_null_string_int.json
@@ -1,0 +1,30 @@
+{
+  "description": "Union: 3-way nullable union [null, string, int]",
+  "schema": {
+    "type": "record",
+    "name": "NullableStringInt",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "mixed", "type": ["null", "string", "int"], "default": null}
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "mixed": "Variant(\"String\", \"Int32\")"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "mixed": {"string": "hello"}},
+    {"id": 2, "mixed": null},
+    {"id": 3, "mixed": {"int": 42}},
+    {"id": 4, "mixed": null},
+    {"id": 5, "mixed": {"string": "world"}},
+    {"id": 6, "mixed": {"int": 99}},
+    {"id": 7, "mixed": null},
+    {"id": 8, "mixed": {"string": "test"}},
+    {"id": 9, "mixed": {"int": 7}},
+    {"id": 10, "mixed": null}
+  ],
+  "expected_row_count": 10
+}

--- a/src/testFixtures/avro/schemas/incompatible/union_two_records.json
+++ b/src/testFixtures/avro/schemas/incompatible/union_two_records.json
@@ -1,0 +1,39 @@
+{
+  "description": "Union: union of two different record types [recordA, recordB]",
+  "schema": {
+    "type": "record",
+    "name": "TwoRecords",
+    "namespace": "com.clickhouse.kafka.connect.avro.test",
+    "fields": [
+      {"name": "id", "type": "int"},
+      {"name": "payload", "type": [{
+        "type": "record",
+        "name": "TypeA",
+        "fields": [
+          {"name": "label", "type": "string"}
+        ]
+      }, {
+        "type": "record",
+        "name": "TypeB",
+        "fields": [
+          {"name": "count", "type": "int"}
+        ]
+      }]
+      }
+    ]
+  },
+  "clickhouse_columns": {
+    "id": "Int32",
+    "payload": "Variant(Tuple(label String), Tuple(count Int32))"
+  },
+  "clickhouse_order_by": "id",
+  "records": [
+    {"id": 1, "payload": {"com.clickhouse.kafka.connect.avro.test.TypeA": {"label": "foo"}}},
+    {"id": 3, "payload": {"com.clickhouse.kafka.connect.avro.test.TypeB": {"count": 42}}},
+    {"id": 5, "payload": {"com.clickhouse.kafka.connect.avro.test.TypeA": {"label": "bar"}}},
+    {"id": 6, "payload": {"com.clickhouse.kafka.connect.avro.test.TypeB": {"count": 99}}},
+    {"id": 8, "payload": {"com.clickhouse.kafka.connect.avro.test.TypeA": {"label": "baz"}}},
+    {"id": 9, "payload": {"com.clickhouse.kafka.connect.avro.test.TypeB": {"count": 7}}}
+  ],
+  "expected_row_count": 6
+}


### PR DESCRIPTION
## Summary
In this PR:
- define an integration test harness to produce avro records to a kafka topic and sink them into ClickHouse
- add compatible and incompatible avro schemas. The incompatible schemas will be documented and investigated further.
    **- note: _this is meant to be an evolving set of schemas. As we extend the connector to support previously incompatible schemas, we should move them to `compatible` to ensure they are covered in the integration test runs._**

Closes: https://github.com/ClickHouse/clickhouse-kafka-connect/issues/635

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added