### PR TITLE
Update clickhouse-java to 0.9.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,6 +79,19 @@ extra.apply {
 
 val clickhouseDependencies: Configuration by configurations.creating
 
+// Resolve lz4-java capability conflict between at.yawk.lz4:lz4-java (from clickhouse-java 0.9.8)
+// and org.lz4:lz4-java (from kafka-clients)
+configurations.all {
+    resolutionStrategy.capabilitiesResolution.withCapability("org.lz4:lz4-java") {
+        val toBeSelected = candidates.firstOrNull { it.id.let { id ->
+            id is ModuleComponentIdentifier && id.group == "at.yawk.lz4"
+        }}
+        if (toBeSelected != null) {
+            select(toBeSelected)
+        }
+        because("at.yawk.lz4:lz4-java is the newer, relocated artifact used by clickhouse-java")
+    }
+}
 
 dependencies {
     implementation("org.apache.kafka:connect-api:${project.extra["kafkaVersion"]}")


### PR DESCRIPTION
## Summary
The Java driver should be upgraded on a regular basis, moving from `0.9.4` -> `0.9.8`

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
