### PR TITLE
Add claude-reviewer GH action

### DIFF
--- a/.github/workflows/claude-reviewer.yml
+++ b/.github/workflows/claude-reviewer.yml
@@ -1,0 +1,86 @@
+name: claude-review-assistant.yml
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    env:
+      GH_TOKEN: ${{ github.token }}
+      # PR number lives in different places depending on the event type
+      PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+      COMMENTER: ${{ github.event.comment.user.login }}
+      REPO: ${{ github.repository }}
+      # Reactions API endpoint differs: issue comments vs PR review comments
+      COMMENT_REACTIONS_URL: ${{ github.event_name == 'pull_request_review_comment' && format('repos/{0}/pulls/comments/{1}/reactions', github.repository, github.event.comment.id) || format('repos/{0}/issues/comments/{1}/reactions', github.repository, github.event.comment.id) }}
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+
+    steps:
+      - name: Check commenter permissions
+        run: |
+          PERMISSION=$(gh api "repos/${REPO}/collaborators/${COMMENTER}/permission" --jq '.permission')
+          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" ]]; then
+            gh pr comment "$PR_NUMBER" --repo "$REPO" \
+              --body "Sorry @${COMMENTER}, only repo collaborators with write access can trigger claude reviews."
+            echo "::error::User ${COMMENTER} has '${PERMISSION}' permission, needs 'write' or 'admin'"
+            exit 1
+          fi
+          echo "User ${COMMENTER} has '${PERMISSION}' permission — authorized"
+      - name: Add eyes reaction
+        run: |
+          gh api "${COMMENT_REACTIONS_URL}" -f content='eyes' --silent
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: anthropics/claude-code-action@v1
+        with:
+          #          ref:
+          #          - https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md#automatic-pr-code-review
+          #          - https://github.com/anthropics/claude-code-action/blob/6cad158a175744eb2e76f7f5fd108ec63145598c/.claude/commands/review-pr.md?plain=1#L4
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR_NUMBER: ${{ github.event.pull_request.number }}
+            
+            OBJECTIVE:
+            Read the comment you were tagged in and respond to the user. Gather relevant context for your answers from:
+            - CLAUDE.md/AGENTS.md
+            - REVIEW.md
+            - The commit history of the branch
+            - Any existing issue/PR discussions
+            
+            If you are asked to review this pull request, run the following command: `/review-pr`
+
+            RULES:
+            - Use `gh pr comment` for top-level feedback.
+            - Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) to highlight specific code issues.
+            - Only post GitHub comments - don't submit review text as messages.
+            
+            Note: The PR branch is already checked out in the current working directory.
+
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --max-turns 10
+            --model claude-opus-4-6
+            --system-prompt "You are an agent assisting users in reviewing PR's in this repository. Follow the coding patterns and standards of the project. Ensure all new code you propose has tests. Do NOT change the PR title, description, or automatically push commits to this branch without explicitly asking the commenter beforehand."
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary
- This workflow gives claude clear permissions, objectives, and rules for the agent in how it should respond to users in a PR. This way, we have tight control over the prompt and the expected outputs. 💪
- It also includes a system prompt to increase the likelihood of certain actions by default (for ex, Do NOT change the PR title, description, or automatically push commits to this branch without explicitly asking the commenter beforehand).
- It prevents abuse by checking the commenter's permissions and asserts that only writers/admins may invoke claude reviews.
- It invokes the /review-pr command, which launches specialized, parallel subagents to handle different aspects of the code review. See: https://github.com/anthropics/claude-code-action/blob/6cad158a175744eb2e76f7f5fd108ec63145598c/.claude/commands/review-pr.md?plain=1#L3

## Example usage in a PR comment
- "@claude" -> should review the PR
- "@claude review this PR"
- "@claude where is the best place to move this helper function to prevent code duplication?"
