### PR TITLE
Upgrade clickhouse-java to 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Dependencies
+* Updated clickhouse-java version from `0.9.4` to `0.9.5`
+
 # 1.3.7, 2026-03-25 
 
 ## Security

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ repositories {
 }
 
 extra.apply {
-    set("clickHouseDriverVersion", "0.9.4")
+    set("clickHouseDriverVersion", "0.9.5")
     set("kafkaVersion", "2.7.0")
     set("gson", "2.13.1")
     set("jackson", "2.21.2")


### PR DESCRIPTION
## Summary
* Upgrades `com.clickhouse` Java client from `0.9.4` to `0.9.5`
* All unit tests passing (218 tests, 215 succeeded, 3 skipped)

## Changes
- Updated `clickHouseDriverVersion` in `build.gradle.kts` from `0.9.4` to `0.9.5`
- Updated CHANGELOG.md

## Notes
Versions `0.9.6`, `0.9.7`, and `0.9.8` were tested but fail due to a dependency conflict: `client-v2` in those versions pulls `at.yawk.lz4:lz4-java` which conflicts with Kafka's `org.lz4:lz4-java:1.7.1` on the `org.lz4:lz4-java` capability. `0.9.5` is the newest compatible version.

## Test plan
- [x] Unit tests pass with `./gradlew clean test`
- [ ] Integration tests (manual verification recommended)
- [ ] Verify connector functionality end-to-end

Generated with [Claude Code](https://claude.com/claude-code)