### PR TITLE
Improve cloud consistency

### DIFF
--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseBase.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseBase.java
@@ -280,4 +280,8 @@ public class ClickHouseBase {
     protected String createTopicName(String name) {
         return String.format("%s_%d", name, System.currentTimeMillis());
     }
+
+    protected String createTestUsername(String baseName) {
+        return String.format("%s_%d", baseName, System.currentTimeMillis());
+    }
 }

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClientTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClientTest.java
@@ -92,11 +92,13 @@ public class ClickHouseHelperClientTest extends ClickHouseBase {
     public void describeNestedUnFlattenedTable() {
         String nestedTopic = createTopicName("nested_unflattened_table_test");
         String normalTopic = createTopicName("normal_unflattened_table_test");
-        ClickHouseTestHelpers.query(chc, "CREATE USER IF NOT EXISTS unflatten IDENTIFIED BY '123FOURfive^&*91011' SETTINGS flatten_nested=0");
-        ClickHouseTestHelpers.query(chc, "GRANT CURRENT GRANTS ON *.* TO unflatten");
+        String testUsername = createTestUsername("unflatten");
+        ClickHouseHelperClient adminChc = chc;
+        ClickHouseTestHelpers.query(adminChc, String.format("CREATE USER IF NOT EXISTS `%s` IDENTIFIED BY '123FOURfive^&*91011' SETTINGS flatten_nested=0", testUsername));
+        ClickHouseTestHelpers.query(adminChc, String.format("GRANT CURRENT GRANTS ON *.* TO `%s`", testUsername));
 
         Map<String, String> props = createProps();
-        props.put("username", "unflatten");
+        props.put("username", testUsername);
         props.put("password", "123FOURfive^&*91011");
         chc = createClient(props);
 
@@ -114,9 +116,9 @@ public class ClickHouseHelperClientTest extends ClickHouseBase {
             Table normalTable = chc.describeTable(chc.getDatabase(), normalTopic);
             Assertions.assertEquals(1, normalTable.getRootColumnsList().size());
         } finally {
-            ClickHouseTestHelpers.dropTable(chc, nestedTopic);
-            ClickHouseTestHelpers.dropTable(chc, normalTopic);
-            ClickHouseTestHelpers.query(chc, "DROP USER IF EXISTS unflatten");
+            ClickHouseTestHelpers.dropTable(adminChc, nestedTopic);
+            ClickHouseTestHelpers.dropTable(adminChc, normalTopic);
+            ClickHouseTestHelpers.query(adminChc, String.format("DROP USER IF EXISTS `%s`", testUsername));
         }
     }
 

--- a/src/testFixtures/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseTestHelpers.java
+++ b/src/testFixtures/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseTestHelpers.java
@@ -110,6 +110,7 @@ public class ClickHouseTestHelpers {
         String query = String.format("SELECT * FROM `%s`", tableName);
         QuerySettings querySettings = new QuerySettings();
         querySettings.setFormat(ClickHouseFormat.JSONEachRow);
+        querySettings.serverSetting("select_sequential_consistency", "1");
         try {
             QueryResponse queryResponse = chc.getClient().query(query, querySettings).get();
             List<JSONObject> jsonObjects = new ArrayList<>();


### PR DESCRIPTION
# Summary
In this PR, two small changes stabilized our cloud tests:


## Added select_sequential_consistency = 1
We used to get this error from time to time:

```
ClickHouseSinkTaskWithSchemaTest > testAvroDateAndTimeTypes() FAILED
    org.opentest4j.AssertionFailedError: expected: <3> but was: <0>
        at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at app//org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
        at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:150)
        at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:145)
        at app//org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:528)
        at app//com.clickhouse.kafka.connect.sink.ClickHouseSinkTaskWithSchemaTest.testAvroDateAndTimeTypes(ClickHouseSinkTaskWithSchemaTest.java:1794)

```

Where a simple retry solved the problem. That is a classic ClickHouse read consistency problem; more about it can be found in this [doc page](https://clickhouse.com/docs/knowledgebase/read_consistency#answer). The error can be found in [this GitHub Job](https://github.com/ClickHouse/clickhouse-kafka-connect/actions/runs/24309657609/job/70977849394)

## V1 & V2 cloud tests colision

```
ClickHouseHelperClientTest > describeNestedUnFlattenedTable() FAILED
    java.lang.RuntimeException: com.clickhouse.client.ClickHouseException: Code: 516. DB::Exception: unflatten: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED)
        at com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient.queryV1(ClickHouseHelperClient.java:292)
        at com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient.queryV1(ClickHouseHelperClient.java:259)
        at com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers.query(ClickHouseTestHelpers.java:74)
        at com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClientTest.describeNestedUnFlattenedTable(ClickHouseHelperClientTest.java:119)

        Caused by:
        com.clickhouse.client.ClickHouseException: Code: 516. DB::Exception: unflatten: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED)
            at app//com.clickhouse.client.ClickHouseException.of(ClickHouseException.java:152)
            at app//com.clickhouse.client.AbstractClient.lambda$execute$0(AbstractClient.java:282)
            at java.base@17.0.18/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
            at java.base@17.0.18/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
            at java.base@17.0.18/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
            at java.base@17.0.18/java.lang.Thread.run(Thread.java:840)

            Caused by:
            java.io.IOException: Code: 516. DB::Exception: unflatten: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED)
                at com.clickhouse.client.http.ApacheHttpConnectionImpl.checkResponse(ApacheHttpConnectionImpl.java:262)
                at com.clickhouse.client.http.ApacheHttpConnectionImpl.post(ApacheHttpConnectionImpl.java:325)
                at com.clickhouse.client.http.ClickHouseHttpClient.send(ClickHouseHttpClient.java:196)
                at com.clickhouse.client.AbstractClient.sendAsync(AbstractClient.java:165)
                at com.clickhouse.client.AbstractClient.lambda$execute$0(AbstractClient.java:280)
                ... 4 more

```
The V1 and V2 cloud test jobs run concurrently against the same ClickHouse Cloud instance. Both tests created a shared 'unflatten' user, whichever job finished first would drop it, while the other was still using it, causing intermittent `AUTHENTICATION_FAILED (516)` errors.

Fixed by generating a unique username per test run (timestamp suffix) and using the admin client for cleanup instead of the unflatten user's own client.

[GitHub Job Failure](https://github.com/ClickHouse/clickhouse-kafka-connect/actions/runs/24313224720/job/70986368760)


The fixes were validated by running the cloud tests 8 times in a row with no errors.

Closes #711 


