### PR TITLE
Parameterize tests to run against local clickhouse clusters

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -55,3 +55,26 @@ jobs:
         with:
           arguments: integrationTest
             --tests "com.clickhouse.kafka.connect.sink.ClickHouseSinkConnectorIntegrationTest"
+  build-and-run-cluster:
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        clickhouse: [ "25.3", "25.8", "25.10", "25.11", "25.12", "latest", "head" ]
+    name: Kafka Connect integration tests against cluster ClickHouse ${{ matrix.clickhouse }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Setup and execute Gradle 'integrationTest' task
+        uses: gradle/gradle-build-action@v2
+        env:
+          CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
+          CLICKHOUSE_CLUSTER_MODE: true
+        with:
+          arguments: integrationTest
+            --tests "com.clickhouse.kafka.connect.sink.ClickHouseSinkConnectorIntegrationTest"
+            --tests "com.clickhouse.kafka.connect.sink.ExactlyOnceTest"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -92,3 +92,35 @@ jobs:
           path: |
             **/build/reports/tests
           retention-days: 5
+  cluster-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        client: ["V1", "V2"]
+        clickhouse: ["25.3", "25.8", "25.10", "25.11", "25.12", "latest"]
+    name: ClickHouse Cluster ${{ matrix.clickhouse }} Client version ${{ matrix.client }} tests
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3
+      - name: Setup cluster, run tests, tear down cluster
+        env:
+          CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
+          CLIENT_VERSION: ${{ matrix.client }}
+          CLICKHOUSE_CLUSTER_MODE: true
+        run: ./gradlew test
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: result cluster_${{ matrix.client }}_${{ matrix.clickhouse }}
+          path: |
+            **/build/reports/tests
+          retention-days: 5

--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseCloudTest.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseCloudTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Assumptions;
 public class ClickHouseCloudTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClickHouseCloudTest.class);
     private static final Properties properties = System.getProperties();
+    private static final boolean isCluster = ClickHouseTestHelpers.isCluster();
+    private static final boolean isCloud = ClickHouseTestHelpers.isCloud();
 
     private Map<String, String> getTestProperties() {
         Map<String, String> props = new HashMap<>();
@@ -61,7 +63,8 @@ public class ClickHouseCloudTest {
 
     @BeforeAll
     public static void checkPropsExist() {
-        Assumptions.assumeFalse(ClickHouseTestHelpers.isCluster(), "Cloud tests are not supported in cluster mode");
+        Assumptions.assumeFalse(isCluster, "Cloud tests are not supported in cluster mode");
+        Assumptions.assumeTrue(isCloud, "Cloud tests are not supported in standalone mode");
         ClickHouseTestHelpers.logAndThrowIfCloudPropNotExists(LOGGER, properties, ClickHouseTestHelpers.CLICKHOUSE_CLOUD_HOST_SYSTEM_PROP);
         ClickHouseTestHelpers.logAndThrowIfCloudPropNotExists(LOGGER, properties, ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PORT_SYSTEM_PROP);
         ClickHouseTestHelpers.logAndThrowIfCloudPropNotExists(LOGGER, properties, ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PASSWORD_SYSTEM_PROP);

--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseCloudTest.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseCloudTest.java
@@ -1,12 +1,11 @@
 package com.clickhouse.kafka.connect.sink;
 
-import com.clickhouse.client.*;
 import com.clickhouse.client.api.query.GenericRecord;
 import com.clickhouse.client.api.query.Records;
-import com.clickhouse.data.ClickHouseRecord;
 import com.clickhouse.kafka.connect.ClickHouseSinkConnector;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseDeploymentType;
 import com.clickhouse.kafka.connect.sink.helper.CreateTableStatement;
 import com.clickhouse.kafka.connect.sink.helper.SchemalessTestData;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -20,7 +19,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import org.junit.jupiter.api.Assumptions;
 
+/**
+ * NOTE: this test does NOT run against cluster or standalone ClickHouse.
+ */
 public class ClickHouseCloudTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClickHouseCloudTest.class);
     private static final Properties properties = System.getProperties();
@@ -58,6 +61,7 @@ public class ClickHouseCloudTest {
 
     @BeforeAll
     public static void checkPropsExist() {
+        Assumptions.assumeFalse(ClickHouseTestHelpers.isCluster(), "Cloud tests are not supported in cluster mode");
         ClickHouseTestHelpers.logAndThrowIfCloudPropNotExists(LOGGER, properties, ClickHouseTestHelpers.CLICKHOUSE_CLOUD_HOST_SYSTEM_PROP);
         ClickHouseTestHelpers.logAndThrowIfCloudPropNotExists(LOGGER, properties, ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PORT_SYSTEM_PROP);
         ClickHouseTestHelpers.logAndThrowIfCloudPropNotExists(LOGGER, properties, ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PASSWORD_SYSTEM_PROP);
@@ -68,14 +72,14 @@ public class ClickHouseCloudTest {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = "schemaless_overlap_table_test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, ClickHouseDeploymentType.CLOUD);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16").column("str", "String")
                 .column("p_int8", "Int8").column("p_int16", "Int16").column("p_int32", "Int32")
                 .column("p_int64", "Int64").column("p_float32", "Float32")
                 .column("p_float64", "Float64").column("p_bool", "Bool")
-                .engine("ReplicatedMergeTree").orderByColumn("off16").execute(chc);
+                .orderByColumn("off16").execute(chc);
         Collection<SinkRecord> sr = SchemalessTestData.createPrimitiveTypes(topic, 1);
         Collection<SinkRecord> firstBatch = new ArrayList<>();
         Collection<SinkRecord> secondBatch = new ArrayList<>();
@@ -111,9 +115,9 @@ public class ClickHouseCloudTest {
         chst.put(thirdBatch);
         chst.stop();
         LOGGER.info("Total Records: {}", sr.size());
-        LOGGER.info("Row Count: {}", ClickHouseTestHelpers.countRows(chc, topic));
-        Assertions.assertTrue(ClickHouseTestHelpers.countRows(chc, topic) >= sr.size());
+        LOGGER.info("Row Count: {}", ClickHouseTestHelpers.countRows(chc, topic, ClickHouseDeploymentType.CLOUD));
+        Assertions.assertTrue(ClickHouseTestHelpers.countRows(chc, topic, ClickHouseDeploymentType.CLOUD) >= sr.size());
         Assertions.assertTrue(checkSequentialRows(chc, topic, sr.size()));
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, ClickHouseDeploymentType.CLOUD);
     }
 }

--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseCloudTest.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseCloudTest.java
@@ -82,7 +82,9 @@ public class ClickHouseCloudTest {
                 .column("p_int8", "Int8").column("p_int16", "Int16").column("p_int32", "Int32")
                 .column("p_int64", "Int64").column("p_float32", "Float32")
                 .column("p_float64", "Float64").column("p_bool", "Bool")
-                .orderByColumn("off16").execute(chc);
+                .orderByColumn("off16")
+                .deploymentType(ClickHouseDeploymentType.CLOUD)
+                .execute(chc);
         Collection<SinkRecord> sr = SchemalessTestData.createPrimitiveTypes(topic, 1);
         Collection<SinkRecord> firstBatch = new ArrayList<>();
         Collection<SinkRecord> secondBatch = new ArrayList<>();

--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConnectorIntegrationTest.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConnectorIntegrationTest.java
@@ -11,6 +11,7 @@ import com.clickhouse.kafka.connect.sink.helper.CreateTableStatement;
 import eu.rekawek.toxiproxy.Proxy;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -53,6 +54,7 @@ public class ClickHouseSinkConnectorIntegrationTest {
     private static final int PROXY_PORT = 8666;
     private static final String SINK_CONNECTOR_NAME = "ClickHouseSinkConnector";
     private static final boolean isCluster = ClickHouseTestHelpers.isCluster();
+    private static final boolean isCloud = ClickHouseTestHelpers.isCloud();
     private static final CreateTableStatement STOCK_TABLE = new CreateTableStatement()
             .column("side", "String")
             .column("quantity", "Int32")
@@ -72,6 +74,7 @@ public class ClickHouseSinkConnectorIntegrationTest {
 
     @BeforeAll
     public static void setup() throws IOException {
+        Assumptions.assumeFalse(isCloud, "ClickHouseSinkConnectorIntegrationTest is not supported against cloud");
         Network network = Network.newNetwork();
         List<String> connectorPath = new LinkedList<>();
         String confluentArchive = new File(Paths.get("build/confluentArchive").toString()).getAbsolutePath();
@@ -198,11 +201,7 @@ public class ClickHouseSinkConnectorIntegrationTest {
         props.put(ClickHouseSinkConnector.SSL_ENABLED, "false");
         props.put(ClickHouseSinkConnector.CLIENT_VERSION, "V2");
         if (isCluster) {
-            props.put(ClickHouseSinkConnector.HOSTNAME, ClickHouseCluster.getHost());
-            props.put(ClickHouseSinkConnector.PORT, ClickHouseCluster.getPort().toString());
-            props.put(ClickHouseSinkConnector.DATABASE, ClickHouseTestHelpers.DATABASE_DEFAULT);
-            props.put(ClickHouseSinkConnector.USERNAME, ClickHouseTestHelpers.USERNAME_DEFAULT);
-            props.put(ClickHouseSinkConnector.PASSWORD, "");
+            props.putAll(ClickHouseCluster.getClusterProps(ClickHouseTestHelpers.DATABASE_DEFAULT));
         } else {
             // standalone
             props.put(ClickHouseSinkConnector.HOSTNAME, db.getHost());

--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConnectorIntegrationTest.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConnectorIntegrationTest.java
@@ -3,7 +3,9 @@ package com.clickhouse.kafka.connect.sink;
 import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.kafka.connect.ClickHouseSinkConnector;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseCluster;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseDeploymentType;
 import com.clickhouse.kafka.connect.sink.helper.ConfluentPlatform;
 import com.clickhouse.kafka.connect.sink.helper.CreateTableStatement;
 import eu.rekawek.toxiproxy.Proxy;
@@ -11,7 +13,8 @@ import eu.rekawek.toxiproxy.ToxiproxyClient;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.clickhouse.ClickHouseContainer;
@@ -26,17 +29,30 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * <pre>
+ * NOTE 1: this test does NOT run against ClickHouse cloud
+ * </pre>
+ * <pre>
+ * NOTE 2: this test explicitly connects to the proxy endpoint and avoids setting PROXY_HOST/PROXY_PORT
+ * because the client makes requests with absolute URI's to the server when the proxy config is set.
+ * TODO: Once <a href="https://github.com/ClickHouse/ClickHouse/issues/58828">this issue</a> is fixed, we can revert this test to use the client proxy config.
+ * </pre>
+ */
 public class ClickHouseSinkConnectorIntegrationTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClickHouseSinkConnectorIntegrationTest.class);
     public static ConfluentPlatform confluentPlatform;
     private static ClickHouseContainer db;
-    private static ClickHouseHelperClient chcNoProxy;
+    private static ClickHouseHelperClient chc;
     public static ToxiproxyContainer toxiproxy;
-    public static Proxy clickhouseProxy;
+    public static Proxy proxy;
+    private static final int PROXY_PORT = 8666;
     private static final String SINK_CONNECTOR_NAME = "ClickHouseSinkConnector";
+    private static final boolean isCluster = ClickHouseTestHelpers.isCluster();
     private static final CreateTableStatement STOCK_TABLE = new CreateTableStatement()
             .column("side", "String")
             .column("quantity", "Int32")
@@ -45,126 +61,157 @@ public class ClickHouseSinkConnectorIntegrationTest {
             .column("account", "String")
             .column("userid", "String")
             .column("insertTime", "DateTime DEFAULT now()")
-            .engine("MergeTree")
             .orderByColumn("symbol");
 
+    public static Stream<ClickHouseDeploymentType> deploymentTypesForTests() {
+        if (isCluster) {
+            return Stream.of(ClickHouseDeploymentType.THREE_SHARDS_ONE_REPLICA_EACH, ClickHouseDeploymentType.ONE_SHARD_THREE_REPLICAS);
+        }
+        return Stream.of(ClickHouseDeploymentType.STANDALONE);
+    }
+
     @BeforeAll
-    public static void setup() {
+    public static void setup() throws IOException {
         Network network = Network.newNetwork();
         List<String> connectorPath = new LinkedList<>();
         String confluentArchive = new File(Paths.get("build/confluentArchive").toString()).getAbsolutePath();
         connectorPath.add(confluentArchive);
         confluentPlatform = new ConfluentPlatform(network, connectorPath);
 
-        db = new ClickHouseContainer(ClickHouseTestHelpers.CLICKHOUSE_DOCKER_IMAGE).withNetwork(network).withNetworkAliases(ClickHouseTestHelpers.CLICKHOUSE_DB_NETWORK_ALIAS);
-        db.start();
+        if (!isCluster) {
+            db = new ClickHouseContainer(ClickHouseTestHelpers.CLICKHOUSE_DOCKER_IMAGE)
+                    .withNetwork(network)
+                    .withNetworkAliases(ClickHouseTestHelpers.CLICKHOUSE_DB_NETWORK_ALIAS);
+            db.start();
+        }
 
-        toxiproxy = new ToxiproxyContainer(ClickHouseTestHelpers.TOXIPROXY_DOCKER_IMAGE_NAME).withNetwork(network).withNetworkAliases(ClickHouseTestHelpers.TOXIPROXY_NETWORK_ALIAS);
+        toxiproxy = new ToxiproxyContainer(ClickHouseTestHelpers.TOXIPROXY_DOCKER_IMAGE_NAME)
+                .withNetwork(network)
+                .withNetworkAliases(ClickHouseTestHelpers.TOXIPROXY_NETWORK_ALIAS);
+        if (isCluster) {
+            toxiproxy = toxiproxy.withExtraHost("host.docker.internal", "host-gateway");
+        }
         toxiproxy.start();
 
-        chcNoProxy = createClientNoProxy(getTestProperties());
+        LOGGER.info("Started proxy container: {}", toxiproxy.getControlPort());
+        ToxiproxyClient toxiproxyClient = new ToxiproxyClient(toxiproxy.getHost(), toxiproxy.getControlPort());
+
+        String upstream;
+        if (isCluster) {
+            upstream = String.format("host.docker.internal:%d", ClickHouseCluster.getPort());
+        } else {
+            upstream = String.format("%s:%d", ClickHouseTestHelpers.CLICKHOUSE_DB_NETWORK_ALIAS, ClickHouseProtocol.HTTP.getDefaultPort());
+        }
+        proxy = toxiproxyClient.createProxy("clickhouse-proxy", "0.0.0.0:" + PROXY_PORT, upstream);
+        LOGGER.info("Proxy configured {}", proxy.getListen());
+        chc = ClickHouseTestHelpers.createClient(getTestProperties());
     }
 
     @BeforeEach
     public void beforeEach() throws IOException {
         confluentPlatform.deleteConnectors(SINK_CONNECTOR_NAME);
-
-        if (clickhouseProxy != null) {
-            clickhouseProxy.delete();
-        }
-
-        ToxiproxyClient toxiproxyClient = new ToxiproxyClient(toxiproxy.getHost(), toxiproxy.getControlPort());
-        clickhouseProxy = toxiproxyClient.createProxy("clickhouse-proxy", "0.0.0.0:8666", String.format("%s:%d", ClickHouseTestHelpers.CLICKHOUSE_DB_NETWORK_ALIAS, ClickHouseProtocol.HTTP.getDefaultPort()));
     }
 
     @AfterAll
     public static void tearDown() {
-        db.stop();
+        if (!isCluster) {
+            db.stop();
+        }
         toxiproxy.stop();
         confluentPlatform.close();
     }
 
-    @Test
-    public void stockGenSingleTaskTest() throws IOException, InterruptedException {
-        String topicName = "stockGenSingleTaskTest";
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void stockGenSingleTaskTest(ClickHouseDeploymentType deploymentType) throws IOException, InterruptedException {
+        String topicName = "stockGenSingleTaskTest_" + deploymentType;
         confluentPlatform.createTopic(topicName, 1);
         int dataCount = generateData(topicName, 1, 100);
-        setupConnector(topicName, 1);
-        ClickHouseTestHelpers.waitWhileCounting(chcNoProxy, topicName, 3);
-        assertTrue(dataCount <= ClickHouseTestHelpers.countRows(chcNoProxy, topicName));
+        setupConnector(topicName, 1, deploymentType);
+        ClickHouseTestHelpers.waitWhileCounting(chc, topicName, 3, deploymentType);
+        assertTrue(dataCount <= ClickHouseTestHelpers.countRows(chc, topicName, deploymentType));
     }
 
-    @Test
-    public void stockGenWithJdbcPropSingleTaskTest() throws IOException, InterruptedException {
-        String topicName = "stockGenWithJdbcPropSingleTaskTest";
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void stockGenWithJdbcPropSingleTaskTest(ClickHouseDeploymentType deploymentType) throws IOException, InterruptedException {
+        String topicName = "stockGenWithJdbcPropSingleTaskTest_" + deploymentType;
         confluentPlatform.createTopic(topicName, 1);
         int dataCount = generateData(topicName, 1, 100);
-        setupConnectorWithJdbcProperties(topicName, 1);
-        ClickHouseTestHelpers.waitWhileCounting(chcNoProxy, topicName, 3);
-        assertTrue(dataCount <= ClickHouseTestHelpers.countRows(chcNoProxy, topicName));
+        setupConnectorWithJdbcProperties(topicName, 1, deploymentType);
+        ClickHouseTestHelpers.waitWhileCounting(chc, topicName, 3, deploymentType);
+        assertTrue(dataCount <= ClickHouseTestHelpers.countRows(chc, topicName, deploymentType));
     }
 
-    @Test
-    public void stockGenSingleTaskSchemalessTest() throws IOException, InterruptedException {
-        String topicName = "stockGenSingleTaskSchemalessTest";
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void stockGenSingleTaskSchemalessTest(ClickHouseDeploymentType deploymentType) throws IOException, InterruptedException {
+        String topicName = "stockGenSingleTaskSchemalessTest_" + deploymentType;
         confluentPlatform.createTopic(topicName, 1);
         int dataCount = generateSchemalessData(topicName, 1, 100);
-        setupSchemalessConnector(topicName, 1);
-        ClickHouseTestHelpers.waitWhileCounting(chcNoProxy, topicName, 3);
-        assertTrue(dataCount <= ClickHouseTestHelpers.countRows(chcNoProxy, topicName));
+        setupSchemalessConnector(topicName, 1, deploymentType);
+        ClickHouseTestHelpers.waitWhileCounting(chc, topicName, 3, deploymentType);
+        assertTrue(dataCount <= ClickHouseTestHelpers.countRows(chc, topicName, deploymentType));
     }
 
-    @Test
-    public void stockGenSingleTaskInterruptTest() throws IOException, InterruptedException {
-        checkInterruptTest("stockGenSingleTaskInterruptTest", 1);
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void stockGenSingleTaskInterruptTest(ClickHouseDeploymentType deploymentType) throws IOException, InterruptedException {
+        checkInterruptTest("stockGenSingleTaskInterruptTest_" + deploymentType, 1, deploymentType);
     }
 
-    @Test
-    public void stockGenMultiTaskInterruptTest() throws IOException, InterruptedException {
-        checkInterruptTest("stockGenMultiTaskInterruptTest", 3);
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void stockGenMultiTaskInterruptTest(ClickHouseDeploymentType deploymentType) throws IOException, InterruptedException {
+        checkInterruptTest("stockGenMultiTaskInterruptTest_" + deploymentType, 3, deploymentType);
     }
 
-    @Test
-    public void stockGenMultiTaskTopicTest() throws IOException, InterruptedException {
-        String topicName = "stockGenMultiTaskTopicTest";
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void stockGenMultiTaskTopicTest(ClickHouseDeploymentType deploymentType) throws IOException, InterruptedException {
+        String topicName = "stockGenMultiTaskTopicTest_" + deploymentType;
         int parCount = 3;
         confluentPlatform.createTopic(topicName, parCount);
         int dataCount = generateData(topicName, parCount, 200);
-        setupConnector(topicName, parCount);
-        ClickHouseTestHelpers.waitWhileCounting(chcNoProxy, topicName, 3);
+        setupConnector(topicName, parCount, deploymentType);
+        ClickHouseTestHelpers.waitWhileCounting(chc, topicName, 3, deploymentType);
         LOGGER.info(confluentPlatform.getConnectors());
-        assertTrue(dataCount <= ClickHouseTestHelpers.countRows(chcNoProxy, topicName));
+        assertTrue(dataCount <= ClickHouseTestHelpers.countRows(chc, topicName, deploymentType));
     }
 
-    @Test
-    public void stockGenMultiTaskSchemalessTest() throws IOException, InterruptedException {
-        String topicName = "stockGenMultiTaskSchemalessTest";
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void stockGenMultiTaskSchemalessTest(ClickHouseDeploymentType deploymentType) throws IOException, InterruptedException {
+        String topicName = "stockGenMultiTaskSchemalessTest_" + deploymentType;
         int parCount = 3;
         confluentPlatform.createTopic(topicName, parCount);
         int dataCount = generateSchemalessData(topicName, parCount, 200);
-        setupSchemalessConnector(topicName, parCount);
-        ClickHouseTestHelpers.waitWhileCounting(chcNoProxy, topicName, 3);
+        setupSchemalessConnector(topicName, parCount, deploymentType);
+        ClickHouseTestHelpers.waitWhileCounting(chc, topicName, 3, deploymentType);
         LOGGER.info(confluentPlatform.getConnectors());
-        assertTrue(dataCount <= ClickHouseTestHelpers.countRows(chcNoProxy, topicName));
+        assertTrue(dataCount <= ClickHouseTestHelpers.countRows(chc, topicName, deploymentType));
     }
 
     private static Map<String, String> getTestProperties() {
         Map<String, String> props = new HashMap<>();
-        props.put(ClickHouseSinkConnector.HOSTNAME, db.getHost());
-        props.put(ClickHouseSinkConnector.PORT, String.valueOf(db.getMappedPort(ClickHouseProtocol.HTTP.getDefaultPort())));
-        props.put(ClickHouseSinkConnector.DATABASE, "default");
-        props.put(ClickHouseSinkConnector.USERNAME, db.getUsername());
-        props.put(ClickHouseSinkConnector.PASSWORD, db.getPassword());
-        props.put(ClickHouseSinkConnector.SSL_ENABLED, "false");
-        props.put(ClickHouseSinkConfig.PROXY_TYPE, "HTTP");
-        props.put(ClickHouseSinkConfig.PROXY_HOST, toxiproxy.getHost());
-        props.put(ClickHouseSinkConfig.PROXY_PORT, String.valueOf(toxiproxy.getMappedPort(8666)));
-        return props;
-    }
-
-    private static ClickHouseHelperClient createClientNoProxy(Map<String, String> props) {
         props.put(ClickHouseSinkConfig.PROXY_TYPE, "IGNORE");
-        return ClickHouseTestHelpers.createClient(props);
+        props.put(ClickHouseSinkConnector.SSL_ENABLED, "false");
+        props.put(ClickHouseSinkConnector.CLIENT_VERSION, "V2");
+        if (isCluster) {
+            props.put(ClickHouseSinkConnector.HOSTNAME, ClickHouseCluster.getHost());
+            props.put(ClickHouseSinkConnector.PORT, ClickHouseCluster.getPort().toString());
+            props.put(ClickHouseSinkConnector.DATABASE, ClickHouseTestHelpers.DATABASE_DEFAULT);
+            props.put(ClickHouseSinkConnector.USERNAME, ClickHouseTestHelpers.USERNAME_DEFAULT);
+            props.put(ClickHouseSinkConnector.PASSWORD, "");
+        } else {
+            // standalone
+            props.put(ClickHouseSinkConnector.HOSTNAME, db.getHost());
+            props.put(ClickHouseSinkConnector.PORT, String.valueOf(db.getMappedPort(ClickHouseProtocol.HTTP.getDefaultPort())));
+            props.put(ClickHouseSinkConnector.DATABASE, ClickHouseTestHelpers.DATABASE_DEFAULT);
+            props.put(ClickHouseSinkConnector.USERNAME, db.getUsername());
+            props.put(ClickHouseSinkConnector.PASSWORD, db.getPassword());
+        }
+        return props;
     }
 
     private int generateData(String topicName, int numberOfPartitions, int numberOfRecords) throws IOException, InterruptedException {
@@ -175,64 +222,68 @@ public class ClickHouseSinkConnectorIntegrationTest {
         return confluentPlatform.generateData("src/integrationTest/resources/stock_gen_json.json", topicName, numberOfPartitions, numberOfRecords);
     }
 
-    private void setupConnector(String topicName, int taskCount) throws IOException, InterruptedException {
+    private void setupConnector(String topicName, int taskCount, ClickHouseDeploymentType deploymentType) throws IOException, InterruptedException {
         LOGGER.info("Setting up connector...");
         confluentPlatform.deleteConnectors(SINK_CONNECTOR_NAME);
-        ClickHouseTestHelpers.dropTable(chcNoProxy, topicName);
-        new CreateTableStatement(STOCK_TABLE).tableName(topicName).execute(chcNoProxy);
+        ClickHouseTestHelpers.dropTable(chc, topicName, deploymentType);
+        new CreateTableStatement(STOCK_TABLE).tableName(topicName).deploymentType(deploymentType).execute(chc);
 
         String payloadClickHouseSink = String.join("", Files.readAllLines(Paths.get("src/integrationTest/resources/clickhouse_sink.json")));
-        // The client makes requests with absolute URIs when a proxy is configured - currently, requests with absolute paths are rejected by CH server.
-        // To work around this, transparently connect to the toxiproxy endpoint and avoid configuring the proxy settings on the client. The proxy will relay relative URIs, which the CH server expects.
-        String jsonString = String.format(payloadClickHouseSink, SINK_CONNECTOR_NAME, SINK_CONNECTOR_NAME, taskCount, topicName, "toxiproxy", 8666, db.getUsername(), db.getPassword());
+        String jsonString;
+        jsonString = String.format(payloadClickHouseSink, SINK_CONNECTOR_NAME, SINK_CONNECTOR_NAME, taskCount, topicName,
+                "toxiproxy", PROXY_PORT, chc.getUsername(), chc.getPassword());
 
         confluentPlatform.createConnect(jsonString);
         Thread.sleep(1000);
     }
 
-    private void setupSchemalessConnector(String topicName, int taskCount) throws IOException, InterruptedException {
+    private void setupSchemalessConnector(String topicName, int taskCount, ClickHouseDeploymentType deploymentType) throws IOException, InterruptedException {
         LOGGER.info("Setting up schemaless connector...");
-        ClickHouseTestHelpers.dropTable(chcNoProxy, topicName);
-        new CreateTableStatement(STOCK_TABLE).tableName(topicName).execute(chcNoProxy);
+        ClickHouseTestHelpers.dropTable(chc, topicName, deploymentType);
+        new CreateTableStatement(STOCK_TABLE).tableName(topicName).deploymentType(deploymentType).execute(chc);
 
         String payloadClickHouseSink = String.join("", Files.readAllLines(Paths.get("src/integrationTest/resources/clickhouse_sink_schemaless.json")));
-        String jsonString = String.format(payloadClickHouseSink, SINK_CONNECTOR_NAME, SINK_CONNECTOR_NAME, taskCount, topicName, "toxiproxy", 8666, db.getUsername(), db.getPassword());
+        String jsonString;
+        jsonString = String.format(payloadClickHouseSink, SINK_CONNECTOR_NAME, SINK_CONNECTOR_NAME, taskCount, topicName,
+                "toxiproxy", PROXY_PORT, chc.getUsername(), chc.getPassword());
 
         confluentPlatform.createConnect(jsonString);
         Thread.sleep(1000);
     }
 
-    private void setupConnectorWithJdbcProperties(String topicName, int taskCount) throws IOException, InterruptedException {
+    private void setupConnectorWithJdbcProperties(String topicName, int taskCount, ClickHouseDeploymentType deploymentType) throws IOException, InterruptedException {
         LOGGER.info("Setting up connector with jdbc properties...");
         confluentPlatform.deleteConnectors(SINK_CONNECTOR_NAME);
-        ClickHouseTestHelpers.dropTable(chcNoProxy, topicName);
-        new CreateTableStatement(STOCK_TABLE).tableName(topicName).execute(chcNoProxy);
+        ClickHouseTestHelpers.dropTable(chc, topicName, deploymentType);
+        new CreateTableStatement(STOCK_TABLE).tableName(topicName).deploymentType(deploymentType).execute(chc);
 
         String payloadClickHouseSink = String.join("", Files.readAllLines(Paths.get("src/integrationTest/resources/clickhouse_sink_with_jdbc_prop.json")));
-        String jsonString = String.format(payloadClickHouseSink, SINK_CONNECTOR_NAME, SINK_CONNECTOR_NAME, taskCount, topicName, "toxiproxy", 8666, db.getUsername(), db.getPassword());
+        String jsonString;
+        jsonString = String.format(payloadClickHouseSink, SINK_CONNECTOR_NAME, SINK_CONNECTOR_NAME, taskCount, topicName,
+                "toxiproxy", PROXY_PORT, chc.getUsername(), chc.getPassword());
 
         confluentPlatform.createConnect(jsonString);
         Thread.sleep(1000);
     }
 
-    private void checkInterruptTest(String topicName, int parCount) throws InterruptedException, IOException {
+    private void checkInterruptTest(String topicName, int parCount, ClickHouseDeploymentType deploymentType) throws InterruptedException, IOException {
         confluentPlatform.createTopic(topicName, parCount);
         int dataCount = generateData(topicName, parCount, 2500);
-        setupConnector(topicName, parCount);
-        int databaseCount = ClickHouseTestHelpers.countRows(chcNoProxy, topicName);
+        setupConnector(topicName, parCount, deploymentType);
+        int databaseCount = ClickHouseTestHelpers.countRows(chc, topicName, deploymentType);
         int lastCount = 0;
         int loopCount = 0;
 
         while (databaseCount != lastCount || loopCount < 5) {
             if (loopCount == 0) {
                 LOGGER.info("Disabling proxy");
-                clickhouseProxy.disable();
-            } else if (!clickhouseProxy.isEnabled()) {
+                proxy.disable();
+            } else if (!proxy.isEnabled()) {
                 LOGGER.info("Re-enabling proxy");
-                clickhouseProxy.enable();
+                proxy.enable();
             }
             Thread.sleep(3500);
-            databaseCount = ClickHouseTestHelpers.countRows(chcNoProxy, topicName);
+            databaseCount = ClickHouseTestHelpers.countRows(chc, topicName, deploymentType);
             if (lastCount == databaseCount) {
                 loopCount++;
             } else {
@@ -242,6 +293,6 @@ public class ClickHouseSinkConnectorIntegrationTest {
             lastCount = databaseCount;
         }
 
-        assertTrue(dataCount <= ClickHouseTestHelpers.countRows(chcNoProxy, topicName));
+        assertTrue(dataCount <= ClickHouseTestHelpers.countRows(chc, topicName, deploymentType));
     }
 }

--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ExactlyOnceTest.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ExactlyOnceTest.java
@@ -2,7 +2,7 @@ package com.clickhouse.kafka.connect.sink;
 
 import com.clickhouse.client.api.query.GenericRecord;
 import com.clickhouse.client.api.query.Records;
-import com.clickhouse.client.config.ClickHouseProxyType;
+import com.clickhouse.kafka.connect.ClickHouseSinkConnector;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseCloudAPI;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseCluster;
@@ -22,10 +22,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -42,6 +39,7 @@ public class ExactlyOnceTest {
     private static final Properties cloudProperties = System.getProperties();
     private static final String SINK_CONNECTOR_NAME = "ClickHouseSinkConnector";
     private static final boolean isCluster = ClickHouseTestHelpers.isCluster();
+    private static final boolean isCloud = ClickHouseTestHelpers.isCloud();
     private static final CreateTableStatement STOCK_TABLE = new CreateTableStatement()
             .column("side", "String")
             .column("quantity", "Int32")
@@ -59,36 +57,37 @@ public class ExactlyOnceTest {
         return Stream.of(ClickHouseDeploymentType.CLOUD);
     }
 
-    @BeforeAll
-    public static void checkPropsExistAndSetUp() {
+    private static Map<String, String> getTestProperties() {
+        Map<String, String> props = new HashMap<>();
+        props.put(ClickHouseSinkConfig.PROXY_TYPE, "IGNORE");
+        props.put(ClickHouseSinkConnector.CLIENT_VERSION, "V2");
         if (isCluster) {
-            chc = new ClickHouseHelperClient.ClickHouseClientBuilder(
-                    ClickHouseCluster.getHost(), ClickHouseCluster.getPort(), ClickHouseProxyType.IGNORE, null, -1)
-                    .setDatabase(ClickHouseTestHelpers.DATABASE_DEFAULT)
-                    .setUsername(ClickHouseTestHelpers.USERNAME_DEFAULT)
-                    .setPassword("")
-                    .sslEnable(false)
-                    .useClientV2(true)
-                    .build();
-            // clickhouseCloudAPI is intentionally left null — restartService() is cloud-only
+            props.putAll(ClickHouseCluster.getClusterProps(ClickHouseTestHelpers.DATABASE_DEFAULT));
         } else {
             // cloud
+            props.putAll(Map.of(
+                    ClickHouseSinkConnector.HOSTNAME, cloudProperties.getProperty(ClickHouseTestHelpers.CLICKHOUSE_CLOUD_HOST_SYSTEM_PROP),
+                    ClickHouseSinkConnector.PORT, cloudProperties.getProperty(ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PORT_SYSTEM_PROP),
+                    ClickHouseSinkConnector.DATABASE, ClickHouseTestHelpers.DATABASE_DEFAULT,
+                    ClickHouseSinkConnector.USERNAME, ClickHouseTestHelpers.USERNAME_DEFAULT,
+                    ClickHouseSinkConnector.PASSWORD, cloudProperties.getProperty(ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PASSWORD_SYSTEM_PROP),
+                    ClickHouseSinkConnector.SSL_ENABLED, "true"
+            ));
+        }
+        return props;
+    }
+
+    @BeforeAll
+    public static void checkPropsExistAndSetUp() {
+        Assumptions.assumeTrue(isCluster || isCloud, "ExactlyOnceTest in not supported against standalone");
+        if (isCloud) {
             ClickHouseTestHelpers.logAndThrowIfCloudPropNotExists(LOGGER, cloudProperties, ClickHouseTestHelpers.CLICKHOUSE_CLOUD_HOST_SYSTEM_PROP);
             ClickHouseTestHelpers.logAndThrowIfCloudPropNotExists(LOGGER, cloudProperties, ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PORT_SYSTEM_PROP);
             ClickHouseTestHelpers.logAndThrowIfCloudPropNotExists(LOGGER, cloudProperties, ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PASSWORD_SYSTEM_PROP);
-
-            chc = new ClickHouseHelperClient.ClickHouseClientBuilder(
-                    cloudProperties.getProperty(ClickHouseTestHelpers.CLICKHOUSE_CLOUD_HOST_SYSTEM_PROP),
-                    Integer.parseInt(cloudProperties.getProperty(ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PORT_SYSTEM_PROP)),
-                    ClickHouseProxyType.IGNORE, null, -1)
-                    .setUsername(ClickHouseTestHelpers.USERNAME_DEFAULT)
-                    .setPassword(cloudProperties.getProperty(ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PASSWORD_SYSTEM_PROP))
-                    .sslEnable(true)
-                    .useClientV2(true)
-                    .build();
             clickhouseCloudAPI = new ClickHouseCloudAPI(cloudProperties);
         }
 
+        chc = ClickHouseTestHelpers.createClient(getTestProperties());
         Network network = Network.newNetwork();
         List<String> connectorPath = new LinkedList<>();
         String confluentArchive = new File(Paths.get("build/confluentArchive").toString()).getAbsolutePath();

--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ExactlyOnceTest.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/ExactlyOnceTest.java
@@ -5,10 +5,14 @@ import com.clickhouse.client.api.query.Records;
 import com.clickhouse.client.config.ClickHouseProxyType;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseCloudAPI;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseCluster;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseDeploymentType;
 import com.clickhouse.kafka.connect.sink.helper.ConfluentPlatform;
 import com.clickhouse.kafka.connect.sink.helper.CreateTableStatement;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
@@ -27,14 +31,17 @@ import java.util.stream.StreamSupport;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-
+/**
+ * NOTE: this test does NOT run against standalone ClickHouse
+ */
 public class ExactlyOnceTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(ExactlyOnceTest.class);
     public static ConfluentPlatform confluentPlatform;
     private static ClickHouseCloudAPI clickhouseCloudAPI;
-    private static ClickHouseHelperClient chcNoProxy;
-    private static final Properties properties = System.getProperties();
+    private static ClickHouseHelperClient chc;
+    private static final Properties cloudProperties = System.getProperties();
     private static final String SINK_CONNECTOR_NAME = "ClickHouseSinkConnector";
+    private static final boolean isCluster = ClickHouseTestHelpers.isCluster();
     private static final CreateTableStatement STOCK_TABLE = new CreateTableStatement()
             .column("side", "String")
             .column("quantity", "Int32")
@@ -43,24 +50,44 @@ public class ExactlyOnceTest {
             .column("account", "String")
             .column("userid", "String")
             .column("insertTime", "DateTime DEFAULT now()")
-            .engine("MergeTree")
             .orderByColumn("symbol");
+
+    public static Stream<ClickHouseDeploymentType> deploymentTypesForTests() {
+        if (isCluster) {
+            return Stream.of(ClickHouseDeploymentType.THREE_SHARDS_ONE_REPLICA_EACH, ClickHouseDeploymentType.ONE_SHARD_THREE_REPLICAS);
+        }
+        return Stream.of(ClickHouseDeploymentType.CLOUD);
+    }
 
     @BeforeAll
     public static void checkPropsExistAndSetUp() {
-        ClickHouseTestHelpers.logAndThrowIfCloudPropNotExists(LOGGER, properties, ClickHouseTestHelpers.CLICKHOUSE_CLOUD_HOST_SYSTEM_PROP);
-        ClickHouseTestHelpers.logAndThrowIfCloudPropNotExists(LOGGER, properties, ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PORT_SYSTEM_PROP);
-        ClickHouseTestHelpers.logAndThrowIfCloudPropNotExists(LOGGER, properties, ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PASSWORD_SYSTEM_PROP);
+        if (isCluster) {
+            chc = new ClickHouseHelperClient.ClickHouseClientBuilder(
+                    ClickHouseCluster.getHost(), ClickHouseCluster.getPort(), ClickHouseProxyType.IGNORE, null, -1)
+                    .setDatabase(ClickHouseTestHelpers.DATABASE_DEFAULT)
+                    .setUsername(ClickHouseTestHelpers.USERNAME_DEFAULT)
+                    .setPassword("")
+                    .sslEnable(false)
+                    .useClientV2(true)
+                    .build();
+            // clickhouseCloudAPI is intentionally left null — restartService() is cloud-only
+        } else {
+            // cloud
+            ClickHouseTestHelpers.logAndThrowIfCloudPropNotExists(LOGGER, cloudProperties, ClickHouseTestHelpers.CLICKHOUSE_CLOUD_HOST_SYSTEM_PROP);
+            ClickHouseTestHelpers.logAndThrowIfCloudPropNotExists(LOGGER, cloudProperties, ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PORT_SYSTEM_PROP);
+            ClickHouseTestHelpers.logAndThrowIfCloudPropNotExists(LOGGER, cloudProperties, ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PASSWORD_SYSTEM_PROP);
 
-        chcNoProxy = new ClickHouseHelperClient.ClickHouseClientBuilder(properties.getProperty(ClickHouseTestHelpers.CLICKHOUSE_CLOUD_HOST_SYSTEM_PROP),
-                Integer.parseInt(properties.getProperty(ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PORT_SYSTEM_PROP)), ClickHouseProxyType.IGNORE, null, -1)
-                .setUsername(ClickHouseTestHelpers.USERNAME_DEFAULT)
-                .setPassword(properties.getProperty(ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PASSWORD_SYSTEM_PROP))
-                .sslEnable(true)
-                .useClientV2(true)
-                .build();
-        clickhouseCloudAPI = new ClickHouseCloudAPI(properties);
-
+            chc = new ClickHouseHelperClient.ClickHouseClientBuilder(
+                    cloudProperties.getProperty(ClickHouseTestHelpers.CLICKHOUSE_CLOUD_HOST_SYSTEM_PROP),
+                    Integer.parseInt(cloudProperties.getProperty(ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PORT_SYSTEM_PROP)),
+                    ClickHouseProxyType.IGNORE, null, -1)
+                    .setUsername(ClickHouseTestHelpers.USERNAME_DEFAULT)
+                    .setPassword(cloudProperties.getProperty(ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PASSWORD_SYSTEM_PROP))
+                    .sslEnable(true)
+                    .useClientV2(true)
+                    .build();
+            clickhouseCloudAPI = new ClickHouseCloudAPI(cloudProperties);
+        }
 
         Network network = Network.newNetwork();
         List<String> connectorPath = new LinkedList<>();
@@ -81,56 +108,72 @@ public class ExactlyOnceTest {
         confluentPlatform.deleteConnectors(SINK_CONNECTOR_NAME);
     }
 
-    @Test
-    public void checkTotalsEqual() throws InterruptedException, IOException {
-        assertTrue(compareSchemalessCounts("singlePartitionTopic", 1));
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void checkTotalsEqual(ClickHouseDeploymentType deploymentType) throws InterruptedException, IOException {
+        assertTrue(compareSchemalessCounts("singlePartitionTopic_" + deploymentType, 1, deploymentType));
     }
 
-    @Test
-    public void checkTotalsEqualMulti() throws InterruptedException, IOException {
-        assertTrue(compareSchemalessCounts("multiPartitionTopic", 3));
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void checkTotalsEqualMulti(ClickHouseDeploymentType deploymentType) throws InterruptedException, IOException {
+        assertTrue(compareSchemalessCounts("multiPartitionTopic_" + deploymentType, 3, deploymentType));
     }
 
-    @Test
-    public void checkSpottyNetwork() throws InterruptedException, IOException, URISyntaxException {
-        checkSpottyNetworkSchemaless("checkSpottyNetworkSinglePartition", 1);
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void checkSpottyNetwork(ClickHouseDeploymentType deploymentType) throws InterruptedException, IOException, URISyntaxException {
+        Assumptions.assumeFalse(isCluster,
+                "checkSpottyNetwork requires ClickHouse Cloud API to stop/restart the service; not supported in cluster mode");
+        checkSpottyNetworkSchemaless("checkSpottyNetworkSinglePartition_" + deploymentType, 1, deploymentType);
     }
 
-    @Test
-    public void checkSpottyNetworkMulti() throws InterruptedException, IOException, URISyntaxException {
-        checkSpottyNetworkSchemaless("checkSpottyNetworkMultiPartitions", 3);
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void checkSpottyNetworkMulti(ClickHouseDeploymentType deploymentType) throws InterruptedException, IOException, URISyntaxException {
+        Assumptions.assumeFalse(isCluster,
+                "checkSpottyNetworkMulti requires ClickHouse Cloud API to stop/restart the service; not supported in cluster mode");
+        checkSpottyNetworkSchemaless("checkSpottyNetworkMultiPartitions_" + deploymentType, 3, deploymentType);
     }
 
-    private static void setupSchemaConnector(String topicName, int taskCount) throws IOException, InterruptedException {
+    private static void setupSchemaConnector(String topicName, int taskCount, ClickHouseDeploymentType deploymentType) throws IOException, InterruptedException {
         LOGGER.info("Setting up connector...");
-        setupConnector("src/integrationTest/resources/clickhouse_sink_no_proxy.json", topicName, taskCount);
+        setupConnector("src/integrationTest/resources/clickhouse_sink_no_proxy.json", topicName, taskCount, deploymentType);
         Thread.sleep(5 * 1000);
     }
 
-    private static void setupSchemalessConnector(String topicName, int taskCount) throws IOException, InterruptedException {
+    private static void setupSchemalessConnector(String topicName, int taskCount, ClickHouseDeploymentType deploymentType) throws IOException, InterruptedException {
         LOGGER.info("Setting schemaless up connector...");
-        setupConnector("src/integrationTest/resources/clickhouse_sink_no_proxy_schemaless.json", topicName, taskCount);
+        setupConnector("src/integrationTest/resources/clickhouse_sink_no_proxy_schemaless.json", topicName, taskCount, deploymentType);
         Thread.sleep(5 * 1000);
     }
 
-    private static void setupConnector(String fileName, String topicName, int taskCount) throws IOException {
+    private static void setupConnector(String fileName, String topicName, int taskCount, ClickHouseDeploymentType deploymentType) throws IOException {
         System.out.println("Setting up connector...");
-        ClickHouseTestHelpers.dropTable(chcNoProxy, topicName);
-        new CreateTableStatement(STOCK_TABLE) // implicitly SharedMergeTree in CH Cloud
-                .tableName(topicName).execute(chcNoProxy);
+        ClickHouseTestHelpers.dropTable(chc, topicName, deploymentType);
+        new CreateTableStatement(STOCK_TABLE)
+                .tableName(topicName).deploymentType(deploymentType).execute(chc);
 
         String payloadClickHouseSink = String.join("", Files.readAllLines(Paths.get(fileName)));
-        String jsonString = String.format(payloadClickHouseSink, SINK_CONNECTOR_NAME, SINK_CONNECTOR_NAME, taskCount, topicName,
-                properties.getProperty(ClickHouseTestHelpers.CLICKHOUSE_CLOUD_HOST_SYSTEM_PROP),
-                properties.getProperty(ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PORT_SYSTEM_PROP),
-                ClickHouseTestHelpers.DATABASE_DEFAULT,
-                ClickHouseTestHelpers.USERNAME_DEFAULT,
-                properties.getProperty(ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PASSWORD_SYSTEM_PROP),
-                true);
+        String jsonString;
+        if (isCluster) {
+            jsonString = String.format(payloadClickHouseSink, SINK_CONNECTOR_NAME, SINK_CONNECTOR_NAME, taskCount, topicName,
+                    "host.docker.internal", ClickHouseCluster.getPort().toString(),
+                    ClickHouseTestHelpers.DATABASE_DEFAULT,
+                    ClickHouseTestHelpers.USERNAME_DEFAULT, "",
+                    false, true); // ssl=false, exactlyOnce=true
+        } else {
+            jsonString = String.format(payloadClickHouseSink, SINK_CONNECTOR_NAME, SINK_CONNECTOR_NAME, taskCount, topicName,
+                    cloudProperties.getProperty(ClickHouseTestHelpers.CLICKHOUSE_CLOUD_HOST_SYSTEM_PROP),
+                    cloudProperties.getProperty(ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PORT_SYSTEM_PROP),
+                    ClickHouseTestHelpers.DATABASE_DEFAULT,
+                    ClickHouseTestHelpers.USERNAME_DEFAULT,
+                    cloudProperties.getProperty(ClickHouseTestHelpers.CLICKHOUSE_CLOUD_PASSWORD_SYSTEM_PROP),
+                    true, true); // ssl=true, exactlyOnce=true
+        }
 
         confluentPlatform.createConnect(jsonString);
     }
-
 
     private int generateData(String topicName, int numberOfPartitions, int numberOfRecords) throws IOException, InterruptedException {
         return confluentPlatform.generateData("src/integrationTest/resources/stock_gen.json", topicName, numberOfPartitions, numberOfRecords);
@@ -140,46 +183,39 @@ public class ExactlyOnceTest {
         return confluentPlatform.generateData("src/integrationTest/resources/stock_gen_json.json", topicName, numberOfPartitions, numberOfRecords);
     }
 
-    private boolean compareSchemalessCounts(String topicName, int partitions) throws InterruptedException, IOException {
-        new CreateTableStatement(STOCK_TABLE) // implicitly SharedMergeTree in CH Cloud
-                .tableName(topicName).ifNotExists(true).execute(chcNoProxy);
-        ClickHouseTestHelpers.clearTable(chcNoProxy, topicName);
+    private boolean compareSchemalessCounts(String topicName, int partitions, ClickHouseDeploymentType deploymentType) throws InterruptedException, IOException {
         confluentPlatform.createTopic(topicName, partitions);
         int count = generateSchemalessData(topicName, partitions, 250);
         LOGGER.info("Expected Total: {}", count);
-        setupSchemalessConnector(topicName, partitions);
-        ClickHouseTestHelpers.waitWhileCounting(chcNoProxy, topicName, 5);
+        setupSchemalessConnector(topicName, partitions, deploymentType);
+        ClickHouseTestHelpers.waitWhileCounting(chc, topicName, 5, deploymentType);
 
-        int[] databaseCounts = getCounts(chcNoProxy, topicName);//Essentially the final count
-        ClickHouseTestHelpers.dropTable(chcNoProxy, topicName);
+        int[] databaseCounts = getCounts(chc, topicName, deploymentType);
+        ClickHouseTestHelpers.dropTable(chc, topicName, deploymentType);
         return databaseCounts[2] == 0 && databaseCounts[1] == count;
     }
 
-
-    private void checkSpottyNetworkSchemaless(String topicName, int numberOfPartitions) throws InterruptedException, IOException, URISyntaxException {
+    private void checkSpottyNetworkSchemaless(String topicName, int numberOfPartitions, ClickHouseDeploymentType deploymentType) throws InterruptedException, IOException, URISyntaxException {
         boolean allSuccess = true;
         int runCount = 1;
         do {
             LOGGER.info("Run: {}", runCount);
             confluentPlatform.createTopic(topicName, numberOfPartitions);
-            new CreateTableStatement(STOCK_TABLE) // implicitly SharedMergeTree in CH Cloud
-                .tableName(topicName).ifNotExists(true).execute(chcNoProxy);
-            ClickHouseTestHelpers.clearTable(chcNoProxy, topicName);
 
             int count = generateSchemalessData(topicName, numberOfPartitions, 1500);
-            setupSchemalessConnector(topicName, numberOfPartitions);
+            setupSchemalessConnector(topicName, numberOfPartitions, deploymentType);
 
             clickhouseCloudAPI.restartService();
             confluentPlatform.restartConnector(SINK_CONNECTOR_NAME);
 
             LOGGER.info("Expected Total: {}", count);
-            ClickHouseTestHelpers.waitWhileCounting(chcNoProxy, topicName, 7);
+            ClickHouseTestHelpers.waitWhileCounting(chc, topicName, 7, deploymentType);
 
-            int[] databaseCounts = getCounts(chcNoProxy, topicName);//Essentially the final count
+            int[] databaseCounts = getCounts(chc, topicName, deploymentType);
             if (databaseCounts[2] != 0 || databaseCounts[1] != count) {
                 allSuccess = false;
                 LOGGER.error("Duplicates: {}", databaseCounts[2]);
-                try (Records records = selectDuplicates(chcNoProxy, topicName)) {
+                try (Records records = selectDuplicates(chc, topicName)) {
                     records.forEach(record -> LOGGER.error("Duplicate: {}", record));
                 } catch (Exception e) {
                     throw new RuntimeException(e);
@@ -188,7 +224,7 @@ public class ExactlyOnceTest {
 
             confluentPlatform.deleteConnectors(SINK_CONNECTOR_NAME);
             confluentPlatform.deleteTopic(topicName);
-            ClickHouseTestHelpers.dropTable(chcNoProxy, topicName);
+            ClickHouseTestHelpers.dropTable(chc, topicName, deploymentType);
             runCount++;
         } while (runCount < 3 && allSuccess);
 
@@ -201,9 +237,9 @@ public class ExactlyOnceTest {
         return chc.queryV2(queryString);
     }
 
-    private static int[] getCounts(ClickHouseHelperClient chc, String tableName) {
-        String queryCount = String.format("SELECT count(*) as total, uniqExact(*) as uniqueTotal, total - uniqueTotal FROM `%s`", tableName);
-
+    private static int[] getCounts(ClickHouseHelperClient chc, String tableName, ClickHouseDeploymentType deploymentType) {
+        String from = ClickHouseTestHelpers.buildFromClause(chc, tableName, deploymentType);
+        String queryCount = "SELECT count(*) as total, uniqExact(*) as uniqueTotal, total - uniqueTotal FROM " + from + " SETTINGS select_sequential_consistency = 1";
         try (Records records = chc.queryV2(queryCount)) {
             GenericRecord first = StreamSupport.stream(records.spliterator(), false).findFirst().orElseThrow();
             return Stream.of(first.getInteger(1), first.getInteger(2), first.getInteger(3)).mapToInt(Integer::intValue).toArray();

--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/helper/ConfluentPlatform.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/helper/ConfluentPlatform.java
@@ -140,6 +140,7 @@ public class ConfluentPlatform {
                 .withEnv("CONNECT_CONSUMER_INTERCEPTOR_CLASSES", "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor")
                 .withEnv("CONNECT_PLUGIN_PATH", "/usr/share/java,/usr/share/confluent-hub-components")
                 .withEnv("CONNECT_LOG4J_LOGGERS", "org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR,com.clickhouse=DEBUG")
+                .withExtraHost("host.docker.internal", "host-gateway")
                 .waitingFor(Wait.forHttp("/connectors").forStatusCode(200));
 
         if (connectorPathList != null) {

--- a/src/integrationTest/resources/clickhouse_sink_no_proxy.json
+++ b/src/integrationTest/resources/clickhouse_sink_no_proxy.json
@@ -10,7 +10,7 @@
     "database": "%s",
     "username": "%s",
     "password": "%s",
-    "ssl": "true",
+    "ssl": "%b",
     "exactlyOnce" : "%b"
   }
 }

--- a/src/integrationTest/resources/clickhouse_sink_no_proxy_schemaless.json
+++ b/src/integrationTest/resources/clickhouse_sink_no_proxy_schemaless.json
@@ -12,7 +12,7 @@
     "database": "%s",
     "username": "%s",
     "password": "%s",
-    "ssl": "true",
+    "ssl": "%b",
     "exactlyOnce" : "%b"
   }
 }

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseBase.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseBase.java
@@ -3,6 +3,8 @@ package com.clickhouse.kafka.connect.sink;
 import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.kafka.connect.ClickHouseSinkConnector;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseDeploymentType;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseCluster;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
 import com.google.crypto.tink.internal.Random;
 import org.junit.jupiter.api.AfterAll;
@@ -16,23 +18,39 @@ import org.testcontainers.containers.Network;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ClickHouseBase {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClickHouseBase.class);
     protected ClickHouseContainer db;
-    protected boolean isCloud = ClickHouseTestHelpers.isCloud();
+    protected static boolean isCloud = ClickHouseTestHelpers.isCloud();
+    protected static boolean isCluster = ClickHouseTestHelpers.isCluster();
     protected String database = ClickHouseTestHelpers.DATABASE_DEFAULT;
+
+    public static Stream<ClickHouseDeploymentType> deploymentTypesForTests() {
+        if (isCluster) {
+            return Stream.of(ClickHouseDeploymentType.THREE_SHARDS_ONE_REPLICA_EACH, ClickHouseDeploymentType.ONE_SHARD_THREE_REPLICAS);
+        } else if (isCloud) {
+            return Stream.of(ClickHouseDeploymentType.CLOUD);
+        }
+        return Stream.of(ClickHouseDeploymentType.STANDALONE);
+    }
 
     @BeforeAll
     public void setup() throws IOException {
-        if (!isCloud) {
+        if (isCluster) {
+            // cluster lifecycle is managed by Gradle and must be started before tests run
+            if (!ClickHouseCluster.isStarted()) {
+                throw new IOException("cluster is not running - aborting tests");
+            }
+        } else if (!isCloud) {
             setupContainer(ClickHouseTestHelpers.CLICKHOUSE_DOCKER_IMAGE);
         }
 
         try (var tmpClient = ClickHouseTestHelpers.createClient(getBaseProps())) {
             setDatabase(String.format("kafka_connect_test_%d_%s", Math.abs(Random.randInt()), System.currentTimeMillis()));
-            ClickHouseTestHelpers.createDatabase(database, tmpClient);
+            ClickHouseTestHelpers.createDatabase(database, tmpClient, isCluster ? ClickHouseDeploymentType.THREE_SHARDS_ONE_REPLICA_EACH : ClickHouseDeploymentType.STANDALONE);
             tmpClient.ping();
         }
     }
@@ -54,7 +72,7 @@ public class ClickHouseBase {
 
     @AfterAll
     protected void tearDown() {
-        if (!isCloud) {
+        if (!isCloud && !isCluster) {
             ClickHouseContainer ch = getDb();
             if (ch != null) {
                 LOGGER.info("Stopping db container: id={}, port={}", ch.getContainerId(), ch.getMappedPort(8123));
@@ -101,6 +119,13 @@ public class ClickHouseBase {
             props.put(ClickHouseSinkConnector.SSL_ENABLED, "true");
             props.put(String.valueOf(ClickHouseClientOption.CONNECTION_TIMEOUT), "60000");
             props.put("clickhouseSettings", "insert_quorum=3");
+        } else if (isCluster) {
+            props.put(ClickHouseSinkConnector.HOSTNAME, ClickHouseCluster.getHost());
+            props.put(ClickHouseSinkConnector.PORT, ClickHouseCluster.getPort().toString());
+            props.put(ClickHouseSinkConnector.DATABASE, database);
+            props.put(ClickHouseSinkConnector.USERNAME, ClickHouseTestHelpers.USERNAME_DEFAULT);
+            props.put(ClickHouseSinkConnector.PASSWORD, "");
+            props.put(ClickHouseSinkConnector.SSL_ENABLED, "false");
         } else {
             props.put(ClickHouseSinkConnector.HOSTNAME, getDb().getHost());
             props.put(ClickHouseSinkConnector.PORT, getDb().getMappedPort(8123).toString());

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseBase.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseBase.java
@@ -120,12 +120,7 @@ public class ClickHouseBase {
             props.put(String.valueOf(ClickHouseClientOption.CONNECTION_TIMEOUT), "60000");
             props.put("clickhouseSettings", "insert_quorum=3");
         } else if (isCluster) {
-            props.put(ClickHouseSinkConnector.HOSTNAME, ClickHouseCluster.getHost());
-            props.put(ClickHouseSinkConnector.PORT, ClickHouseCluster.getPort().toString());
-            props.put(ClickHouseSinkConnector.DATABASE, database);
-            props.put(ClickHouseSinkConnector.USERNAME, ClickHouseTestHelpers.USERNAME_DEFAULT);
-            props.put(ClickHouseSinkConnector.PASSWORD, "");
-            props.put(ClickHouseSinkConnector.SSL_ENABLED, "false");
+            props.putAll(ClickHouseCluster.getClusterProps(database));
         } else {
             props.put(ClickHouseSinkConnector.HOSTNAME, getDb().getHost());
             props.put(ClickHouseSinkConnector.PORT, getDb().getMappedPort(8123).toString());

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkJdbcPropertiesTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkJdbcPropertiesTest.java
@@ -7,7 +7,9 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseDeploymentType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,7 +33,6 @@ public class ClickHouseSinkJdbcPropertiesTest extends ClickHouseBase {
             .column("p_float32", "Float32")
             .column("p_float64", "Float64")
             .column("p_bool", "Bool")
-            .engine("MergeTree")
             .orderByColumn("off16");
 
     public Collection<SinkRecord> createPrimitiveTypes(String topic, int partition) {
@@ -165,27 +166,29 @@ public class ClickHouseSinkJdbcPropertiesTest extends ClickHouseBase {
         return array;
     }
 
-    @Test
-    public void primitiveTypesTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void primitiveTypesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.JDBC_CONNECTION_PROPERTIES, "?load_balancing_policy=random&health_check_interval=5000&failover=2");
 
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         // `arr_int8` Array(Int8), `arr_int16` Array(Int16), `arr_int32` Array(Int32), `arr_int64` Array(Int64), `arr_float32` Array(Float32), `arr_float64` Array(Float64), `arr_bool` Array(Bool)
         String topic = createTopicName("schemaless_primitive_types_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(SMALL_INT_TABLE).tableName(topic).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(SMALL_INT_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr = createPrimitiveTypes(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void withEmptyDataRecordsTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void withEmptyDataRecordsTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         if (isCloud) {
             props.put(ClickHouseSinkConfig.JDBC_CONNECTION_PROPERTIES, "?ssl=true&sslmode=none");
@@ -195,14 +198,14 @@ public class ClickHouseSinkJdbcPropertiesTest extends ClickHouseBase {
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         // `arr_int8` Array(Int8), `arr_int16` Array(Int16), `arr_int32` Array(Int32), `arr_int64` Array(Int64), `arr_float32` Array(Float32), `arr_float64` Array(Float64), `arr_bool` Array(Bool)
         String topic = createTopicName("schemaless_empty_records_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(SMALL_INT_TABLE).tableName(topic).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(SMALL_INT_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr = createWithEmptyDataRecords(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size() / 2, ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size() / 2, ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 }

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskBufferTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskBufferTest.java
@@ -2,10 +2,12 @@ package com.clickhouse.kafka.connect.sink;
 
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseDeploymentType;
 import com.clickhouse.kafka.connect.sink.helper.CreateTableStatement;
 import com.clickhouse.kafka.connect.sink.helper.SchemalessTestData;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,16 +40,16 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
             .column("p_float32", "Float32")
             .column("p_float64", "Float64")
             .column("p_bool", "Bool")
-            .engine("MergeTree")
             .orderByColumn("off16");
 
-    @Test
-    public void bufferingDisabledByDefault() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void bufferingDisabledByDefault(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("buffer_disabled_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
 
         Collection<SinkRecord> sr = SchemalessTestData.createPrimitiveTypes(topic, 1);
 
@@ -56,17 +58,18 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         task.put(sr);
         task.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void bufferFlushOnSizeThreshold() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void bufferFlushOnSizeThreshold(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.BUFFER_COUNT, "500");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("buffer_size_flush_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
 
         // Send 300 records (below threshold of 500) - should NOT be flushed yet
         List<SinkRecord> batch1 = SchemalessTestData.createPrimitiveTypes(topic, 1, 300);
@@ -74,34 +77,35 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         task.start(props);
         task.put(batch1);
 
-        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic),
+        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic, deploymentType),
                 "Records should be buffered, not flushed yet");
 
         // Send 300 more records (total 600 > threshold 500) - should trigger flush
         List<SinkRecord> batch2 = SchemalessTestData.createPrimitiveTypes(topic, 1, 300);
         task.put(batch2);
 
-        assertEquals(600, ClickHouseTestHelpers.countRows(chc, topic),
+        assertEquals(600, ClickHouseTestHelpers.countRows(chc, topic, deploymentType),
                 "Buffer should have been flushed after reaching threshold");
 
         task.stop();
     }
 
-    @Test
-    public void bufferGracefulShutdownRedelivers() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void bufferGracefulShutdownRedelivers(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.BUFFER_COUNT, "5000");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("buffer_shutdown_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
 
         List<SinkRecord> records = SchemalessTestData.createPrimitiveTypes(topic, 1, 100);
         ClickHouseSinkTask task = new ClickHouseSinkTask();
         task.start(props);
         task.put(records);
 
-        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic),
+        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic, deploymentType),
                 "Records should be buffered, not flushed yet");
 
         // Simulate real framework shutdown: close(all) then stop()
@@ -111,18 +115,19 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         task.close(Collections.singletonList(tp));
         task.stop();
 
-        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic),
+        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic, deploymentType),
                 "Unflushed records should NOT be written — they'll be redelivered on restart");
     }
 
-    @Test
-    public void bufferRebalanceRemovesRevokedPartitions() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void bufferRebalanceRemovesRevokedPartitions(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.BUFFER_COUNT, "5000");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("buffer_rebalance_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
 
         ClickHouseSinkTask task = new ClickHouseSinkTask();
         task.start(props);
@@ -134,7 +139,7 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         allRecords.addAll(SchemalessTestData.createPrimitiveTypes(topic, 2, 100));
         task.put(allRecords);
 
-        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic),
+        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic, deploymentType),
                 "All 300 records should be buffered");
 
         // Simulate cooperative rebalance: P2 revoked
@@ -148,29 +153,30 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         task.put(moreRecords);
 
         // Only P0 and P1 records should have been written — P2 records were removed by close()
-        int totalRows = ClickHouseTestHelpers.countRows(chc, topic);
+        int totalRows = ClickHouseTestHelpers.countRows(chc, topic, deploymentType);
         assertEquals(5200, totalRows,
                 "Only P0 (2600) + P1 (2600) records should be written, P2 records removed by rebalance");
 
         task.stop();
     }
 
-    @Test
-    public void bufferFlushOnTimeThreshold() throws InterruptedException {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void bufferFlushOnTimeThreshold(ClickHouseDeploymentType deploymentType) throws InterruptedException {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.BUFFER_COUNT, "50000");
         props.put(ClickHouseSinkConfig.BUFFER_FLUSH_TIME, "2000");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("buffer_time_flush_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
 
         List<SinkRecord> records = SchemalessTestData.createPrimitiveTypes(topic, 1, 100);
         ClickHouseSinkTask task = new ClickHouseSinkTask();
         task.start(props);
         task.put(records);
 
-        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic),
+        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic, deploymentType),
                 "Records should be buffered, not flushed yet");
 
         // Wait for the time threshold to pass
@@ -179,20 +185,21 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         // Next put (even empty) should trigger time-based flush
         task.put(new ArrayList<>());
 
-        assertEquals(100, ClickHouseTestHelpers.countRows(chc, topic),
+        assertEquals(100, ClickHouseTestHelpers.countRows(chc, topic, deploymentType),
                 "Buffered records should be flushed after time threshold");
 
         task.stop();
     }
 
-    @Test
-    public void bufferAccumulatesMultipleBatches() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void bufferAccumulatesMultipleBatches(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.BUFFER_COUNT, "2500");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("buffer_multi_batch_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
 
         ClickHouseSinkTask task = new ClickHouseSinkTask();
         task.start(props);
@@ -206,7 +213,7 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         }
 
         // 5 * 400 = 2000, still below 2500 threshold
-        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic),
+        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic, deploymentType),
                 "Records should still be buffered (2000 < 2500)");
 
         // One more batch to push over threshold
@@ -214,14 +221,15 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         task.put(finalBatch);
         totalRecords += finalBatch.size();
 
-        assertEquals(totalRecords, ClickHouseTestHelpers.countRows(chc, topic),
+        assertEquals(totalRecords, ClickHouseTestHelpers.countRows(chc, topic, deploymentType),
                 "All accumulated records should be flushed after crossing threshold");
 
         task.stop();
     }
 
-    @Test
-    public void bufferIncompatibleWithExactlyOnce() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void bufferIncompatibleWithExactlyOnce(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.BUFFER_COUNT, "500");
         props.put(ClickHouseSinkConfig.EXACTLY_ONCE, "true");
@@ -233,8 +241,9 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
 
     // ==================== Offset management tests (crash & rebalance safety) ====================
 
-    @Test
-    public void preCommitReturnsEmptyWhenAllBuffered() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void preCommitReturnsEmptyWhenAllBuffered(ClickHouseDeploymentType deploymentType) {
         // Simulates crash safety: if records are only buffered (not flushed to CH),
         // preCommit() must return empty so offsets are NOT committed.
         // On crash/restart, Kafka redelivers these records.
@@ -242,8 +251,8 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         props.put(ClickHouseSinkConfig.BUFFER_COUNT, "5000");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("precommit_empty_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
 
         ClickHouseSinkTask task = new ClickHouseSinkTask();
         task.start(props);
@@ -264,16 +273,17 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         task.stop();
     }
 
-    @Test
-    public void preCommitReturnsCorrectOffsetsAfterFlush() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void preCommitReturnsCorrectOffsetsAfterFlush(ClickHouseDeploymentType deploymentType) {
         // After buffer flushes to ClickHouse, preCommit() must return the correct
         // offsets so the framework commits them.
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.BUFFER_COUNT, "500");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("precommit_offset_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
 
         ClickHouseSinkTask task = new ClickHouseSinkTask();
         task.start(props);
@@ -285,7 +295,7 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         task.put(allRecords);
 
         // Verify data reached ClickHouse
-        assertEquals(600, ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(600, ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
 
         // preCommit should return offsets for both partitions
         Map<TopicPartition, OffsetAndMetadata> currentOffsets = new java.util.HashMap<>();
@@ -301,16 +311,17 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         task.stop();
     }
 
-    @Test
-    public void preCommitClearsAfterReturning() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void preCommitClearsAfterReturning(ClickHouseDeploymentType deploymentType) {
         // After preCommit() returns offsets, the next call should return empty
         // if no new data was flushed (matches S3's getOffsetToCommitAndReset pattern).
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.BUFFER_COUNT, "500");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("precommit_reset_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
 
         ClickHouseSinkTask task = new ClickHouseSinkTask();
         task.start(props);
@@ -329,16 +340,17 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         task.stop();
     }
 
-    @Test
-    public void preCommitExcludesRevokedPartitionsAfterRebalance() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void preCommitExcludesRevokedPartitionsAfterRebalance(ClickHouseDeploymentType deploymentType) {
         // After close() revokes a partition, preCommit() must NOT return offsets
         // for that partition, even if data was previously flushed for it.
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.BUFFER_COUNT, "500");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("precommit_rebalance_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
 
         ClickHouseSinkTask task = new ClickHouseSinkTask();
         task.start(props);
@@ -350,7 +362,7 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         allRecords.addAll(SchemalessTestData.createPrimitiveTypes(topic, 2, 200));
         task.put(allRecords);
 
-        assertEquals(600, ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(600, ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
 
         // Simulate rebalance: revoke P2
         task.close(Collections.singletonList(new TopicPartition(topic, 2)));
@@ -366,8 +378,9 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         task.stop();
     }
 
-    @Test
-    public void crashAfterFlushIsIdempotent() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void crashAfterFlushIsIdempotent(ClickHouseDeploymentType deploymentType) {
         // Verifies that if ClickHouse receives data and then a crash happens
         // AFTER preCommit but BEFORE the framework commits, the data is safe:
         // Kafka will redeliver, and ClickHouse gets duplicates (at-least-once).
@@ -376,8 +389,8 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         props.put(ClickHouseSinkConfig.BUFFER_COUNT, "500");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("crash_after_flush_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
 
         ClickHouseSinkTask task = new ClickHouseSinkTask();
         task.start(props);
@@ -385,7 +398,7 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         // Batch 1: flush 600 records
         List<SinkRecord> batch1 = SchemalessTestData.createPrimitiveTypes(topic, 1, 600);
         task.put(batch1);
-        assertEquals(600, ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(600, ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
 
         Map<TopicPartition, OffsetAndMetadata> offsets1 = task.preCommit(new java.util.HashMap<>());
         assertEquals(600, offsets1.get(new TopicPartition(topic, 1)).offset());
@@ -393,7 +406,7 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         // Batch 2: buffer 200 records (below threshold, not flushed)
         List<SinkRecord> batch2 = SchemalessTestData.createPrimitiveTypes(topic, 1, 200);
         task.put(batch2);
-        assertEquals(600, ClickHouseTestHelpers.countRows(chc, topic),
+        assertEquals(600, ClickHouseTestHelpers.countRows(chc, topic, deploymentType),
                 "Batch 2 should still be buffered");
 
         // preCommit returns empty — batch 2 not flushed
@@ -411,16 +424,17 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
 
     // ==================== Insert failure edge cases (putDirect fails) ====================
 
-    @Test
-    public void putDirectFailsNoErrorTolerance_offsetsNotCommitted() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void putDirectFailsNoErrorTolerance_offsetsNotCommitted(ClickHouseDeploymentType deploymentType) {
         // Edge case: buffer flush triggers putDirect → insert fails → exception propagates.
         // Offsets must NOT be committed so Kafka redelivers on restart (at-least-once).
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.BUFFER_COUNT, "500");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("insert_fail_no_tolerance_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
 
         ClickHouseSinkTask task = new ClickHouseSinkTask();
         task.start(props);
@@ -429,11 +443,11 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         List<SinkRecord> batch1 = SchemalessTestData.createPrimitiveTypes(topic, 1, 300);
         task.put(batch1);
 
-        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic),
+        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic, deploymentType),
                 "Records should be buffered, not flushed yet");
 
         // Drop the table to make the next insert fail
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
 
         // Add 300 more records to cross threshold → triggers flush → insert fails
         List<SinkRecord> batch2 = SchemalessTestData.createPrimitiveTypes(topic, 1, 300);
@@ -449,8 +463,9 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         task.stop();
     }
 
-    @Test
-    public void putDirectFailsWithErrorTolerance_offsetsCommitted() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void putDirectFailsWithErrorTolerance_offsetsCommitted(ClickHouseDeploymentType deploymentType) {
         // Edge case: buffer flush triggers putDirect → insert fails → error tolerance swallows it.
         // With error tolerance, records go to DLQ and offsets ARE committed (same as non-buffered behavior).
         Map<String, String> props = getBaseProps();
@@ -458,8 +473,8 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         props.put(ClickHouseSinkConfig.ERRORS_TOLERANCE, ClickHouseSinkConfig.ERROR_TOLERANCE_ALL);
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("insert_fail_tolerance_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
 
         ClickHouseSinkTask task = new ClickHouseSinkTask();
         task.start(props);
@@ -469,7 +484,7 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         task.put(batch1);
 
         // Drop the table to make the next insert fail
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
 
         // Add 300 more records to cross threshold → triggers flush → insert fails but is tolerated
         List<SinkRecord> batch2 = SchemalessTestData.createPrimitiveTypes(topic, 1, 300);
@@ -489,14 +504,15 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
 
     // ==================== Partition tests ====================
 
-    @Test
-    public void bufferMultiplePartitions() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void bufferMultiplePartitions(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.BUFFER_COUNT, "500");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("buffer_multi_partition_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
 
         ClickHouseSinkTask task = new ClickHouseSinkTask();
         task.start(props);
@@ -510,7 +526,7 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         task.put(allRecords);
 
         // 600 > 500 threshold, should be flushed
-        assertEquals(600, ClickHouseTestHelpers.countRows(chc, topic),
+        assertEquals(600, ClickHouseTestHelpers.countRows(chc, topic, deploymentType),
                 "Records from all partitions should be flushed together");
 
         task.stop();

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskBufferTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskBufferTest.java
@@ -6,6 +6,7 @@ import com.clickhouse.kafka.connect.sink.helper.ClickHouseDeploymentType;
 import com.clickhouse.kafka.connect.sink.helper.CreateTableStatement;
 import com.clickhouse.kafka.connect.sink.helper.SchemalessTestData;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
@@ -227,9 +228,8 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
         task.stop();
     }
 
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("deploymentTypesForTests")
-    public void bufferIncompatibleWithExactlyOnce(ClickHouseDeploymentType deploymentType) {
+    @Test
+    public void bufferIncompatibleWithExactlyOnce() {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.BUFFER_COUNT, "500");
         props.put(ClickHouseSinkConfig.EXACTLY_ONCE, "true");

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskMappingTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskMappingTest.java
@@ -2,11 +2,13 @@ package com.clickhouse.kafka.connect.sink;
 
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseDeploymentType;
 import com.clickhouse.kafka.connect.sink.helper.CreateTableStatement;
 import com.clickhouse.kafka.connect.sink.helper.SchemaTestData;
 import com.clickhouse.kafka.connect.sink.helper.SchemalessTestData;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collection;
 import java.util.Map;
@@ -20,36 +22,38 @@ public class ClickHouseSinkTaskMappingTest extends ClickHouseBase{
             .column("p_int8", "Int8").column("p_int16", "Int16").column("p_int32", "Int32")
             .column("p_int64", "Int64").column("p_float32", "Float32")
             .column("p_float64", "Float64").column("p_bool", "Bool")
-            .engine("MergeTree").orderByColumn("off16");
+            .orderByColumn("off16");
 
     private static final CreateTableStatement ARRAY_TYPES_TABLE = new CreateTableStatement()
             .column("off16", "Int16").column("arr", "Array(String)").column("arr_empty", "Array(String)")
             .column("arr_int8", "Array(Int8)").column("arr_int16", "Array(Int16)").column("arr_int32", "Array(Int32)")
             .column("arr_int64", "Array(Int64)").column("arr_float32", "Array(Float32)")
             .column("arr_float64", "Array(Float64)").column("arr_bool", "Array(Bool)")
-            .engine("MergeTree").orderByColumn("off16");
+            .orderByColumn("off16");
 
-    @Test
-    public void schemalessSingleTableMappingTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void schemalessSingleTableMappingTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.TABLE_MAPPING, "mapping_table_test=table_mapping_test");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = "mapping_table_test";
         String tableName = "table_mapping_test";
-        ClickHouseTestHelpers.dropTable(chc, tableName);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(tableName).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, tableName, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(tableName).deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr = SchemalessTestData.createPrimitiveTypes(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, tableName));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, tableName, deploymentType));
     }
 
-    @Test
-    public void schemalessMultiDifferentTableMappingTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void schemalessMultiDifferentTableMappingTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.TABLE_MAPPING, "mapping_table_test=table_mapping_test, mapping_table_test2=table_mapping_test2");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
@@ -58,10 +62,10 @@ public class ClickHouseSinkTaskMappingTest extends ClickHouseBase{
         String topic2 = "mapping_table_test2";
         String tableName1 = "table_mapping_test";
         String tableName2 = "table_mapping_test2";
-        ClickHouseTestHelpers.dropTable(chc, tableName1);
-        ClickHouseTestHelpers.dropTable(chc, tableName2);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(tableName1).execute(chc);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(tableName2).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, tableName1, deploymentType);
+        ClickHouseTestHelpers.dropTable(chc, tableName2, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(tableName1).deploymentType(deploymentType).execute(chc);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(tableName2).deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr1 = SchemalessTestData.createPrimitiveTypes(topic1, 1);
         Collection<SinkRecord> sr2 = SchemalessTestData.createPrimitiveTypes(topic2, 1);
 
@@ -70,12 +74,13 @@ public class ClickHouseSinkTaskMappingTest extends ClickHouseBase{
         chst.put(sr1);
         chst.put(sr2);
         chst.stop();
-        assertEquals(sr1.size(), ClickHouseTestHelpers.countRows(chc, tableName1));
-        assertEquals(sr2.size(), ClickHouseTestHelpers.countRows(chc, tableName2));
+        assertEquals(sr1.size(), ClickHouseTestHelpers.countRows(chc, tableName1, deploymentType));
+        assertEquals(sr2.size(), ClickHouseTestHelpers.countRows(chc, tableName2, deploymentType));
     }
 
-    @Test
-    public void schemalessMultiSameTableMappingTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void schemalessMultiSameTableMappingTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.TABLE_MAPPING, "mapping_table_test=table_mapping_test, mapping_table_test2=table_mapping_test");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
@@ -83,8 +88,8 @@ public class ClickHouseSinkTaskMappingTest extends ClickHouseBase{
         String topic1 = "mapping_table_test";
         String topic2 = "mapping_table_test2";
         String tableName = "table_mapping_test";
-        ClickHouseTestHelpers.dropTable(chc, tableName);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(tableName).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, tableName, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(tableName).deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr1 = SchemalessTestData.createPrimitiveTypes(topic1, 1);
         Collection<SinkRecord> sr2 = SchemalessTestData.createPrimitiveTypes(topic2, 1);
 
@@ -93,11 +98,12 @@ public class ClickHouseSinkTaskMappingTest extends ClickHouseBase{
         chst.put(sr1);
         chst.put(sr2);
         chst.stop();
-        assertEquals(sr1.size() + sr2.size(), ClickHouseTestHelpers.countRows(chc, tableName));
+        assertEquals(sr1.size() + sr2.size(), ClickHouseTestHelpers.countRows(chc, tableName, deploymentType));
     }
 
-    @Test
-    public void schemalessMixedTableMappingTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void schemalessMixedTableMappingTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.TABLE_MAPPING, "mapping_table_test=table_mapping_test, mapping_table_test2=table_mapping_test2");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
@@ -107,12 +113,12 @@ public class ClickHouseSinkTaskMappingTest extends ClickHouseBase{
         String topic3 = "mapping_table_test3";
         String tableName1 = "table_mapping_test";
         String tableName2 = "table_mapping_test2";
-        ClickHouseTestHelpers.dropTable(chc, tableName1);
-        ClickHouseTestHelpers.dropTable(chc, tableName2);
-        ClickHouseTestHelpers.dropTable(chc, topic3);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(tableName1).execute(chc);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(tableName2).execute(chc);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic3).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, tableName1, deploymentType);
+        ClickHouseTestHelpers.dropTable(chc, tableName2, deploymentType);
+        ClickHouseTestHelpers.dropTable(chc, topic3, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(tableName1).deploymentType(deploymentType).execute(chc);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(tableName2).deploymentType(deploymentType).execute(chc);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic3).deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr1 = SchemalessTestData.createPrimitiveTypes(topic1, 1);
         Collection<SinkRecord> sr2 = SchemalessTestData.createPrimitiveTypes(topic2, 1);
         Collection<SinkRecord> sr3 = SchemalessTestData.createPrimitiveTypes(topic3, 1);
@@ -123,21 +129,22 @@ public class ClickHouseSinkTaskMappingTest extends ClickHouseBase{
         chst.put(sr2);
         chst.put(sr3);
         chst.stop();
-        assertEquals(sr1.size(), ClickHouseTestHelpers.countRows(chc, tableName1));
-        assertEquals(sr2.size(), ClickHouseTestHelpers.countRows(chc, tableName2));
-        assertEquals(sr3.size(), ClickHouseTestHelpers.countRows(chc, topic3));
+        assertEquals(sr1.size(), ClickHouseTestHelpers.countRows(chc, tableName1, deploymentType));
+        assertEquals(sr2.size(), ClickHouseTestHelpers.countRows(chc, tableName2, deploymentType));
+        assertEquals(sr3.size(), ClickHouseTestHelpers.countRows(chc, topic3, deploymentType));
     }
 
-    @Test
-    public void schemaArrayTypesSingleTableMappingTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void schemaArrayTypesSingleTableMappingTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.TABLE_MAPPING, "array_string_table_test=array_string_mapping_table_test");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = "array_string_table_test";
         String tableName = "array_string_mapping_table_test";
-        ClickHouseTestHelpers.dropTable(chc, tableName);
-        new CreateTableStatement(ARRAY_TYPES_TABLE).tableName(tableName).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, tableName, deploymentType);
+        new CreateTableStatement(ARRAY_TYPES_TABLE).tableName(tableName).deploymentType(deploymentType).execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createArrayType(topic, 1);
 
@@ -146,11 +153,12 @@ public class ClickHouseSinkTaskMappingTest extends ClickHouseBase{
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, tableName));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, tableName, deploymentType));
     }
 
-    @Test
-    public void schemaArrayTypesMultipleDifferentTableMappingTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void schemaArrayTypesMultipleDifferentTableMappingTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.TABLE_MAPPING, "array_string_table_test=array_string_mapping_table_test, array_string_table_test2=array_string_mapping_table_test2");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
@@ -159,10 +167,10 @@ public class ClickHouseSinkTaskMappingTest extends ClickHouseBase{
         String topic2 = "array_string_table_test2";
         String tableName1 = "array_string_mapping_table_test";
         String tableName2 = "array_string_mapping_table_test2";
-        ClickHouseTestHelpers.dropTable(chc, tableName1);
-        ClickHouseTestHelpers.dropTable(chc, tableName2);
-        new CreateTableStatement(ARRAY_TYPES_TABLE).tableName(tableName1).execute(chc);
-        new CreateTableStatement(ARRAY_TYPES_TABLE).tableName(tableName2).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, tableName1, deploymentType);
+        ClickHouseTestHelpers.dropTable(chc, tableName2, deploymentType);
+        new CreateTableStatement(ARRAY_TYPES_TABLE).tableName(tableName1).deploymentType(deploymentType).execute(chc);
+        new CreateTableStatement(ARRAY_TYPES_TABLE).tableName(tableName2).deploymentType(deploymentType).execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr1 = SchemaTestData.createArrayType(topic1, 1);
         Collection<SinkRecord> sr2 = SchemaTestData.createArrayType(topic2, 1);
@@ -173,13 +181,14 @@ public class ClickHouseSinkTaskMappingTest extends ClickHouseBase{
         chst.put(sr2);
         chst.stop();
 
-        assertEquals(sr1.size(), ClickHouseTestHelpers.countRows(chc, tableName1));
-        assertEquals(sr2.size(), ClickHouseTestHelpers.countRows(chc, tableName2));
+        assertEquals(sr1.size(), ClickHouseTestHelpers.countRows(chc, tableName1, deploymentType));
+        assertEquals(sr2.size(), ClickHouseTestHelpers.countRows(chc, tableName2, deploymentType));
     }
 
 
-    @Test
-    public void schemaArrayTypesMultipleSameTableMappingTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void schemaArrayTypesMultipleSameTableMappingTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.TABLE_MAPPING, "array_string_table_test=array_string_mapping_table_test, array_string_table_test2=array_string_mapping_table_test");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
@@ -187,8 +196,8 @@ public class ClickHouseSinkTaskMappingTest extends ClickHouseBase{
         String topic1 = "array_string_table_test";
         String topic2 = "array_string_table_test2";
         String tableName = "array_string_mapping_table_test";
-        ClickHouseTestHelpers.dropTable(chc, tableName);
-        new CreateTableStatement(ARRAY_TYPES_TABLE).tableName(tableName).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, tableName, deploymentType);
+        new CreateTableStatement(ARRAY_TYPES_TABLE).tableName(tableName).deploymentType(deploymentType).execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr1 = SchemaTestData.createArrayType(topic1, 1);
         Collection<SinkRecord> sr2 = SchemaTestData.createArrayType(topic2, 1);
@@ -199,11 +208,12 @@ public class ClickHouseSinkTaskMappingTest extends ClickHouseBase{
         chst.put(sr2);
         chst.stop();
 
-        assertEquals(sr1.size() + sr2.size(), ClickHouseTestHelpers.countRows(chc, tableName));
+        assertEquals(sr1.size() + sr2.size(), ClickHouseTestHelpers.countRows(chc, tableName, deploymentType));
     }
 
-    @Test
-    public void schemaArrayTypesMixedTableMappingTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void schemaArrayTypesMixedTableMappingTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.TABLE_MAPPING, "array_string_table_test=array_string_mapping_table_test, array_string_table_test2=array_string_mapping_table_test2");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
@@ -213,12 +223,12 @@ public class ClickHouseSinkTaskMappingTest extends ClickHouseBase{
         String topic3 = "array_string_table_test3";
         String tableName1 = "array_string_mapping_table_test";
         String tableName2 = "array_string_mapping_table_test2";
-        ClickHouseTestHelpers.dropTable(chc, tableName1);
-        ClickHouseTestHelpers.dropTable(chc, tableName2);
-        ClickHouseTestHelpers.dropTable(chc, topic3);
-        new CreateTableStatement(ARRAY_TYPES_TABLE).tableName(tableName1).execute(chc);
-        new CreateTableStatement(ARRAY_TYPES_TABLE).tableName(tableName2).execute(chc);
-        new CreateTableStatement(ARRAY_TYPES_TABLE).tableName(topic3).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, tableName1, deploymentType);
+        ClickHouseTestHelpers.dropTable(chc, tableName2, deploymentType);
+        ClickHouseTestHelpers.dropTable(chc, topic3, deploymentType);
+        new CreateTableStatement(ARRAY_TYPES_TABLE).tableName(tableName1).deploymentType(deploymentType).execute(chc);
+        new CreateTableStatement(ARRAY_TYPES_TABLE).tableName(tableName2).deploymentType(deploymentType).execute(chc);
+        new CreateTableStatement(ARRAY_TYPES_TABLE).tableName(topic3).deploymentType(deploymentType).execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr1 = SchemaTestData.createArrayType(topic1, 1);
         Collection<SinkRecord> sr2 = SchemaTestData.createArrayType(topic2, 1);
@@ -231,8 +241,8 @@ public class ClickHouseSinkTaskMappingTest extends ClickHouseBase{
         chst.put(sr3);
         chst.stop();
 
-        assertEquals(sr1.size(), ClickHouseTestHelpers.countRows(chc, tableName1));
-        assertEquals(sr2.size(), ClickHouseTestHelpers.countRows(chc, tableName2));
-        assertEquals(sr3.size(), ClickHouseTestHelpers.countRows(chc, topic3));
+        assertEquals(sr1.size(), ClickHouseTestHelpers.countRows(chc, tableName1, deploymentType));
+        assertEquals(sr2.size(), ClickHouseTestHelpers.countRows(chc, tableName2, deploymentType));
+        assertEquals(sr3.size(), ClickHouseTestHelpers.countRows(chc, topic3, deploymentType));
     }
 }

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessProxyTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessProxyTest.java
@@ -2,20 +2,19 @@ package com.clickhouse.kafka.connect.sink;
 
 import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
-import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
-import com.clickhouse.kafka.connect.sink.helper.CreateTableStatement;
-import com.clickhouse.kafka.connect.sink.helper.SchemalessTestData;
+import com.clickhouse.kafka.connect.sink.helper.*;
 import eu.rekawek.toxiproxy.Proxy;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.toxiproxy.ToxiproxyContainer;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -43,7 +42,7 @@ public class ClickHouseSinkTaskSchemalessProxyTest extends ClickHouseBase {
             .column("p_int8", "Int8").column("p_int16", "Int16").column("p_int32", "Int32")
             .column("p_int64", "Int64").column("p_float32", "Float32")
             .column("p_float64", "Float64").column("p_bool", "Bool")
-            .engine("MergeTree").orderByColumn("off16");
+            .orderByColumn("off16");
 
     private static final CreateTableStatement MAP_TYPES_TABLE = new CreateTableStatement()
             .column("off16", "Int16").column("map_string_string", "Map(String, String)")
@@ -51,20 +50,33 @@ public class ClickHouseSinkTaskSchemalessProxyTest extends ClickHouseBase {
             .column("map_string_map", "Map(String, Map(String, Int64))")
             .column("map_string_array", "Map(String, Array(String))")
             .column("map_map_map", "Map(String, Map(String, Map(String, String)))")
-            .engine("MergeTree").orderByColumn("off16");
+            .orderByColumn("off16");
 
     @BeforeAll
     public void setup() throws IOException {
         super.setup();
 
-        toxiproxy = new ToxiproxyContainer(ClickHouseTestHelpers.TOXIPROXY_DOCKER_IMAGE_NAME).withNetwork(isCloud ? Network.newNetwork() : db.getNetwork()).withNetworkAliases(ClickHouseTestHelpers.TOXIPROXY_NETWORK_ALIAS);
+        toxiproxy = new ToxiproxyContainer(ClickHouseTestHelpers.TOXIPROXY_DOCKER_IMAGE_NAME)
+                .withNetwork(isCluster || isCloud ? Network.newNetwork() : db.getNetwork())
+                .withNetworkAliases(ClickHouseTestHelpers.TOXIPROXY_NETWORK_ALIAS);
+        if (isCluster) {
+            toxiproxy = toxiproxy.withExtraHost("host.docker.internal", "host-gateway");
+        }
         toxiproxy.start();
 
         log.info("Started proxy container: {}", toxiproxy.getControlPort());
         ToxiproxyClient toxiproxyClient = new ToxiproxyClient(toxiproxy.getHost(), toxiproxy.getControlPort());
 
         ClickHouseSinkConfig csc = new ClickHouseSinkConfig(getBaseProps());
-        proxy = toxiproxyClient.createProxy("clickhouse-proxy", "0.0.0.0:" + PROXY_PORT, isCloud ? String.format("%s:%d", csc.getHostname(), csc.getPort()) : String.format("%s:%d", ClickHouseTestHelpers.CLICKHOUSE_DB_NETWORK_ALIAS, ClickHouseProtocol.HTTP.getDefaultPort()));
+        String upstream;
+        if (isCloud) {
+            upstream = String.format("%s:%d", csc.getHostname(), csc.getPort());
+        } else if (isCluster) {
+            upstream = String.format("host.docker.internal:%d", ClickHouseCluster.getPort());
+        } else {
+            upstream = String.format("%s:%d", ClickHouseTestHelpers.CLICKHOUSE_DB_NETWORK_ALIAS, ClickHouseProtocol.HTTP.getDefaultPort());
+        }
+        proxy = toxiproxyClient.createProxy("clickhouse-proxy", "0.0.0.0:" + PROXY_PORT, upstream);
         log.info("Proxy configured {}", proxy.getListen());
     }
 
@@ -97,8 +109,9 @@ public class ClickHouseSinkTaskSchemalessProxyTest extends ClickHouseBase {
         return props;
     }
 
-    @Test
-    public void proxyPingTest() throws IOException {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void proxyPingTest(ClickHouseDeploymentType deploymentType) throws IOException {
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(getTestProperties());
         assertTrue(chc.ping());
         proxy.disable();
@@ -107,66 +120,70 @@ public class ClickHouseSinkTaskSchemalessProxyTest extends ClickHouseBase {
         assertTrue(chc.ping());
     }
 
-    @Test
-    public void primitiveTypesTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void primitiveTypesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
-        String topic = "schemaless_primitive_types_table_test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        String topic = createTopicName("schemaless_primitive_types_table_test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr = SchemalessTestData.createPrimitiveTypes(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void withEmptyDataRecordsTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void withEmptyDataRecordsTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
-        String topic = "schemaless_empty_records_table_test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        String topic = createTopicName("schemaless_empty_records_table_test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr = SchemalessTestData.createWithEmptyDataRecords(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size() / 2, ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size() / 2, ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void NullableValuesTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void NullableValuesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
-        String topic = "schemaless_nullable_values_table_test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        String topic = createTopicName("schemaless_nullable_values_table_test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16").column("str", "String").column("null_str", "Nullable(String)")
                 .column("p_int8", "Int8").column("p_int16", "Int16").column("p_int32", "Int32")
                 .column("p_int64", "Int64").column("p_float32", "Float32").column("p_float64", "Float64").column("p_bool", "Bool")
-                .engine("MergeTree").orderByColumn("off16").execute(chc);
+                .orderByColumn("off16").deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr = SchemalessTestData.createPrimitiveTypesWithNulls(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void arrayTypesTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void arrayTypesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
-        String topic = "schemaless_array_string_table_test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        String topic = createTopicName("schemaless_array_string_table_test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16").column("arr", "Array(String)").column("arr_empty", "Array(String)")
@@ -174,7 +191,7 @@ public class ClickHouseSinkTaskSchemalessProxyTest extends ClickHouseBase {
                 .column("arr_int64", "Array(Int64)").column("arr_float32", "Array(Float32)").column("arr_float64", "Array(Float64)")
                 .column("arr_bool", "Array(Bool)").column("arr_str_arr", "Array(Array(String))")
                 .column("arr_arr_str_arr", "Array(Array(Array(String)))").column("arr_map", "Array(Map(String, String))")
-                .engine("MergeTree").orderByColumn("off16").execute(chc);
+                .orderByColumn("off16").deploymentType(deploymentType).execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemalessTestData.createArrayType(topic, 1);
 
@@ -182,17 +199,18 @@ public class ClickHouseSinkTaskSchemalessProxyTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void mapTypesTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void mapTypesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
-        String topic = "schemaless_map_table_test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(MAP_TYPES_TABLE).tableName(topic).execute(chc);
+        String topic = createTopicName("schemaless_map_table_test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(MAP_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
 
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemalessTestData.createMapType(topic, 1);
@@ -201,18 +219,19 @@ public class ClickHouseSinkTaskSchemalessProxyTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
     // https://github.com/ClickHouse/clickhouse-kafka-connect/issues/38
-    public void specialCharTableNameTest() {
+    public void specialCharTableNameTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
-        String topic = "special-char-table-test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(MAP_TYPES_TABLE).tableName(topic).execute(chc);
+        String topic = createTopicName("special-char-table-test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(MAP_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemalessTestData.createMapType(topic, 1);
 
@@ -220,57 +239,62 @@ public class ClickHouseSinkTaskSchemalessProxyTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void emojisCharsDataTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void emojisCharsDataTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
-        String topic = "emojis_table_test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        String topic = createTopicName("emojis_table_test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic).column("off16", "Int16").column("str", "String")
-                .engine("MergeTree").orderByColumn("off16").execute(chc);
+                .orderByColumn("off16").deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr = SchemalessTestData.createDataWithEmojis(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size() / 2, ClickHouseTestHelpers.countRowsWithEmojis(chc, topic));
+        assertEquals(sr.size() / 2, ClickHouseTestHelpers.countRowsWithEmojis(chc, topic, deploymentType));
     }
 
-    @Test
-    public void tableMappingTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void tableMappingTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         props.put(ClickHouseSinkConfig.TABLE_MAPPING, "mapping_table_test=table_mapping_test");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = "mapping_table_test";
-        String tableName = "table_mapping_test";
-        ClickHouseTestHelpers.dropTable(chc, tableName);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(tableName).execute(chc);
+        String tableName = createTopicName("table_mapping_test");
+        // Update table mapping to use unique table name
+        props.put(ClickHouseSinkConfig.TABLE_MAPPING, topic + "=" + tableName);
+        ClickHouseTestHelpers.dropTable(chc, tableName, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(tableName).deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr = SchemalessTestData.createPrimitiveTypes(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, tableName));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, tableName, deploymentType));
     }
 
-    @Test
-    public void decimalDataTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void decimalDataTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
-        String topic = "decimal_table_test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        String topic = createTopicName("decimal_table_test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic).column("num", "String").column("decimal_14_2", "Decimal(14, 2)")
-                .engine("MergeTree").orderByColumn("num").execute(chc);
+                .orderByColumn("num").deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr = SchemalessTestData.createDecimalTypes(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
@@ -278,7 +302,7 @@ public class ClickHouseSinkTaskSchemalessProxyTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
-        assertEquals(499700, ClickHouseTestHelpers.sumRows(chc, topic, "decimal_14_2"));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
+        assertEquals(499700, ClickHouseTestHelpers.sumRows(chc, topic, "decimal_14_2", deploymentType));
     }
 }

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessProxyTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessProxyTest.java
@@ -8,6 +8,7 @@ import eu.rekawek.toxiproxy.ToxiproxyClient;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -109,9 +110,8 @@ public class ClickHouseSinkTaskSchemalessProxyTest extends ClickHouseBase {
         return props;
     }
 
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("deploymentTypesForTests")
-    public void proxyPingTest(ClickHouseDeploymentType deploymentType) throws IOException {
+    @Test
+    public void proxyPingTest() throws IOException {
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(getTestProperties());
         assertTrue(chc.ping());
         proxy.disable();

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskSchemalessTest.java
@@ -3,13 +3,15 @@ package com.clickhouse.kafka.connect.sink;
 import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseDeploymentType;
 import com.clickhouse.kafka.connect.sink.helper.CreateTableStatement;
 import com.clickhouse.kafka.connect.sink.helper.SchemalessTestData;
 import com.clickhouse.kafka.connect.test.junit.extension.FromVersionConditionExtension;
 import com.clickhouse.kafka.connect.test.junit.extension.SinceClickHouseVersion;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.Serializable;
 import java.util.Collection;
@@ -32,74 +34,77 @@ public class ClickHouseSinkTaskSchemalessTest extends ClickHouseBase {
             .column("p_float32", "Float32")
             .column("p_float64", "Float64")
             .column("p_bool", "Bool")
-            .engine("MergeTree")
             .orderByColumn("off16");
 
-    @Test
-    public void primitiveTypesTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void primitiveTypesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         // `arr_int8` Array(Int8), `arr_int16` Array(Int16), `arr_int32` Array(Int32), `arr_int64` Array(Int64), `arr_float32` Array(Float32), `arr_float64` Array(Float64), `arr_bool` Array(Bool)
         String topic = createTopicName("schemaless_primitive_types_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr = SchemalessTestData.createPrimitiveTypes(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
-        assertTrue(ClickHouseTestHelpers.validateRows(chc, topic, sr));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
+        assertTrue(ClickHouseTestHelpers.validateRows(chc, topic, sr, deploymentType));
     }
 
-    @Test
-    public void primitiveTypesSubsetTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void primitiveTypesSubsetTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         // `arr_int8` Array(Int8), `arr_int16` Array(Int16), `arr_int32` Array(Int32), `arr_int64` Array(Int64), `arr_float32` Array(Float32), `arr_float64` Array(Float64), `arr_bool` Array(Bool)
         String topic = createTopicName("schemaless_primitive_types_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("str", "String")
                 .column("p_int8", "Int8")
-                .engine("MergeTree").orderByColumn("off16").execute(chc);
+                .orderByColumn("off16").deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr = SchemalessTestData.createPrimitiveTypes(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
-        assertFalse(ClickHouseTestHelpers.validateRows(chc, topic, sr));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
+        assertFalse(ClickHouseTestHelpers.validateRows(chc, topic, sr, deploymentType));
     }
 
-    @Test
-    public void withEmptyDataRecordsTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void withEmptyDataRecordsTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         // `arr_int8` Array(Int8), `arr_int16` Array(Int16), `arr_int32` Array(Int32), `arr_int64` Array(Int64), `arr_float32` Array(Float32), `arr_float64` Array(Float64), `arr_bool` Array(Bool)
         String topic = createTopicName("schemaless_empty_records_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr = SchemalessTestData.createWithEmptyDataRecords(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size() / 2, ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size() / 2, ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void NullableValuesTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void NullableValuesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         // `arr_int8` Array(Int8), `arr_int16` Array(Int16), `arr_int32` Array(Int32), `arr_int64` Array(Int64), `arr_float32` Array(Float32), `arr_float64` Array(Float64), `arr_bool` Array(Bool)
         String topic = createTopicName("schemaless_nullable_values_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
@@ -112,23 +117,24 @@ public class ClickHouseSinkTaskSchemalessTest extends ClickHouseBase {
                 .column("p_float32", "Float32")
                 .column("p_float64", "Float64")
                 .column("p_bool", "Bool")
-                .engine("MergeTree").orderByColumn("off16").execute(chc);
+                .orderByColumn("off16").deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr = SchemalessTestData.createPrimitiveTypesWithNulls(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void arrayTypesTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void arrayTypesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("schemaless_array_string_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
@@ -141,7 +147,7 @@ public class ClickHouseSinkTaskSchemalessTest extends ClickHouseBase {
                 .column("arr_float32", "Array(Float32)")
                 .column("arr_float64", "Array(Float64)")
                 .column("arr_bool", "Array(Bool)")
-                .engine("MergeTree").orderByColumn("off16").execute(chc);
+                .orderByColumn("off16").deploymentType(deploymentType).execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemalessTestData.createArrayType(topic, 1);
 
@@ -149,23 +155,24 @@ public class ClickHouseSinkTaskSchemalessTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void mapTypesTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void mapTypesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("schemaless_map_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("map_string_string", "Map(String, String)")
                 .column("map_string_int64", "Map(String, Int64)")
                 .column("map_int64_string", "Map(Int64, String)")
-                .engine("MergeTree").orderByColumn("off16").execute(chc);
+                .orderByColumn("off16").deploymentType(deploymentType).execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemalessTestData.createMapType(topic, 1);
 
@@ -173,24 +180,25 @@ public class ClickHouseSinkTaskSchemalessTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
     // https://github.com/ClickHouse/clickhouse-kafka-connect/issues/38
-    public void specialCharTableNameTest() {
+    public void specialCharTableNameTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("special-char-table-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("map_string_string", "Map(String, String)")
                 .column("map_string_int64", "Map(String, Int64)")
                 .column("map_int64_string", "Map(Int64, String)")
-                .engine("MergeTree").orderByColumn("off16").execute(chc);
+                .orderByColumn("off16").deploymentType(deploymentType).execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemalessTestData.createMapType(topic, 1);
 
@@ -198,42 +206,44 @@ public class ClickHouseSinkTaskSchemalessTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void emojisCharsDataTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void emojisCharsDataTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("emojis_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("str", "String")
-                .engine("MergeTree").orderByColumn("off16").execute(chc);
+                .orderByColumn("off16").deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr = SchemalessTestData.createDataWithEmojis(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size() / 2, ClickHouseTestHelpers.countRowsWithEmojis(chc, topic));
+        assertEquals(sr.size() / 2, ClickHouseTestHelpers.countRowsWithEmojis(chc, topic, deploymentType));
     }
 
-    @Test
-    public void decimalDataTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void decimalDataTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("decimal_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("num", "String")
                 .column("decimal_14_2", "Decimal(14, 2)")
-                .engine("MergeTree").orderByColumn("num").execute(chc);
+                .orderByColumn("num").deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr = SchemalessTestData.createDecimalTypes(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
@@ -241,22 +251,23 @@ public class ClickHouseSinkTaskSchemalessTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
-        assertEquals(499700, ClickHouseTestHelpers.sumRows(chc, topic, "decimal_14_2"));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
+        assertEquals(499700, ClickHouseTestHelpers.sumRows(chc, topic, "decimal_14_2", deploymentType));
     }
 
-    @Test
-    public void nullableDecimalDataTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void nullableDecimalDataTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("nullable_decimal_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("num", "String")
                 .column("decimal_14_2", "Nullable(Decimal(14, 2))")
-                .engine("MergeTree").orderByColumn("num").execute(chc);
+                .orderByColumn("num").deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr = SchemalessTestData.createNullableDecimalTypes(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
@@ -264,17 +275,18 @@ public class ClickHouseSinkTaskSchemalessTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
-        assertEquals(450180, ClickHouseTestHelpers.sumRows(chc, topic, "decimal_14_2"));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
+        assertEquals(450180, ClickHouseTestHelpers.sumRows(chc, topic, "decimal_14_2", deploymentType));
     }
 
-    @Test
-    public void overlappingDataTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void overlappingDataTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("schemaless_primitive_types_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
         List<SinkRecord> sr = SchemalessTestData.createPrimitiveTypes(topic, 1);
         List<SinkRecord> smallerCollection = sr.subList(0, sr.size() / 2);
 
@@ -283,18 +295,19 @@ public class ClickHouseSinkTaskSchemalessTest extends ClickHouseBase {
         chst.put(smallerCollection);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
     @SinceClickHouseVersion("24.10")
-    public void jsonTypeTest() {
+    public void jsonTypeTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("schemaless_json_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         Map<String, Serializable> clientSettings = new HashMap<>();
         clientSettings.put(ClientConfigProperties.serverSetting("allow_experimental_json_type"), "1");
         new CreateTableStatement()
@@ -302,13 +315,13 @@ public class ClickHouseSinkTaskSchemalessTest extends ClickHouseBase {
                 .column("off16", "Int16")
                 .column("content", "JSON")
                 .column("struct", "JSON")
-                .engine("MergeTree").orderByColumn("off16").settings(clientSettings).execute(chc);
+                .orderByColumn("off16").settings(clientSettings).deploymentType(deploymentType).execute(chc);
 
         Collection<SinkRecord> sr = SchemalessTestData.createJSONType(topic, 1, 10);
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 }

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskStringTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskStringTest.java
@@ -1,15 +1,16 @@
 package com.clickhouse.kafka.connect.sink;
 
-import com.clickhouse.client.api.query.Records;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
 import com.clickhouse.kafka.connect.sink.dlq.InMemoryDLQ;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseDeploymentType;
 import com.clickhouse.kafka.connect.sink.helper.CreateTableStatement;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -17,7 +18,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.LongStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,7 +34,6 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
             .column("p_float32", "Float32")
             .column("p_float64", "Float64")
             .column("p_bool", "Bool")
-            .engine("MergeTree")
             .orderByColumn("off16");
 
     private static final CreateTableStatement ARRAY_TYPES_TABLE = new CreateTableStatement()
@@ -48,7 +47,7 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
             .column("arr_float32", "Array(Float32)")
             .column("arr_float64", "Array(Float64)")
             .column("arr_bool", "Array(Bool)")
-            .engine("MergeTree")
+
             .orderByColumn("off16");
 
     private static final CreateTableStatement MAP_TYPES_TABLE = new CreateTableStatement()
@@ -56,26 +55,16 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
             .column("map_string_string", "Map(String, String)")
             .column("map_string_int64", "Map(String, Int64)")
             .column("map_int64_string", "Map(Int64, String)")
-            .engine("MergeTree")
+
             .orderByColumn("off16");
 
-    private int countRowsWithEmojis(ClickHouseHelperClient chc, String topic) {
-        String queryCount = "select count(*) from " + topic + " where str LIKE '%\uD83D\uDE00%' SETTINGS select_sequential_consistency = 1";
-        try (Records records = chc.getClient().queryRecords(queryCount).get()) {
-            String value = records.iterator().next().getString(1);
-            return Integer.parseInt(value);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+
+    private int countRowsWithEmojis(ClickHouseHelperClient chc, String topic, ClickHouseDeploymentType deploymentType) {
+        return ClickHouseTestHelpers.countRowsWithEmojis(chc, topic, deploymentType);
     }
-    private int countRows(ClickHouseHelperClient chc, String topic) {
-        String queryCount = String.format("select count(*) from `%s` SETTINGS select_sequential_consistency = 1", topic);
-        try (Records records = chc.getClient().queryRecords(queryCount).get()) {
-            String value = records.iterator().next().getString(1);
-            return Integer.parseInt(value);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+
+    private int countRows(ClickHouseHelperClient chc, String topic, ClickHouseDeploymentType deploymentType) {
+        return ClickHouseTestHelpers.countRows(chc, topic, deploymentType);
     }
 
     public Collection<SinkRecord> createPrimitiveTypes(String topic, int partition) {
@@ -390,15 +379,18 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         });
         return array;
     }
-    @Test
-    public void primitiveTypesTest() {
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void primitiveTypesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         // `arr_int8` Array(Int8), `arr_int16` Array(Int16), `arr_int32` Array(Int32), `arr_int64` Array(Int64), `arr_float32` Array(Float32), `arr_float64` Array(Float64), `arr_bool` Array(Bool)
         String topic = createTopicName("schemaless_primitive_types_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(PRIMITIVE_TYPES_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = createPrimitiveTypes(topic, 1);
 
@@ -406,18 +398,20 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), countRows(chc, topic));
+        assertEquals(sr.size(), countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void withEmptyDataRecordsTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void withEmptyDataRecordsTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         // `arr_int8` Array(Int8), `arr_int16` Array(Int16), `arr_int32` Array(Int32), `arr_int64` Array(Int64), `arr_float32` Array(Float32), `arr_float64` Array(Float64), `arr_bool` Array(Bool)
         String topic = createTopicName("schemaless_empty_records_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(PRIMITIVE_TYPES_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = createWithEmptyDataRecords(topic, 1);
 
@@ -425,16 +419,17 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size() / 2, countRows(chc, topic));
+        assertEquals(sr.size() / 2, countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void NullableValuesTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void NullableValuesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         // `arr_int8` Array(Int8), `arr_int16` Array(Int16), `arr_int32` Array(Int32), `arr_int64` Array(Int64), `arr_float32` Array(Float32), `arr_float64` Array(Float64), `arr_bool` Array(Bool)
         String topic = createTopicName("schemaless_nullable_values_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
@@ -447,8 +442,9 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
                 .column("p_float32", "Float32")
                 .column("p_float64", "Float64")
                 .column("p_bool", "Bool")
-                .engine("MergeTree")
+
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = createPrimitiveTypesWithNulls(topic, 1);
 
@@ -456,18 +452,20 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), countRows(chc, topic));
+        assertEquals(sr.size(), countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void arrayTypesTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void arrayTypesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("schemaless_array_string_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(ARRAY_TYPES_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = createArrayType(topic, 1);
@@ -476,18 +474,20 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), countRows(chc, topic));
+        assertEquals(sr.size(), countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void mapTypesTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void mapTypesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("schemaless_map_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(MAP_TYPES_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = createMapType(topic, 1);
@@ -496,19 +496,21 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), countRows(chc, topic));
+        assertEquals(sr.size(), countRows(chc, topic, deploymentType));
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
     // https://github.com/ClickHouse/clickhouse-kafka-connect/issues/38
-    public void specialCharTableNameTest() {
+    public void specialCharTableNameTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("special-char-table-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(MAP_TYPES_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = createMapType(topic, 1);
@@ -517,22 +519,24 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), countRows(chc, topic));
+        assertEquals(sr.size(), countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void emojisCharsDataTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void emojisCharsDataTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("emojis_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("str", "String")
-                .engine("MergeTree")
+
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = createDataWithEmojis(topic, 1);
 
@@ -540,21 +544,23 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size() / 2, countRowsWithEmojis(chc, topic));
+        assertEquals(sr.size() / 2, countRowsWithEmojis(chc, topic, deploymentType));
     }
 
 
-    @Test
-    public void tableMappingTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void tableMappingTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.TABLE_MAPPING, "mapping_table_test=table_mapping_test");
 
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = "mapping_table_test";
         String tableName = "table_mapping_test";
-        ClickHouseTestHelpers.dropTable(chc, tableName);
+        ClickHouseTestHelpers.dropTable(chc, tableName, deploymentType);
         new CreateTableStatement(PRIMITIVE_TYPES_TABLE)
                 .tableName(tableName)
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = createPrimitiveTypes(topic, 1);
 
@@ -562,19 +568,21 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), countRows(chc, tableName));
+        assertEquals(sr.size(), countRows(chc, tableName, deploymentType));
     }
 
-    @Test
-    public void csvTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void csvTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.INSERT_FORMAT, "csv");
 
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("csv_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(PRIMITIVE_TYPES_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = createCSV(topic, 1);
 
@@ -582,19 +590,21 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), countRows(chc, topic));
+        assertEquals(sr.size(), countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void tsvTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void tsvTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.INSERT_FORMAT, "tsv");
 
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("tsv_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(PRIMITIVE_TYPES_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = createTSV(topic, 1);
 
@@ -602,10 +612,12 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), countRows(chc, topic));
+        assertEquals(sr.size(), countRows(chc, topic, deploymentType));
     }
-    @Test
-    public void clickHouseErrorCode25() {
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void clickHouseErrorCode25(ClickHouseDeploymentType deploymentType) {
         InMemoryDLQ er = new InMemoryDLQ();
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.INSERT_FORMAT, "json");
@@ -613,13 +625,14 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
 
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("code_25_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("str", "String")
-                .engine("MergeTree")
+
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = createCode25(topic, 1);
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskStringTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskStringTest.java
@@ -47,7 +47,6 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
             .column("arr_float32", "Array(Float32)")
             .column("arr_float64", "Array(Float64)")
             .column("arr_bool", "Array(Bool)")
-
             .orderByColumn("off16");
 
     private static final CreateTableStatement MAP_TYPES_TABLE = new CreateTableStatement()
@@ -55,17 +54,7 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
             .column("map_string_string", "Map(String, String)")
             .column("map_string_int64", "Map(String, Int64)")
             .column("map_int64_string", "Map(Int64, String)")
-
             .orderByColumn("off16");
-
-
-    private int countRowsWithEmojis(ClickHouseHelperClient chc, String topic, ClickHouseDeploymentType deploymentType) {
-        return ClickHouseTestHelpers.countRowsWithEmojis(chc, topic, deploymentType);
-    }
-
-    private int countRows(ClickHouseHelperClient chc, String topic, ClickHouseDeploymentType deploymentType) {
-        return ClickHouseTestHelpers.countRows(chc, topic, deploymentType);
-    }
 
     public Collection<SinkRecord> createPrimitiveTypes(String topic, int partition) {
         Gson gson = new Gson();
@@ -398,7 +387,7 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), countRows(chc, topic, deploymentType));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -419,7 +408,7 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size() / 2, countRows(chc, topic, deploymentType));
+        assertEquals(sr.size() / 2, ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -452,7 +441,7 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), countRows(chc, topic, deploymentType));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -474,7 +463,7 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), countRows(chc, topic, deploymentType));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -496,7 +485,7 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), countRows(chc, topic, deploymentType));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -519,7 +508,7 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), countRows(chc, topic, deploymentType));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -534,7 +523,6 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("str", "String")
-
                 .orderByColumn("off16")
                 .deploymentType(deploymentType)
                 .execute(chc);
@@ -544,7 +532,7 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size() / 2, countRowsWithEmojis(chc, topic, deploymentType));
+        assertEquals(sr.size() / 2, ClickHouseTestHelpers.countRowsWithEmojis(chc, topic, deploymentType));
     }
 
 
@@ -568,7 +556,7 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), countRows(chc, tableName, deploymentType));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, tableName, deploymentType));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -590,7 +578,7 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), countRows(chc, topic, deploymentType));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -612,7 +600,7 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), countRows(chc, topic, deploymentType));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -630,7 +618,6 @@ public class ClickHouseSinkTaskStringTest extends ClickHouseBase {
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("str", "String")
-
                 .orderByColumn("off16")
                 .deploymentType(deploymentType)
                 .execute(chc);

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskTest.java
@@ -14,6 +14,9 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseDeploymentType;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
@@ -44,7 +47,6 @@ public class ClickHouseSinkTaskTest extends ClickHouseBase {
             .column("p_float32", "Float32")
             .column("p_float64", "Float64")
             .column("p_bool", "Bool")
-            .engine("MergeTree")
             .orderByColumn("off16");
 
     public Collection<SinkRecord> createDBTopicSplit(int dbRange, long timeStamp, String topic, int partition, String splitChar) {
@@ -104,8 +106,10 @@ public class ClickHouseSinkTaskTest extends ClickHouseBase {
         }
     }
 
-//    @Test TODO: Fix this test
-    public void testDBTopicSplit() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    @Disabled // TODO: Fix this test
+    public void testDBTopicSplit(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props =  getBaseProps();
         props.put(ClickHouseSinkConfig.ENABLE_DB_TOPIC_SPLIT, "true");
         props.put(ClickHouseSinkConfig.DB_TOPIC_SPLIT_CHAR, ".");
@@ -117,10 +121,11 @@ public class ClickHouseSinkTaskTest extends ClickHouseBase {
         LongStream.range(0, dbRange).forEachOrdered(i -> {
             String databaseName = String.format("%d_%d" , i, timeStamp);
             String tmpTableName = String.format("`%s`.`%s`", databaseName, tableName);
-            ClickHouseTestHelpers.dropTable(chc, tmpTableName);
-            ClickHouseTestHelpers.createDatabase(databaseName, chc);
+            ClickHouseTestHelpers.dropTable(chc, tmpTableName, deploymentType);
+            ClickHouseTestHelpers.createDatabase(databaseName, chc, deploymentType);
             new CreateTableStatement(PRIMITIVE_TYPES_TABLE)
                     .tableName(tmpTableName)
+                    .deploymentType(deploymentType)
                     .execute(chc);
         });
 
@@ -133,22 +138,25 @@ public class ClickHouseSinkTaskTest extends ClickHouseBase {
         } catch (Exception e) {
             fail("Exception should not be thrown");
         }
-        LongStream.range(0, dbRange).forEachOrdered(i -> {
-            int count = ClickHouseTestHelpers.countRows(chc, String.valueOf(i), tableName);
-            assertEquals(DEFAULT_TOTAL_RECORDS, count);
-        });
+        // TODO: uncomment this when fixed
+//        LongStream.range(0, dbRange).forEachOrdered(i -> {
+//            int count = ClickHouseTestHelpers.countRows(chc, String.valueOf(i), tableName);
+//            assertEquals(DEFAULT_TOTAL_RECORDS, count);
+//        });
     }
 
 
-    @Test
-    public void simplifiedBatchingSchemaless() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void simplifiedBatchingSchemaless(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.IGNORE_PARTITIONS_WHEN_BATCHING, "true");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("schemaless_simple_batch_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(PRIMITIVE_TYPES_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = SchemalessTestData.createPrimitiveTypes(topic, 1);
         sr.addAll(SchemalessTestData.createPrimitiveTypes(topic, 2));
@@ -158,14 +166,15 @@ public class ClickHouseSinkTaskTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
-        assertTrue(ClickHouseTestHelpers.validateRows(chc, topic, sr));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
+        assertTrue(ClickHouseTestHelpers.validateRows(chc, topic, sr, deploymentType));
         //assertEquals(1, com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers.countInsertQueries(chc, topic));
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
     @Disabled
-    public void clientNameTest() throws Exception {
+    public void clientNameTest(ClickHouseDeploymentType deploymentType) throws Exception {
         // TODO: fix instability of the test.
         if (isCloud) {
             // TODO: Temp disable for cloud because executeQueryIgnoreResult logs not available in time. This is passing on cloud but is flaky.
@@ -175,9 +184,10 @@ public class ClickHouseSinkTaskTest extends ClickHouseBase {
         props.put(ClickHouseSinkConfig.IGNORE_PARTITIONS_WHEN_BATCHING, "true");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("schemaless_simple_batch_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(PRIMITIVE_TYPES_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = SchemalessTestData.createPrimitiveTypes(topic, 1);
         sr.addAll(SchemalessTestData.createPrimitiveTypes(topic, 2));
@@ -187,19 +197,24 @@ public class ClickHouseSinkTaskTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
-        assertTrue(ClickHouseTestHelpers.validateRows(chc, topic, sr));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
+        assertTrue(ClickHouseTestHelpers.validateRows(chc, topic, sr, deploymentType));
 
-        chc.queryV2("SYSTEM FLUSH LOGS " + (isCloud ? "ON CLUSTER 'default'" : "")).close();
+        String flushLogsCluster = isCloud ? " ON CLUSTER 'default'"
+                : deploymentType.isLocalCluster() ? " ON CLUSTER '" + deploymentType.clusterName + "'" : "";
+        chc.queryV2("SYSTEM FLUSH LOGS" + flushLogsCluster).close();
 
-        String getLogRecords = String.format("SELECT http_user_agent, executeQueryIgnoreResult FROM clusterAllReplicas('default', system.query_log) " +
+        String queryLogFrom = deploymentType.isLocalCluster()
+                ? "clusterAllReplicas('" + deploymentType.clusterName + "', system, query_log, rand())"
+                : "system.query_log";
+        String getLogRecords = String.format("SELECT http_user_agent, query FROM " + queryLogFrom +
                         "   WHERE query_kind = 'Insert' " +
                         "   AND type = 'QueryStart'" +
                         "   AND has(databases,'%1$s') " +
                         "   AND position(http_user_agent, '%2$s') > -1 LIMIT 100",
                 chc.getDatabase(), ClickHouseHelperClient.CONNECT_CLIENT_NAME);
 
-        String debugQuery = String.format("SELECT http_user_agent, query_kind, type FROM clusterAllReplicas('default', system.query_log) LIMIT 10");
+        String debugQuery = String.format("SELECT http_user_agent, query_kind, type FROM " + queryLogFrom + " LIMIT 10");
         List<GenericRecord> debugRecords = chc.getClient().queryAll(debugQuery);
         StringBuilder sb = new StringBuilder();
         for (GenericRecord record : debugRecords) {
@@ -213,15 +228,17 @@ public class ClickHouseSinkTaskTest extends ClickHouseBase {
         }
     }
 
-    @Test
-    public void statisticsTest() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void statisticsTest(ClickHouseDeploymentType deploymentType) throws Exception {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.IGNORE_PARTITIONS_WHEN_BATCHING, "true");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("topic.statistics_test-01");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(PRIMITIVE_TYPES_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = SchemalessTestData.createPrimitiveTypes(topic, 1);
         sr.addAll(SchemalessTestData.createPrimitiveTypes(topic, 2));
@@ -278,15 +295,17 @@ public class ClickHouseSinkTaskTest extends ClickHouseBase {
         assertThrows(InstanceNotFoundException.class, () -> mBeanServer.getMBeanInfo(topicMbeanName));
     }
 
-    @Test
-    public void receiveLagTimeTest() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void receiveLagTimeTest(ClickHouseDeploymentType deploymentType) throws Exception {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.IGNORE_PARTITIONS_WHEN_BATCHING, "true");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("schemaless_simple_batch_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(PRIMITIVE_TYPES_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
@@ -342,8 +361,9 @@ public class ClickHouseSinkTaskTest extends ClickHouseBase {
         chst.stop();
     }
 
-    @Test
-    public void preCommitReturnsInsertedOffsetsForMultipleTopics() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void preCommitReturnsInsertedOffsetsForMultipleTopics(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.REPORT_INSERTED_OFFSETS, "true");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
@@ -351,13 +371,15 @@ public class ClickHouseSinkTaskTest extends ClickHouseBase {
         String topic1 = createTopicName("precommit_offsets_t1");
         String topic2 = createTopicName("precommit_offsets_t2");
 
-        ClickHouseTestHelpers.dropTable(chc, topic1);
-        ClickHouseTestHelpers.dropTable(chc, topic2);
+        ClickHouseTestHelpers.dropTable(chc, topic1, deploymentType);
+        ClickHouseTestHelpers.dropTable(chc, topic2, deploymentType);
         new CreateTableStatement(PRIMITIVE_TYPES_TABLE)
                 .tableName(topic1)
+                .deploymentType(deploymentType)
                 .execute(chc);
         new CreateTableStatement(PRIMITIVE_TYPES_TABLE)
                 .tableName(topic2)
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         int totalRecordsTopic1 = 100;
@@ -391,17 +413,19 @@ public class ClickHouseSinkTaskTest extends ClickHouseBase {
         chst.stop();
     }
 
-    @Test
-    public void preCommitReturnsCurrentOffsetsWhenIgnorePartitions() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void preCommitReturnsCurrentOffsetsWhenIgnorePartitions(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.IGNORE_PARTITIONS_WHEN_BATCHING, "true");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("precommit_ignore_partitions");
 
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(PRIMITIVE_TYPES_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         int totalRecords = 100;
@@ -424,8 +448,9 @@ public class ClickHouseSinkTaskTest extends ClickHouseBase {
         chst.stop();
     }
 
-    @Test
-    public void closeRemovesRevokedPartitionFromPreCommitOffsets() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void closeRemovesRevokedPartitionFromPreCommitOffsets(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.REPORT_INSERTED_OFFSETS, "true");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
@@ -433,13 +458,15 @@ public class ClickHouseSinkTaskTest extends ClickHouseBase {
         String topic1 = createTopicName("precommit_close_remove_t1");
         String topic2 = createTopicName("precommit_close_remove_t2");
 
-        ClickHouseTestHelpers.dropTable(chc, topic1);
-        ClickHouseTestHelpers.dropTable(chc, topic2);
+        ClickHouseTestHelpers.dropTable(chc, topic1, deploymentType);
+        ClickHouseTestHelpers.dropTable(chc, topic2, deploymentType);
         new CreateTableStatement(PRIMITIVE_TYPES_TABLE)
                 .tableName(topic1)
+                .deploymentType(deploymentType)
                 .execute(chc);
         new CreateTableStatement(PRIMITIVE_TYPES_TABLE)
                 .tableName(topic2)
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         int totalRecordsTopic1 = 50;
@@ -474,8 +501,9 @@ public class ClickHouseSinkTaskTest extends ClickHouseBase {
         chst.stop();
     }
 
-    @Test
-    public void onPartitionsRevokedRemovesRevokedPartitionFromPreCommitOffsets() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void onPartitionsRevokedRemovesRevokedPartitionFromPreCommitOffsets(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.REPORT_INSERTED_OFFSETS, "true");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
@@ -483,13 +511,15 @@ public class ClickHouseSinkTaskTest extends ClickHouseBase {
         String topic1 = createTopicName("precommit_revoke_remove_t1");
         String topic2 = createTopicName("precommit_revoke_remove_t2");
 
-        ClickHouseTestHelpers.dropTable(chc, topic1);
-        ClickHouseTestHelpers.dropTable(chc, topic2);
+        ClickHouseTestHelpers.dropTable(chc, topic1, deploymentType);
+        ClickHouseTestHelpers.dropTable(chc, topic2, deploymentType);
         new CreateTableStatement(PRIMITIVE_TYPES_TABLE)
                 .tableName(topic1)
+                .deploymentType(deploymentType)
                 .execute(chc);
         new CreateTableStatement(PRIMITIVE_TYPES_TABLE)
                 .tableName(topic2)
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         int totalRecordsTopic1 = 40;
@@ -524,15 +554,17 @@ public class ClickHouseSinkTaskTest extends ClickHouseBase {
         chst.stop();
     }
 
-    @Test
-    public void preCommitReturnsCurrentOffsetsWhenReportingInsertedOffsetsDisabled() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void preCommitReturnsCurrentOffsetsWhenReportingInsertedOffsetsDisabled(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("precommit_report_offsets_off");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(PRIMITIVE_TYPES_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         int partition = 0;

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaProxyTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaProxyTest.java
@@ -2,9 +2,7 @@ package com.clickhouse.kafka.connect.sink;
 
 import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
-import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
-import com.clickhouse.kafka.connect.sink.helper.CreateTableStatement;
-import com.clickhouse.kafka.connect.sink.helper.SchemaTestData;
+import com.clickhouse.kafka.connect.sink.helper.*;
 import com.clickhouse.kafka.connect.test.junit.extension.FromVersionConditionExtension;
 import com.clickhouse.kafka.connect.test.junit.extension.SinceClickHouseVersion;
 import com.clickhouse.kafka.connect.util.Utils;
@@ -15,13 +13,14 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.toxiproxy.ToxiproxyContainer;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -50,7 +49,7 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
 
     private static final CreateTableStatement SINGLE_INT16_TABLE = new CreateTableStatement()
             .column("off16", "Int16")
-            .engine("MergeTree").orderByColumn("off16");
+            .orderByColumn("off16");
 
     private static final CreateTableStatement MAP_TYPES_TABLE = new CreateTableStatement()
             .column("off16", "Int16")
@@ -60,7 +59,7 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
             .column("map_string_map", "Map(String, Map(String, Int64))")
             .column("map_string_array", "Map(String, Array(String))")
             .column("map_map_map", "Map(String, Map(String, Map(String, String)))")
-            .engine("MergeTree").orderByColumn("off16");
+            .orderByColumn("off16");
 
     private static final CreateTableStatement ARRAY_TYPES_TABLE = new CreateTableStatement()
             .column("off16", "Int16")
@@ -73,20 +72,33 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
             .column("arr_float32", "Array(Float32)")
             .column("arr_float64", "Array(Float64)")
             .column("arr_bool", "Array(Bool)")
-            .engine("MergeTree").orderByColumn("off16");
+            .orderByColumn("off16");
 
     @BeforeAll
     public void setup() throws IOException {
         super.setup();
 
-        toxiproxy = new ToxiproxyContainer(ClickHouseTestHelpers.TOXIPROXY_DOCKER_IMAGE_NAME).withNetwork(isCloud ? Network.newNetwork() : db.getNetwork()).withNetworkAliases(ClickHouseTestHelpers.TOXIPROXY_NETWORK_ALIAS);
+        toxiproxy = new ToxiproxyContainer(ClickHouseTestHelpers.TOXIPROXY_DOCKER_IMAGE_NAME)
+                .withNetwork(isCluster || isCloud ? Network.newNetwork() : db.getNetwork())
+                .withNetworkAliases(ClickHouseTestHelpers.TOXIPROXY_NETWORK_ALIAS);
+        if (isCluster) {
+            toxiproxy = toxiproxy.withExtraHost("host.docker.internal", "host-gateway");
+        }
         toxiproxy.start();
 
         log.info("Started proxy container: {}", toxiproxy.getControlPort());
         ToxiproxyClient toxiproxyClient = new ToxiproxyClient(toxiproxy.getHost(), toxiproxy.getControlPort());
 
         ClickHouseSinkConfig csc = new ClickHouseSinkConfig(getBaseProps());
-        proxy = toxiproxyClient.createProxy("clickhouse-proxy", "0.0.0.0:" + PROXY_PORT, isCloud ? String.format("%s:%d", csc.getHostname(), csc.getPort()) : String.format("%s:%d", ClickHouseTestHelpers.CLICKHOUSE_DB_NETWORK_ALIAS, ClickHouseProtocol.HTTP.getDefaultPort()));
+        String upstream;
+        if (isCloud) {
+            upstream = String.format("%s:%d", csc.getHostname(), csc.getPort());
+        } else if (isCluster) {
+            upstream = String.format("host.docker.internal:%d", ClickHouseCluster.getPort());
+        } else {
+            upstream = String.format("%s:%d", ClickHouseTestHelpers.CLICKHOUSE_DB_NETWORK_ALIAS, ClickHouseProtocol.HTTP.getDefaultPort());
+        }
+        proxy = toxiproxyClient.createProxy("clickhouse-proxy", "0.0.0.0:" + PROXY_PORT, upstream);
         log.info("Proxy configured {}", proxy.getListen());
     }
 
@@ -120,8 +132,9 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
     }
 
 
-    @Test
-    public void proxyPingTest() throws IOException {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void proxyPingTest(ClickHouseDeploymentType deploymentType) throws IOException {
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(getTestProperties());
         assertTrue(chc.ping());
         proxy.disable();
@@ -130,14 +143,15 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
         assertTrue(chc.ping());
     }
 
-    @Test
-    public void arrayTypesTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void arrayTypesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
-        String topic = "array_string_table_test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(ARRAY_TYPES_TABLE).tableName(topic).execute(chc);
+        String topic = createTopicName("array_string_table_test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(ARRAY_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createArrayType(topic, 1);
 
@@ -146,17 +160,18 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void mapTypesTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void mapTypesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
-        String topic = "map_table_test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(MAP_TYPES_TABLE).tableName(topic).execute(chc);
+        String topic = createTopicName("map_table_test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(MAP_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createMapType(topic, 1);
 
@@ -165,19 +180,29 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
     // https://github.com/ClickHouse/clickhouse-kafka-connect/issues/33
-    public void materializedViewsBug() {
+    public void materializedViewsBug(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
-        String topic = "m_array_string_table_test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(ARRAY_TYPES_TABLE).tableName(topic).execute(chc);
-        ClickHouseTestHelpers.runQuery(chc, String.format("CREATE MATERIALIZED VIEW %s ( `off16` Int16 ) Engine = MergeTree ORDER BY `off16` POPULATE AS SELECT off16 FROM m_array_string_table_test ", topic + "mate"));
+        String topic = createTopicName("m_array_string_table_test");
+        // Drop the MV and its target table before the source table to avoid orphaned dependencies
+        ClickHouseTestHelpers.runQuery(chc, String.format("DROP VIEW IF EXISTS `%s_mv`", topic));
+        ClickHouseTestHelpers.dropTable(chc, topic + "_mate", deploymentType);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(ARRAY_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
+        new CreateTableStatement()
+                .tableName(topic + "_mate")
+                .column("off16", "Int16")
+                .engine("Null")
+                .deploymentType(deploymentType)
+                .execute(chc);
+        ClickHouseTestHelpers.runQuery(chc, String.format("CREATE MATERIALIZED VIEW `%s_mv` TO `%s_mate` AS SELECT off16 FROM `%s`", topic, topic, topic));
         Collection<SinkRecord> sr = SchemaTestData.createArrayType(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
@@ -185,18 +210,19 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
     // https://github.com/ClickHouse/clickhouse-kafka-connect/issues/38
-    public void specialCharTableNameTest() {
+    public void specialCharTableNameTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
-        String topic = "special-char-table-test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
-        new CreateTableStatement(MAP_TYPES_TABLE).tableName(topic).execute(chc);
+        String topic = createTopicName("special-char-table-test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
+        new CreateTableStatement(MAP_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createMapType(topic, 1);
 
@@ -205,20 +231,21 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
     // https://github.com/ClickHouse/clickhouse-kafka-connect/issues/62
-    public void nullValueDataTest() {
+    public void nullValueDataTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
-        String topic = "null-value-table-test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        String topic = createTopicName("null-value-table-test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .column("off16", "Int16").column("null_value_data", "Nullable(DateTime64(6, 'UTC'))")
-                .engine("MergeTree").orderByColumn("off16").tableName(topic).execute(chc);
+                .orderByColumn("off16").tableName(topic).deploymentType(deploymentType).execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createNullValueData(topic, 1);
 
@@ -227,25 +254,26 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
 
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
     // https://github.com/ClickHouse/clickhouse-kafka-connect/issues/57
-    public void supportDatesTest() {
+    public void supportDatesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
-        String topic = "support-dates-table-test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        String topic = createTopicName("support-dates-table-test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .column("off16", "Int16").column("date_number", "Nullable(Date)").column("date32_number", "Nullable(Date32)")
                 .column("datetime_number", "DateTime").column("datetime64_number", "DateTime64")
                 .column("timestamp_int64", "Int64").column("timestamp_date", "DateTime64")
                 .column("time_int32", "Int32").column("time_date32", "Date32")
                 .column("date_date", "Date").column("datetime_date", "DateTime")
-                .engine("MergeTree").orderByColumn("off16").tableName(topic).execute(chc);
+                .orderByColumn("off16").tableName(topic).deploymentType(deploymentType).execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createDateType(topic, 1);
 
@@ -254,20 +282,21 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void detectUnsupportedDataConversions() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void detectUnsupportedDataConversions(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
-        String topic = "support-unsupported-dates-table-test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        String topic = createTopicName("support-unsupported-dates-table-test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .column("off16", "Int16").column("date_number", "Date").column("date32_number", "Date32")
                 .column("datetime_number", "DateTime").column("datetime64_number", "DateTime64")
-                .engine("MergeTree").orderByColumn("off16").tableName(topic).execute(chc);
+                .orderByColumn("off16").tableName(topic).deploymentType(deploymentType).execute(chc);
 
         Collection<SinkRecord> sr = SchemaTestData.createUnsupportedDataConversions(topic, 1);
 
@@ -281,74 +310,78 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
         chst.stop();
     }
 
-    @Test
-    public void withEmptyDataRecordsTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void withEmptyDataRecordsTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
-        String topic = "schema_empty_records_table_test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        String topic = createTopicName("schema_empty_records_table_test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .column("off16", "Int16").column("p_int64", "Int64")
-                .engine("MergeTree").orderByColumn("off16").tableName(topic).execute(chc);
+                .orderByColumn("off16").tableName(topic).deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr = SchemaTestData.createWithEmptyDataRecords(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size() / 2, ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size() / 2, ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void withLowCardinalityTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void withLowCardinalityTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
-        String topic = "schema_empty_records_lc_table_test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        String topic = createTopicName("schema_empty_records_lc_table_test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .column("off16", "Int16").column("p_int64", "Int64")
                 .column("lc_string", "LowCardinality(String)").column("nullable_lc_string", "LowCardinality(Nullable(String))")
-                .engine("MergeTree").orderByColumn("off16").tableName(topic).execute(chc);
+                .orderByColumn("off16").tableName(topic).deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr = SchemaTestData.createWithLowCardinality(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void withUUIDTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void withUUIDTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
-        String topic = "schema_empty_records_lc_table_test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        String topic = createTopicName("schema_empty_records_lc_uuid_test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .column("off16", "Int16").column("uuid", "UUID")
-                .engine("MergeTree").orderByColumn("off16").tableName(topic).execute(chc);
+                .orderByColumn("off16").tableName(topic).deploymentType(deploymentType).execute(chc);
         Collection<SinkRecord> sr = SchemaTestData.createWithUUID(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void schemaWithDefaultsTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void schemaWithDefaultsTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
-        String topic = "default-value-table-test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        String topic = createTopicName("default-value-table-test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .column("off16", "Int16").column("default_value_data", "DateTime DEFAULT now()")
-                .engine("MergeTree").orderByColumn("off16").tableName(topic).execute(chc);
+                .orderByColumn("off16").tableName(topic).deploymentType(deploymentType).execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createNullValueData(topic, 1);
 
@@ -357,19 +390,20 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void schemaWithDecimalTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void schemaWithDecimalTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
-        String topic = "decimal-value-table-test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        String topic = createTopicName("decimal-value-table-test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .column("off16", "Int16").column("decimal_14_2", "Decimal(14, 2)")
-                .engine("MergeTree").orderByColumn("off16").tableName(topic).execute(chc);
+                .orderByColumn("off16").tableName(topic).deploymentType(deploymentType).execute(chc);
 
         Collection<SinkRecord> sr = SchemaTestData.createDecimalValueData(topic, 1);
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
@@ -377,19 +411,20 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
-        assertEquals(499700, ClickHouseTestHelpers.sumRows(chc, topic, "decimal_14_2"));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
+        assertEquals(499700, ClickHouseTestHelpers.sumRows(chc, topic, "decimal_14_2", deploymentType));
     }
 
-    @Test
-    public void schemaWithBytesTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void schemaWithBytesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
-        String topic = "bytes-value-table-test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        String topic = createTopicName("bytes-value-table-test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .column("string", "String")
-                .engine("MergeTree").orderByColumn("string").tableName(topic).execute(chc);
+                .orderByColumn("string").tableName(topic).deploymentType(deploymentType).execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createBytesValueData(topic, 1);
 
@@ -398,23 +433,24 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
     @SinceClickHouseVersion("24.1")
-    public void schemaWithTupleLikeInfluxTest() {
+    public void schemaWithTupleLikeInfluxTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getTestProperties();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
-        String topic = "tuple-like-influx-value-table-test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        String topic = createTopicName("tuple-like-influx-value-table-test");
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .column("off16", "Int16")
                 .column("payload", "Tuple(fields Map(String, Variant(Float64, Int64, String)), tags Map(String, String))")
-                .engine("MergeTree").orderByColumn("off16")
+                .orderByColumn("off16")
                 .settings(Map.of("allow_experimental_variant_type", 1))
-                .tableName(topic).execute(chc);
+                .tableName(topic).deploymentType(deploymentType).execute(chc);
 
         Collection<SinkRecord> sr = SchemaTestData.createTupleLikeInfluxValueData(topic, 1);
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
@@ -422,8 +458,8 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
-        List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic);
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
+        List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic, deploymentType);
 
         LongStream.range(0, sr.size()).forEachOrdered(n -> {
             JSONObject row = rows.get((int) n);

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaProxyTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaProxyTest.java
@@ -13,6 +13,7 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -132,9 +133,8 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
     }
 
 
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("deploymentTypesForTests")
-    public void proxyPingTest(ClickHouseDeploymentType deploymentType) throws IOException {
+    @Test
+    public void proxyPingTest() throws IOException {
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(getTestProperties());
         assertTrue(chc.ping());
         proxy.disable();
@@ -192,7 +192,7 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
 
         String topic = createTopicName("m_array_string_table_test");
         // Drop the MV and its target table before the source table to avoid orphaned dependencies
-        ClickHouseTestHelpers.runQuery(chc, String.format("DROP VIEW IF EXISTS `%s_mv`", topic));
+        ClickHouseTestHelpers.executeQueryIgnoreResult(chc, String.format("DROP VIEW IF EXISTS `%s_mv`", topic));
         ClickHouseTestHelpers.dropTable(chc, topic + "_mate", deploymentType);
         ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(ARRAY_TYPES_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
@@ -202,7 +202,7 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
                 .engine("Null")
                 .deploymentType(deploymentType)
                 .execute(chc);
-        ClickHouseTestHelpers.runQuery(chc, String.format("CREATE MATERIALIZED VIEW `%s_mv` TO `%s_mate` AS SELECT off16 FROM `%s`", topic, topic, topic));
+        ClickHouseTestHelpers.executeQueryIgnoreResult(chc, String.format("CREATE MATERIALIZED VIEW `%s_mv` TO `%s_mate` AS SELECT off16 FROM `%s`", topic, topic, topic));
         Collection<SinkRecord> sr = SchemaTestData.createArrayType(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
@@ -31,10 +31,11 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseDeploymentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +60,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -82,7 +84,6 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
             .column("arr_str_arr", "Array(Array(String))")
             .column("arr_arr_str_arr", "Array(Array(Array(String)))")
             .column("arr_map", "Array(Map(String, String))")
-            .engine("MergeTree")
             .orderByColumn("off16");
 
     private static final CreateTableStatement MAP_TYPES_TABLE = new CreateTableStatement()
@@ -93,24 +94,24 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
             .column("map_string_map", "Map(String, Map(String, Int64))")
             .column("map_string_array", "Map(String, Array(String))")
             .column("map_map_map", "Map(String, Map(String, Map(String, String)))")
-            .engine("MergeTree")
             .orderByColumn("off16");
 
     private static final CreateTableStatement CHANGE_SCHEMA_TABLE = new CreateTableStatement()
             .column("off16", "Int16")
             .column("string", "String")
-            .engine("MergeTree")
             .orderByColumn("`off16`");
 
-    @Test
-    public void arrayTypesTest() {
+    @ParameterizedTest()
+    @MethodSource("deploymentTypesForTests")
+    public void arrayTypesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = "array_string_table_test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(ARRAY_TYPES_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createArrayType(topic, 1);
@@ -120,17 +121,18 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
-        assertTrue(ClickHouseTestHelpers.validateRows(chc, topic, sr));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
+        assertTrue(ClickHouseTestHelpers.validateRows(chc, topic, sr, deploymentType));
     }
 
-    @Test
-    public void arrayNullableSubtypesTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void arrayNullableSubtypesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = "array_nullable_subtypes_table_test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
@@ -143,8 +145,8 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
                 .column("arr_nullable_float32", "Array(Nullable(Float32))")
                 .column("arr_nullable_float64", "Array(Nullable(Float64))")
                 .column("arr_nullable_bool", "Array(Nullable(Bool))")
-                .engine("MergeTree")
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = SchemaTestData.createArrayNullableSubtypes(topic, 1);
 
@@ -153,18 +155,20 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void mapTypesTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void mapTypesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = "map_table_test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(MAP_TYPES_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createMapType(topic, 1);
@@ -174,22 +178,24 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void nullArrayTypeTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void nullArrayTypeTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("nullable_array_string_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("arr", "Array(String)")
-                .engine("MergeTree")
+
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = SchemaTestData.createNullableArrayType(topic, 1);
 
@@ -198,22 +204,24 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void nullableArrayTypeTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void nullableArrayTypeTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("nullable_array_string_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("arr", "Array(Nullable(String))")
-                .engine("MergeTree")
+
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = SchemaTestData.createNullableArrayType(topic, 1);
 
@@ -222,18 +230,19 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
     // https://github.com/ClickHouse/clickhouse-kafka-connect/issues/33
-    public void materializedViewsBug() {
+    public void materializedViewsBug(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("m_array_string_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic + "mate");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic + "mate", deploymentType);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
@@ -246,13 +255,14 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
                 .column("arr_float32", "Array(Float32)")
                 .column("arr_float64", "Array(Float64)")
                 .column("arr_bool", "Array(Bool)")
-                .engine("MergeTree")
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
         new CreateTableStatement()
                 .tableName(topic + "_mate")
                 .column("off16", "Int16")
                 .engine("Null")
+                .deploymentType(deploymentType)
                 .execute(chc);
         ClickHouseTestHelpers.runQuery(chc, String.format("CREATE MATERIALIZED VIEW %s_mv TO " + topic + "_mate AS SELECT off16 FROM " + topic, topic));
         Collection<SinkRecord> sr = SchemaTestData.createArrayType(topic, 1);
@@ -262,19 +272,21 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
     // https://github.com/ClickHouse/clickhouse-kafka-connect/issues/38
-    public void specialCharTableNameTest() {
+    public void specialCharTableNameTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("special-char-table-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(MAP_TYPES_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createMapType(topic, 1);
@@ -284,23 +296,24 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
     // https://github.com/ClickHouse/clickhouse-kafka-connect/issues/62
-    public void nullValueDataTest() {
+    public void nullValueDataTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("null-value-table-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("null_value_data", "Nullable(DateTime64(6, 'UTC'))")
-                .engine("MergeTree")
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createNullValueData(topic, 1);
@@ -310,18 +323,19 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
 
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
     // https://github.com/ClickHouse/clickhouse-kafka-connect/issues/57
-    public void supportDatesTest() {
+    public void supportDatesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("support-dates-table-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
@@ -338,8 +352,8 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
                 .column("time_date32", "Date32")
                 .column("date_date", "Date")
                 .column("datetime_date", "DateTime")
-                .engine("MergeTree")
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createDateType(topic, 1);
@@ -349,9 +363,9 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
 
-        List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic);
+        List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic, deploymentType);
         for (JSONObject row : rows) {
             String dateTime64_9 = row.getString("datetime64_9_number");
             String dateTime64_6 = row.getString("datetime64_6_number");
@@ -362,20 +376,21 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         }
     }
 
-    @Test
-    public void supportArrayDateTime64Test() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void supportArrayDateTime64Test(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("support-array-datetime64-table-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("arr_datetime64_number", "Array(DateTime64)")
                 .column("arr_timestamp_date", "Array(DateTime64)")
-                .engine("MergeTree")
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = SchemaTestData.createArrayDateTime64Type(topic, 1);
 
@@ -384,16 +399,17 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void detectUnsupportedDataConversions() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void detectUnsupportedDataConversions(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("support-unsupported-dates-table-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
@@ -401,8 +417,8 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
                 .column("date32_number", "Date32")
                 .column("datetime_number", "DateTime")
                 .column("datetime64_number", "DateTime64")
-                .engine("MergeTree")
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         Collection<SinkRecord> sr = SchemaTestData.createUnsupportedDataConversions(topic, 1);
@@ -418,20 +434,21 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
     }
 
 
-    @Test
-    public void supportZonedDatesStringTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void supportZonedDatesStringTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("support-dates-string-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("zoned_date", "DateTime64")
                 .column("offset_date", "DateTime64")
-                .engine("MergeTree")
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = SchemaTestData.createZonedTimestampConversions(topic, 1);
 
@@ -440,24 +457,25 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
 
-    @Test
-    public void supportFormattedDatesStringTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void supportFormattedDatesStringTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.DATE_TIME_FORMAT, "format_date=yyyy-MM-dd HH:mm:ss.SSSSSSSSS");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("support-formatted-dates-string-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("format_date", "DateTime64(9)")
-                .engine("MergeTree")
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = SchemaTestData.createFormattedTimestampConversions(topic, 1);
 
@@ -466,8 +484,8 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
-        List<JSONObject> results = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic);
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
+        List<JSONObject> results = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic, deploymentType);
         AtomicBoolean found = new AtomicBoolean(false);
         AtomicInteger count = new AtomicInteger(0);
         sr.forEach(sinkRecord -> {
@@ -484,19 +502,20 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
 
 
 
-    @Test
-    public void withEmptyDataRecordsTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void withEmptyDataRecordsTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("schema_empty_records_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("p_int64", "Int64")
-                .engine("MergeTree")
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = SchemaTestData.createWithEmptyDataRecords(topic, 1);
 
@@ -504,24 +523,25 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size() / 2, ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size() / 2, ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void withLowCardinalityTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void withLowCardinalityTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("schema_empty_records_lc_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("p_int64", "Int64")
                 .column("lc_string", "LowCardinality(String)")
                 .column("nullable_lc_string", "LowCardinality(Nullable(String))")
-                .engine("MergeTree")
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = SchemaTestData.createWithLowCardinality(topic, 1);
 
@@ -529,22 +549,23 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void withUUIDTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void withUUIDTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("schema_empty_records_lc_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("uuid", "UUID")
-                .engine("MergeTree")
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = SchemaTestData.createWithUUID(topic, 1);
 
@@ -552,22 +573,23 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void schemaWithDefaultsTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void schemaWithDefaultsTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("default-value-table-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("default_value_data", "DateTime DEFAULT now()")
-                .engine("MergeTree")
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createNullValueData(topic, 1);
@@ -577,24 +599,25 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
 
-    @Test
-    public void schemaWithEphemeralTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void schemaWithEphemeralTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("default-value-table-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("default_value_data", "DateTime DEFAULT now()")
                 .column("ephemeral_data", "String EPHEMERAL")
-                .engine("MergeTree")
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = SchemaTestData.createNullValueData(topic, 1);
 
@@ -603,24 +626,25 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
 
-    @Test
-    public void schemaWithDefaultsAndNullableTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void schemaWithDefaultsAndNullableTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("default-value-table-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("null_value_data", "Nullable(DateTime)")
                 .column("default_value_data", "DateTime DEFAULT now()")
-                .engine("MergeTree")
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createNullValueData(topic, 1);
@@ -630,22 +654,23 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void schemaWithDecimalTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void schemaWithDecimalTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("decimal-value-table-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("decimal_14_2", "Decimal(14, 2)")
-                .engine("MergeTree")
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         Collection<SinkRecord> sr = SchemaTestData.createDecimalValueData(topic, 1);
@@ -654,27 +679,28 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
-        assertEquals(499700, ClickHouseTestHelpers.sumRows(chc, topic, "decimal_14_2"));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
+        assertEquals(499700, ClickHouseTestHelpers.sumRows(chc, topic, "decimal_14_2", deploymentType));
     }
 
-    @Test
-    public void schemaWithFixedStringTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void schemaWithFixedStringTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("fixed-string-value-table-test");
         int fixedStringSize = RandomUtils.insecure().randomInt(1, 100);
         LOGGER.info("FixedString size: " + fixedStringSize);
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         final int fss = fixedStringSize;
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("fixed_string_string", "FixedString(" + fss + ")")
                 .column("fixed_string_bytes", "FixedString(" + fss + ")")
-                .engine("MergeTree")
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         Collection<SinkRecord> sr = SchemaTestData.createFixedStringData(topic, 1, fixedStringSize);
@@ -683,16 +709,17 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void writeBooleanValueToIntTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void writeBooleanValueToIntTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("schema-with-boolean-and-int-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
@@ -709,8 +736,8 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
                 .column("b3", "Boolean")
                 .column("b4", "Boolean")
                 .column("ii", "UInt8")
-                .engine("MergeTree")
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         int totalRecords = 100;
@@ -773,8 +800,8 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
-        List<JSONObject> rows =ClickHouseTestHelpers.getAllRowsAsJson(chc, topic);
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
+        List<JSONObject> rows =ClickHouseTestHelpers.getAllRowsAsJson(chc, topic, deploymentType);
         for (int i = 0; i < rows.size(); i++) {
             JSONObject row = rows.get(i);
             int off16 = row.getInt("off16");
@@ -798,22 +825,24 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         }
     }
 
-    @Test
-    public void schemaWithFixedStringMismatchTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void schemaWithFixedStringMismatchTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("fixed-string-mismatch-table-test");
         int fixedStringSize = RandomUtils.insecure().randomInt(2, 100);
         LOGGER.info("FixedString size: " + fixedStringSize);
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         final int fss = fixedStringSize;
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("fixed_string_string", "FixedString(" + (fss - 1) + ")")
-                .engine("MergeTree")
+
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         Collection<SinkRecord> sr = SchemaTestData.createFixedStringData(topic, 1, fixedStringSize);
@@ -827,19 +856,20 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.stop();
     }
 
-    @Test
-    public void schemaWithNullableDecimalTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void schemaWithNullableDecimalTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("nullable-decimal-value-table-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("decimal_14_2", "Nullable(Decimal(14, 2))")
-                .engine("MergeTree")
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         Collection<SinkRecord> sr = SchemaTestData.createDecimalValueDataWithNulls(topic, 1);
@@ -848,21 +878,23 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
-        assertEquals(450180, ClickHouseTestHelpers.sumRows(chc, topic, "decimal_14_2"));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
+        assertEquals(450180, ClickHouseTestHelpers.sumRows(chc, topic, "decimal_14_2", deploymentType));
     }
 
-    @Test
-    public void schemaWithBytesTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void schemaWithBytesTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("bytes-value-table-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("string", "String")
-                .engine("MergeTree")
+
                 .orderByColumn("`string`")
+                .deploymentType(deploymentType)
                 .execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createBytesValueData(topic, 1);
@@ -872,39 +904,42 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
-    @Test
-    public void supportEnumTest() {
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void supportEnumTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("enum-value-table-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("enum8_type", "Enum8('A' = 1, 'B' = 2, 'C' = 3)")
                 .column("enum16_type", "Enum16('A' = 1, 'B' = 2, 'C' = 3, 'D' = 4)")
-                .engine("MergeTree")
                 .orderByColumn("off16")
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = SchemaTestData.createEnumValueData(topic, 1);
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
     @Disabled("Disabled because it requires a flag on the instance.")
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
     @SinceClickHouseVersion("24.1")
-    public void schemaWithTupleOfMapsWithVariantTest() {
+    public void schemaWithTupleOfMapsWithVariantTest(ClickHouseDeploymentType deploymentType) {
         Assumptions.assumeFalse(isCloud, "Skip test since experimental is not available in cloud");
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = "tuple-array-map-variant-table-test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
 
         String simpleTuple = "Tuple(" +
                 "    `variant_with_string` Variant(Double, String)," +
@@ -934,9 +969,9 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("tuple", tupleType)
-                .engine("MergeTree")
                 .orderByColumn("`off16`")
                 .settings(Map.of("allow_experimental_variant_type", 1))
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = SchemaTestData.createTupleType(topic, 1, 5);
 
@@ -945,9 +980,9 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
 
-        List<JSONObject> allRows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic);
+        List<JSONObject> allRows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic, deploymentType);
         for (int i = 0; i < sr.size(); i++) {
             JSONObject row = allRows.get(i);
 
@@ -959,9 +994,10 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
     }
 
     @Disabled("Disabled because it requires a flag on the instance.")
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
     @SinceClickHouseVersion("24.1")
-    public void schemaWithNestedTupleMapArrayAndVariant() {
+    public void schemaWithNestedTupleMapArrayAndVariant(ClickHouseDeploymentType deploymentType) {
         if (isCloud) {
             LOGGER.warn("Skip test since experimental is not available in cloud");
             return;
@@ -969,7 +1005,7 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = "nested-tuple-map-array-and-variant-table-test";
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
 
         new CreateTableStatement()
                 .tableName(topic)
@@ -981,9 +1017,9 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
                         "    `map` Map(String, String)," +
                         "    `variant` Variant(Boolean, String)" +
                         "))")
-                .engine("MergeTree")
                 .orderByColumn("`off16`")
                 .settings(Map.of("allow_experimental_variant_type", 1))
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = SchemaTestData.createNestedType(topic, 1);
 
@@ -992,9 +1028,9 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
 
-        List<JSONObject> allRows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic);
+        List<JSONObject> allRows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic, deploymentType);
         for (int i = 0; i < allRows.size(); i++) {
             JSONObject row = allRows.get(i);
 
@@ -1033,13 +1069,14 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         }
     }
 
-    @Test
-    public void unsignedIntegers() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void unsignedIntegers(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = createTopicName("unsigned-integers-table-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
@@ -1047,8 +1084,8 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
                 .column("uint16", "UInt16")
                 .column("uint32", "UInt32")
                 .column("uint64", "UInt64")
-                .engine("MergeTree")
                 .orderByColumn("`off16`")
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = SchemaTestData.createUnsignedIntegers(topic, 1);
 
@@ -1056,17 +1093,19 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void changeSchemaWhileRunning() throws InterruptedException {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void changeSchemaWhileRunning(ClickHouseDeploymentType deploymentType) throws InterruptedException {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("change-schema-while-running-table-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(CHANGE_SCHEMA_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = SchemaTestData.createSimpleData(topic, 1);
 
@@ -1074,37 +1113,40 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
 
 
-        ClickHouseTestHelpers.runQuery(chc, String.format("ALTER TABLE `%s` ADD COLUMN num32 Nullable(Int32) AFTER string", topic));
+        String clusterClause = deploymentType.isLocalCluster() ? " ON CLUSTER '" + deploymentType.clusterName + "'" : "";
+        ClickHouseTestHelpers.runQuery(chc, String.format("ALTER TABLE `%s`%s ADD COLUMN num32 Nullable(Int32) AFTER string", topic, clusterClause));
         Thread.sleep(5000);
         sr = SchemaTestData.createSimpleExtendWithNullableData(topic, 1, 10000, 2000);
         int numRecordsWithNullable = sr.size();
         chst.put(sr);
 
-        ClickHouseTestHelpers.runQuery(chc, String.format("ALTER TABLE `%s` ADD COLUMN num32_default Int32 DEFAULT 0 AFTER num32", topic));
+        ClickHouseTestHelpers.runQuery(chc, String.format("ALTER TABLE `%s`%s ADD COLUMN num32_default Int32 DEFAULT 0 AFTER num32", topic, clusterClause));
         Thread.sleep(5000);
 
         sr = SchemaTestData.createSimpleExtendWithDefaultData(topic, 1, 20000, 3000);
         int numRecordsWithDefault = sr.size();
         System.out.println("numRecordsWithDefault: " + numRecordsWithDefault);
         chst.put(sr);
-        ClickHouseTestHelpers.getAllRowsAsJson(chc, topic).forEach(row -> {
+        ClickHouseTestHelpers.getAllRowsAsJson(chc, topic, deploymentType).forEach(row -> {
             //System.out.println(row);
         });
         chst.stop();
-        assertEquals(numRecords + numRecordsWithNullable + numRecordsWithDefault, ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(numRecords + numRecordsWithNullable + numRecordsWithDefault, ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void changeSchemaWhileRunningAddDefaultColumnOldSchemaData() throws InterruptedException {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void changeSchemaWhileRunningAddDefaultColumnOldSchemaData(ClickHouseDeploymentType deploymentType) throws InterruptedException {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("change-schema-add-default-old-schema-data-test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(CHANGE_SCHEMA_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         Collection<SinkRecord> firstBatch = SchemaTestData.createSimpleData(topic, 1, 1000);
@@ -1124,9 +1166,10 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(firstBatch);
-        assertEquals(firstBatch.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(firstBatch.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
 
-        ClickHouseTestHelpers.runQuery(chc, String.format("ALTER TABLE `%s` ADD COLUMN num32_default Int32 DEFAULT 42 AFTER string", topic));
+        String clusterClause = deploymentType.isLocalCluster() ? " ON CLUSTER '" + deploymentType.clusterName + "'" : "";
+        ClickHouseTestHelpers.runQuery(chc, String.format("ALTER TABLE `%s`%s ADD COLUMN num32_default Int32 DEFAULT 42 AFTER string", topic, clusterClause));
         Thread.sleep(5000);
 
         // Keep writing records with the old schema (without num32_default).
@@ -1134,18 +1177,20 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(secondBatch);
         chst.stop();
 
-        assertEquals(firstBatch.size() + secondBatch.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(firstBatch.size() + secondBatch.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void changeSchemaWhileRunningWithRefreshEnabled() throws InterruptedException {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void changeSchemaWhileRunningWithRefreshEnabled(ClickHouseDeploymentType deploymentType) throws InterruptedException {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         props.put(ClickHouseSinkConfig.TABLE_REFRESH_INTERVAL, "1");
         String topic = createTopicName("change-schema-while-running-table-test-with-refresh-enabled");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(CHANGE_SCHEMA_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
         Collection<SinkRecord> sr = SchemaTestData.createSimpleData(topic, 1);
 
@@ -1153,42 +1198,45 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(sr);
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
 
 
-        ClickHouseTestHelpers.runQuery(chc, String.format("ALTER TABLE `%s` ADD COLUMN num32 Nullable(Int32) AFTER string", topic));
+        String clusterClause = deploymentType.isLocalCluster() ? " ON CLUSTER '" + deploymentType.clusterName + "'" : "";
+        ClickHouseTestHelpers.runQuery(chc, String.format("ALTER TABLE `%s`%s ADD COLUMN num32 Nullable(Int32) AFTER string", topic, clusterClause));
         Thread.sleep(5000);
         sr = SchemaTestData.createSimpleExtendWithNullableData(topic, 1, 10000, 2000);
         int numRecordsWithNullable = sr.size();
         chst.put(sr);
 
-        ClickHouseTestHelpers.runQuery(chc, String.format("ALTER TABLE `%s` ADD COLUMN num32_default Int32 DEFAULT 0 AFTER num32", topic));
+        ClickHouseTestHelpers.runQuery(chc, String.format("ALTER TABLE `%s`%s ADD COLUMN num32_default Int32 DEFAULT 0 AFTER num32", topic, clusterClause));
         Thread.sleep(5000);
 
         sr = SchemaTestData.createSimpleExtendWithDefaultData(topic, 1, 20000, 3000);
         int numRecordsWithDefault = sr.size();
         System.out.println("numRecordsWithDefault: " + numRecordsWithDefault);
         chst.put(sr);
-        ClickHouseTestHelpers.getAllRowsAsJson(chc, topic).forEach(row -> {
+        ClickHouseTestHelpers.getAllRowsAsJson(chc, topic, deploymentType).forEach(row -> {
             //System.out.println(row);
         });
         chst.stop();
-        assertEquals(numRecords + numRecordsWithNullable + numRecordsWithDefault, ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(numRecords + numRecordsWithNullable + numRecordsWithDefault, ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
-    @Test
-    public void tupleTest() {
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void tupleTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("tuple-table-test");
 
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("string", "String")
                 .column("t", "Tuple(`off16` Nullable(Int16), `string` Nullable(String))")
-                .engine("MergeTree")
                 .orderByColumn("`off16`")
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         Collection<SinkRecord> sr = SchemaTestData.createTupleSimpleData(topic, 1);
@@ -1198,23 +1246,25 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
-    @Test
-    public void tupleTestWithDefault() {
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void tupleTestWithDefault(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("tuple-table-test-default");
 
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("string", "String")
                 .column("insert_datetime", "DateTime default now()")
                 .column("t", "Tuple(`off16` Nullable(Int16), `string` Nullable(String))")
-                .engine("MergeTree")
                 .orderByColumn("`off16`")
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         Collection<SinkRecord> sr = SchemaTestData.createTupleSimpleData(topic, 1);
@@ -1224,16 +1274,17 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
-    public void nestedTupleTestWithDefault() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void nestedTupleTestWithDefault(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("nested-tuple-table-test-default");
 
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
@@ -1243,8 +1294,8 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
                         "`off16` Nullable(Int16), " +
                         "`string` Nullable(String), " +
                         "`n` Tuple(`off16` Nullable(Int16), `string` Nullable(String)))")
-                .engine("MergeTree")
                 .orderByColumn("`off16`")
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         Collection<SinkRecord> sr = SchemaTestData.createNestedTupleSimpleData(topic, 1);
@@ -1254,7 +1305,7 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
     /**
@@ -1263,13 +1314,14 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
      * insert path (JSONEachRow).  Covers the Gson→Jackson migration by
      * verifying actual inserted values, not just row counts.
      */
-    @Test
-    public void jacksonStructJsonInsertTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void jacksonStructJsonInsertTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("jackson-struct-json-insert");
 
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
@@ -1280,8 +1332,8 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
                         "`off16` Nullable(Int16), " +
                         "`label` Nullable(String), " +
                         "`n` Tuple(`value` Nullable(Int32), `tag` Nullable(String)))")
-                .engine("MergeTree")
                 .orderByColumn("`off16`")
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         Schema innerTupleSchema = SchemaBuilder.struct()
@@ -1334,9 +1386,9 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(records);
         chst.stop();
 
-        assertEquals(totalRecords, ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(totalRecords, ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
 
-        List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic);
+        List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic, deploymentType);
         assertEquals(totalRecords, rows.size());
 
         // Sort by off16 so we can assert deterministically
@@ -1364,20 +1416,21 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
      * Jackson's JacksonStructSerializer writes explicit nulls which
      * ClickHouse Nullable columns accept correctly.
      */
-    @Test
-    public void jacksonStructWithNullsJsonInsertTest() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void jacksonStructWithNullsJsonInsertTest(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("jackson-struct-nulls-json-insert");
 
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("name", "Nullable(String)")
                 .column("t", "Tuple(`off16` Nullable(Int16), `label` Nullable(String))")
-                .engine("MergeTree")
                 .orderByColumn("`off16`")
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         Schema tupleSchema = SchemaBuilder.struct()
@@ -1420,9 +1473,9 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(records);
         chst.stop();
 
-        assertEquals(2, ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(2, ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
 
-        List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic);
+        List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic, deploymentType);
         rows.sort((a, b) -> Integer.compare(a.getInt("off16"), b.getInt("off16")));
 
         // Row 1: all non-null
@@ -1442,13 +1495,14 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         assertTrue(t2.isNull("label"));
     }
 
-    @Test
-    public void coolSchemaWithRandomFields() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void coolSchemaWithRandomFields(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("cool-schema-with-random-field");
 
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("processing_time", "DateTime")
@@ -1461,8 +1515,8 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
                 .column("desc", "Nullable(String)")
                 .column("tag", "Nullable(String)")
                 .column("va", "Nullable(Float64)")
-                .engine("MergeTree")
                 .orderByColumn("`processing_time`")
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         Collection<SinkRecord> sr = SchemaTestData.createCoolSchemaWithRandomFields(topic, 1);
@@ -1473,17 +1527,18 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(sr);
         chst.stop();
 
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
     @SinceClickHouseVersion("24.10")
-    public void testWritingJsonAsStringWithRowBinary() {
+    public void testWritingJsonAsStringWithRowBinary(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         props.put(ClickHouseSinkConfig.CLICKHOUSE_SETTINGS, "input_format_binary_read_json_as_string=1");
         String topic = createTopicName("schema_json_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
 
         Map<String, Serializable> clientSettings = new HashMap<>();
         clientSettings.put(ClientConfigProperties.serverSetting("allow_experimental_json_type"), "1");
@@ -1492,9 +1547,9 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
                 .column("off16", "Int16")
                 .column("struct_content", "JSON")
                 .column("json_as_str", "JSON")
-                .engine("MergeTree")
                 .orderByColumn("off16")
                 .settings(clientSettings)
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         Collection<SinkRecord> sr = SchemaTestData.createJSONType(topic, 1, 10);
@@ -1502,18 +1557,19 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.start(props);
         chst.put(sr);
         chst.stop();
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
     @SinceClickHouseVersion("24.10")
-    public void testWritingProtoMessageWithRowBinary() throws Exception {
+    public void testWritingProtoMessageWithRowBinary(ClickHouseDeploymentType deploymentType) throws Exception {
 
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         props.put(ClickHouseSinkConfig.CLICKHOUSE_SETTINGS, "input_format_binary_read_json_as_string=1");
         String topic = createTopicName("protobuf_table_test");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
 
         TestProtos.TestMessage userMsg = SchemaTestData.createUserMessage();
         TestProtos.TestMessage productMsg = SchemaTestData.createProductMessage();
@@ -1555,19 +1611,19 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
                 .column("score", "Float64")
                 .column("tags", "Array(String)")
                 .column("content", "JSON")
-                .engine("MergeTree")
                 .orderByColumn("()")
                 .settings(clientSettings)
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
         chst.start(props);
         chst.put(records);
         chst.stop();
-        assertEquals(records.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(records.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
 
         // Verify the actual row data matches the proto JSON conversion by comparing JSON strings
-        List<JSONObject> insertedRows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic);
+        List<JSONObject> insertedRows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic, deploymentType);
         assertEquals(records.size(), insertedRows.size());
 
         // Compare database rows directly with protobuf message fields
@@ -1652,32 +1708,40 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         return partitions;
     }
 
+    private Stream<Arguments> exactlyOnceStateMismatchTestArgs() {
+        List<int[]> splitsAndBatches = List.of(
+                new int[]{11, 7},
+                new int[]{17, 11},
+                new int[]{37, 17},
+                new int[]{61, 37},
+                new int[]{113, 120},
+                new int[]{131, 150},
+                new int[]{150, 160},
+                new int[]{157, 131},
+                new int[]{167, 161},
+                new int[]{229, 220},
+                new int[]{229, 221}
+        );
+        Stream<Arguments> argStream = Stream.of();
+        for (var config : deploymentTypesForTests().collect(Collectors.toSet())) {
+            argStream = Stream.concat(argStream, splitsAndBatches.stream().map(splitAndBatch -> Arguments.of(splitAndBatch[0], splitAndBatch[1], config)));
+        }
+        return argStream;
+    }
+
     @ParameterizedTest
-    //@ValueSource(ints = {11, 17 , 37,  61, 113, 131, 150, 157, 167, 229})
-    @CsvSource({
-            "11, 7",
-            "17, 11",
-            "37, 17",
-            "61, 37",
-            "113, 120",
-            "131, 150",
-            "150, 160",
-            "157, 131",
-            "167, 161",
-            "229, 220",
-            "229, 221",
-    })
-    public void exactlyOnceStateMismatchTest(int split, int batch) {
-        // This test is running only cloud
-        if (!isCloud)
-            return;
+    @MethodSource("exactlyOnceStateMismatchTestArgs")
+    public void exactlyOnceStateMismatchTest(int split, int batch, ClickHouseDeploymentType deploymentType) {
+        Assumptions.assumeFalse(deploymentType.equals(ClickHouseDeploymentType.STANDALONE)); // skip test if running in standalone mode
+
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = "exactly_once_state_mismatch_test_" + split + "_" + batch + "_" + System.currentTimeMillis();
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement(ARRAY_TYPES_TABLE)
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .execute(chc);
         // https://github.com/apache/kafka/blob/trunk/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java#L95-L98
         Collection<SinkRecord> sr = SchemaTestData.createArrayType(topic, 1);
@@ -1693,18 +1757,19 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         for (Collection<SinkRecord> records : data) {
             chst.put(records);
         }
-        assertEquals(data.size() * split, ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(data.size() * split, ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
         for (Collection<SinkRecord> records : data01) {
             chst.put(records);
         }
         chst.stop();
         // after the second insert we have exactly sr.size() records
-        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));assertTrue(ClickHouseTestHelpers.validateRows(chc, topic, sr));
-
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));assertTrue(ClickHouseTestHelpers.validateRows(chc, topic, sr, deploymentType));
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
     }
 
-    @Test
-    public void testAvroWithUnion() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void testAvroWithUnion(ClickHouseDeploymentType deploymentType) throws Exception {
         Image image1 = Image.newBuilder()
                 .setName("image1")
                 .setContent("content")
@@ -1719,14 +1784,14 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         List<SinkRecord> records = SchemaTestData.convertAvroToSinkRecord(topic, new AvroSchema(Image.getClassSchema()), Arrays.asList(image1, image2));
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("name", "String")
                 .column("content", "String")
                 .column("description", "Nullable(String)")
-                .engine("MergeTree")
                 .orderByColumn("()")
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
@@ -1734,12 +1799,12 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.put(records);
         chst.stop();
 
-        List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic);
+        List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic, deploymentType);
         if (rows.size() == 0) {
-            rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic);
+            rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic, deploymentType);
             LOGGER.info("Second attempt read: {}", rows.size());
             if (rows.size() == 0) {
-                rows = ClickHouseTestHelpers.getAllRowsAsJsonCloud(chc, topic);
+                rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic, deploymentType);
                 LOGGER.info("Third attempt read: {}", rows.size());
             }
         }
@@ -1751,10 +1816,12 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         assertEquals("image2", row.getString("name"));
         assertEquals("description", row.getString("description"));
         assertEquals("content2", row.getString("content"));
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
     }
 
-    @Test
-    public void testAvroDateAndTimeTypes() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void testAvroDateAndTimeTypes(ClickHouseDeploymentType deploymentType) throws Exception {
 
         final String topic = createTopicName("test_avro_timestamps");
         final ZoneId tz = ZoneId.of("UTC");
@@ -1774,14 +1841,14 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
 
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
                 .column("id", "Int64")
                 .column("time1", "DateTime64(3)")
                 .column("time2", "DateTime64(3)")
-                .engine("MergeTree")
                 .orderByColumn("()")
+                .deploymentType(deploymentType)
                 .execute(chc);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
@@ -1790,7 +1857,7 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         chst.stop();
 
 
-        List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic);
+        List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic, deploymentType);
         assertEquals(events.size(), rows.size());
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(tz);
         DateTimeFormatter localFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
@@ -1801,5 +1868,6 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
             assertEquals(formatter.format(event.getTime1()), row.get("time1"));
             assertEquals(event.getTime2().atDate(LocalDate.of(1970, 1, 1)).format(localFormatter), row.get("time2"));
         }
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
     }
 }

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
@@ -193,7 +193,6 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("arr", "Array(String)")
-
                 .orderByColumn("off16")
                 .deploymentType(deploymentType)
                 .execute(chc);
@@ -219,7 +218,6 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("arr", "Array(Nullable(String))")
-
                 .orderByColumn("off16")
                 .deploymentType(deploymentType)
                 .execute(chc);
@@ -264,7 +262,7 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
                 .engine("Null")
                 .deploymentType(deploymentType)
                 .execute(chc);
-        ClickHouseTestHelpers.runQuery(chc, String.format("CREATE MATERIALIZED VIEW %s_mv TO " + topic + "_mate AS SELECT off16 FROM " + topic, topic));
+        ClickHouseTestHelpers.executeQueryIgnoreResult(chc, String.format("CREATE MATERIALIZED VIEW %s_mv TO " + topic + "_mate AS SELECT off16 FROM " + topic, topic));
         Collection<SinkRecord> sr = SchemaTestData.createArrayType(topic, 1);
 
         ClickHouseSinkTask chst = new ClickHouseSinkTask();
@@ -840,7 +838,6 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
                 .tableName(topic)
                 .column("off16", "Int16")
                 .column("fixed_string_string", "FixedString(" + (fss - 1) + ")")
-
                 .orderByColumn("off16")
                 .deploymentType(deploymentType)
                 .execute(chc);
@@ -892,7 +889,6 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         new CreateTableStatement()
                 .tableName(topic)
                 .column("string", "String")
-
                 .orderByColumn("`string`")
                 .deploymentType(deploymentType)
                 .execute(chc);
@@ -1117,13 +1113,13 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
 
 
         String clusterClause = deploymentType.isLocalCluster() ? " ON CLUSTER '" + deploymentType.clusterName + "'" : "";
-        ClickHouseTestHelpers.runQuery(chc, String.format("ALTER TABLE `%s`%s ADD COLUMN num32 Nullable(Int32) AFTER string", topic, clusterClause));
+        ClickHouseTestHelpers.executeQueryIgnoreResult(chc, String.format("ALTER TABLE `%s`%s ADD COLUMN num32 Nullable(Int32) AFTER string", topic, clusterClause));
         Thread.sleep(5000);
         sr = SchemaTestData.createSimpleExtendWithNullableData(topic, 1, 10000, 2000);
         int numRecordsWithNullable = sr.size();
         chst.put(sr);
 
-        ClickHouseTestHelpers.runQuery(chc, String.format("ALTER TABLE `%s`%s ADD COLUMN num32_default Int32 DEFAULT 0 AFTER num32", topic, clusterClause));
+        ClickHouseTestHelpers.executeQueryIgnoreResult(chc, String.format("ALTER TABLE `%s`%s ADD COLUMN num32_default Int32 DEFAULT 0 AFTER num32", topic, clusterClause));
         Thread.sleep(5000);
 
         sr = SchemaTestData.createSimpleExtendWithDefaultData(topic, 1, 20000, 3000);
@@ -1169,7 +1165,7 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         assertEquals(firstBatch.size(), ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
 
         String clusterClause = deploymentType.isLocalCluster() ? " ON CLUSTER '" + deploymentType.clusterName + "'" : "";
-        ClickHouseTestHelpers.runQuery(chc, String.format("ALTER TABLE `%s`%s ADD COLUMN num32_default Int32 DEFAULT 42 AFTER string", topic, clusterClause));
+        ClickHouseTestHelpers.executeQueryIgnoreResult(chc, String.format("ALTER TABLE `%s`%s ADD COLUMN num32_default Int32 DEFAULT 42 AFTER string", topic, clusterClause));
         Thread.sleep(5000);
 
         // Keep writing records with the old schema (without num32_default).
@@ -1202,13 +1198,13 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
 
 
         String clusterClause = deploymentType.isLocalCluster() ? " ON CLUSTER '" + deploymentType.clusterName + "'" : "";
-        ClickHouseTestHelpers.runQuery(chc, String.format("ALTER TABLE `%s`%s ADD COLUMN num32 Nullable(Int32) AFTER string", topic, clusterClause));
+        ClickHouseTestHelpers.executeQueryIgnoreResult(chc, String.format("ALTER TABLE `%s`%s ADD COLUMN num32 Nullable(Int32) AFTER string", topic, clusterClause));
         Thread.sleep(5000);
         sr = SchemaTestData.createSimpleExtendWithNullableData(topic, 1, 10000, 2000);
         int numRecordsWithNullable = sr.size();
         chst.put(sr);
 
-        ClickHouseTestHelpers.runQuery(chc, String.format("ALTER TABLE `%s`%s ADD COLUMN num32_default Int32 DEFAULT 0 AFTER num32", topic, clusterClause));
+        ClickHouseTestHelpers.executeQueryIgnoreResult(chc, String.format("ALTER TABLE `%s`%s ADD COLUMN num32_default Int32 DEFAULT 0 AFTER num32", topic, clusterClause));
         Thread.sleep(5000);
 
         sr = SchemaTestData.createSimpleExtendWithDefaultData(topic, 1, 20000, 3000);

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterTest.java
@@ -12,6 +12,7 @@ import com.clickhouse.kafka.connect.sink.db.mapping.Column;
 import com.clickhouse.kafka.connect.sink.db.mapping.Table;
 import com.clickhouse.kafka.connect.sink.db.mapping.Type;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseDeploymentType;
 import com.clickhouse.kafka.connect.sink.helper.CreateTableStatement;
 import com.clickhouse.kafka.connect.test.junit.extension.FromVersionConditionExtension;
 import com.clickhouse.kafka.connect.util.QueryIdentifier;
@@ -26,6 +27,8 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +54,6 @@ public class ClickHouseWriterTest extends ClickHouseBase {
 
     private static final CreateTableStatement SINGLE_INT16_TABLE = new CreateTableStatement()
             .column("off16", "Int16")
-            .engine("MergeTree")
             .orderByColumn("off16");
 
     ClickHouseHelperClient chc = null;
@@ -127,36 +129,38 @@ public class ClickHouseWriterTest extends ClickHouseBase {
         }
     }
 
-    @Test
-    public void updateMapping() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void updateMapping(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("missing_table_mapping_test");
 
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
 
         runWithWriter(props, (chw) -> {
 
-                    chw.updateMapping(chc.getDatabase());
-                    Map<String, Table> tables = chw.getMapping();
-                    assertNull(tables.get(Utils.escapeTableName(chc.getDatabase(), topic)));
+            chw.updateMapping(chc.getDatabase());
+            Map<String, Table> tables = chw.getMapping();
+            assertNull(tables.get(Utils.escapeTableName(chc.getDatabase(), topic)));
 
 
-                    new CreateTableStatement(SINGLE_INT16_TABLE).tableName(topic).execute(chc);
+            new CreateTableStatement(SINGLE_INT16_TABLE).tableName(topic).execute(chc);
 
-                    Table table = chw.getTable(chc.getDatabase(), topic);
-                    assertNotNull(table);
-                    assertEquals(Utils.escapeTableName(chc.getDatabase(), topic), table.getFullName());
+            Table table = chw.getTable(chc.getDatabase(), topic);
+            assertNotNull(table);
+            assertEquals(Utils.escapeTableName(chc.getDatabase(), topic), table.getFullName());
 
-                    tables = chw.getMapping();
-                    assertNotNull(tables.get(Utils.escapeTableName(chc.getDatabase(), topic)));
-                });
+            tables = chw.getMapping();
+            assertNotNull(tables.get(Utils.escapeTableName(chc.getDatabase(), topic)));
+        });
 
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
     }
 
-    @Test
-    public void getTableUsesTopicToTableMapping() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void getTableUsesTopicToTableMapping(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         String topicWithoutBackticks = createTopicName("mapped_source_topic_plain_test");
         String mappedTableWithoutBackticks = createTopicName("mapped_target_table_plain_test");
@@ -168,10 +172,10 @@ public class ClickHouseWriterTest extends ClickHouseBase {
                         + topicWithBackticks + "=" + mappedTableWithBackticks);
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
-        ClickHouseTestHelpers.dropTable(chc, topicWithoutBackticks);
-        ClickHouseTestHelpers.dropTable(chc, topicWithBackticks);
-        ClickHouseTestHelpers.dropTable(chc, mappedTableWithoutBackticks);
-        ClickHouseTestHelpers.dropTable(chc, mappedTableWithBackticksRaw);
+        ClickHouseTestHelpers.dropTable(chc, topicWithoutBackticks, deploymentType);
+        ClickHouseTestHelpers.dropTable(chc, topicWithBackticks, deploymentType);
+        ClickHouseTestHelpers.dropTable(chc, mappedTableWithoutBackticks, deploymentType);
+        ClickHouseTestHelpers.dropTable(chc, mappedTableWithBackticksRaw, deploymentType);
         new CreateTableStatement(SINGLE_INT16_TABLE).tableName(mappedTableWithoutBackticks).execute(chc);
         new CreateTableStatement(SINGLE_INT16_TABLE).tableName(mappedTableWithBackticksRaw).execute(chc);
 
@@ -184,51 +188,59 @@ public class ClickHouseWriterTest extends ClickHouseBase {
             assertNotNull(backtickedMappingTable);
             assertEquals(Utils.escapeTableName(chc.getDatabase(), mappedTableWithBackticksRaw), backtickedMappingTable.getFullName());
         });
-        ClickHouseTestHelpers.dropTable(chc, mappedTableWithoutBackticks);
-        ClickHouseTestHelpers.dropTable(chc, mappedTableWithBackticksRaw);
+        ClickHouseTestHelpers.dropTable(chc, topicWithoutBackticks, deploymentType);
+        ClickHouseTestHelpers.dropTable(chc, topicWithBackticks, deploymentType);
+        ClickHouseTestHelpers.dropTable(chc, mappedTableWithoutBackticks, deploymentType);
+        ClickHouseTestHelpers.dropTable(chc, mappedTableWithBackticksRaw, deploymentType);
     }
 
-    @Test
-    public void getTableThrowsWhenMissingAndSuppressionDisabled() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void getTableThrowsWhenMissingAndSuppressionDisabled(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("missing_table_get_table_throw_test");
 
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
 
         runWithWriter(props, (chw) -> {
             RuntimeException ex = assertThrows(RuntimeException.class, () -> chw.getTable(chc.getDatabase(), topic));
             assertTrue(ex.getMessage().contains("does not exist"));
         });
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
     }
 
-    @Test
-    public void getTableReturnsNullWhenMissingAndSuppressionEnabled() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void getTableReturnsNullWhenMissingAndSuppressionEnabled(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.SUPPRESS_TABLE_EXISTENCE_EXCEPTION, "true");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("missing_table_get_table_suppressed_test");
 
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
 
         runWithWriter(props, (chw) -> {
             Table table = chw.getTable(chc.getDatabase(), topic);
             assertNull(table);
         });
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
     }
 
-    @Test
-    public void doWriteColValue_Tuples() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void doWriteColValue_Tuples(ClickHouseDeploymentType deploymentType) throws Exception {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("do_insert_tuple_order_mismatch_test");
 
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .column("_id", "String")
                 .column("result", "Tuple(`id` String, `isanswered` Int32, `relevancescore` Float64, `subject` String, `istextanswered` Int32)")
-                .engine("MergeTree").orderByColumn("_id").execute(chc);
+                .orderByColumn("_id").execute(chc);
 
         Schema tupleSchema = SchemaBuilder.struct()
                 .field("isanswered", Schema.INT32_SCHEMA)
@@ -272,7 +284,7 @@ public class ClickHouseWriterTest extends ClickHouseBase {
             }
         });
 
-        List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic);
+        List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic, deploymentType);
         assertEquals(1, rows.size());
         JSONObject row = rows.get(0);
         assertEquals("id-1", row.getString("_id"));
@@ -283,6 +295,6 @@ public class ClickHouseWriterTest extends ClickHouseBase {
         assertEquals("SUBJECT", tuple.getString("subject"));
         assertEquals(1, tuple.getInt("istextanswered"));
 
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
     }
 }

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterTest.java
@@ -140,20 +140,20 @@ public class ClickHouseWriterTest extends ClickHouseBase {
 
         runWithWriter(props, (chw) -> {
 
-            chw.updateMapping(chc.getDatabase());
-            Map<String, Table> tables = chw.getMapping();
-            assertNull(tables.get(Utils.escapeTableName(chc.getDatabase(), topic)));
+                chw.updateMapping(chc.getDatabase());
+                Map<String, Table> tables = chw.getMapping();
+                assertNull(tables.get(Utils.escapeTableName(chc.getDatabase(), topic)));
 
 
-            new CreateTableStatement(SINGLE_INT16_TABLE).tableName(topic).execute(chc);
+                new CreateTableStatement(SINGLE_INT16_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
 
-            Table table = chw.getTable(chc.getDatabase(), topic);
-            assertNotNull(table);
-            assertEquals(Utils.escapeTableName(chc.getDatabase(), topic), table.getFullName());
+                Table table = chw.getTable(chc.getDatabase(), topic);
+                assertNotNull(table);
+                assertEquals(Utils.escapeTableName(chc.getDatabase(), topic), table.getFullName());
 
-            tables = chw.getMapping();
-            assertNotNull(tables.get(Utils.escapeTableName(chc.getDatabase(), topic)));
-        });
+                tables = chw.getMapping();
+                assertNotNull(tables.get(Utils.escapeTableName(chc.getDatabase(), topic)));
+            });
 
         ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
     }
@@ -176,8 +176,8 @@ public class ClickHouseWriterTest extends ClickHouseBase {
         ClickHouseTestHelpers.dropTable(chc, topicWithBackticks, deploymentType);
         ClickHouseTestHelpers.dropTable(chc, mappedTableWithoutBackticks, deploymentType);
         ClickHouseTestHelpers.dropTable(chc, mappedTableWithBackticksRaw, deploymentType);
-        new CreateTableStatement(SINGLE_INT16_TABLE).tableName(mappedTableWithoutBackticks).execute(chc);
-        new CreateTableStatement(SINGLE_INT16_TABLE).tableName(mappedTableWithBackticksRaw).execute(chc);
+        new CreateTableStatement(SINGLE_INT16_TABLE).tableName(mappedTableWithoutBackticks).deploymentType(deploymentType).execute(chc);
+        new CreateTableStatement(SINGLE_INT16_TABLE).tableName(mappedTableWithBackticksRaw).deploymentType(deploymentType).execute(chc);
 
         runWithWriter(props, (chw) -> {
             Table plainMappingTable = chw.getTable(chc.getDatabase(), topicWithoutBackticks);
@@ -188,8 +188,6 @@ public class ClickHouseWriterTest extends ClickHouseBase {
             assertNotNull(backtickedMappingTable);
             assertEquals(Utils.escapeTableName(chc.getDatabase(), mappedTableWithBackticksRaw), backtickedMappingTable.getFullName());
         });
-        ClickHouseTestHelpers.dropTable(chc, topicWithoutBackticks, deploymentType);
-        ClickHouseTestHelpers.dropTable(chc, topicWithBackticks, deploymentType);
         ClickHouseTestHelpers.dropTable(chc, mappedTableWithoutBackticks, deploymentType);
         ClickHouseTestHelpers.dropTable(chc, mappedTableWithBackticksRaw, deploymentType);
     }
@@ -240,6 +238,7 @@ public class ClickHouseWriterTest extends ClickHouseBase {
                 .deploymentType(deploymentType)
                 .column("_id", "String")
                 .column("result", "Tuple(`id` String, `isanswered` Int32, `relevancescore` Float64, `subject` String, `istextanswered` Int32)")
+                .deploymentType(deploymentType)
                 .orderByColumn("_id").execute(chc);
 
         Schema tupleSchema = SchemaBuilder.struct()

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClientTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClientTest.java
@@ -3,6 +3,7 @@ package com.clickhouse.kafka.connect.sink.db.helper;
 import com.clickhouse.kafka.connect.sink.ClickHouseBase;
 import com.clickhouse.kafka.connect.sink.db.mapping.Table;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseDeploymentType;
 import com.clickhouse.kafka.connect.sink.helper.CreateTableStatement;
 import com.clickhouse.kafka.connect.test.junit.extension.FromVersionConditionExtension;
 import com.clickhouse.kafka.connect.test.junit.extension.SinceClickHouseVersion;
@@ -10,6 +11,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,7 +26,6 @@ public class ClickHouseHelperClientTest extends ClickHouseBase {
 
     private static final CreateTableStatement SINGLE_NUM_TABLE = new CreateTableStatement()
             .column("num", "String")
-            .engine("MergeTree")
             .orderByColumn("num");
 
     ClickHouseHelperClient chc = null;
@@ -40,56 +42,60 @@ public class ClickHouseHelperClientTest extends ClickHouseBase {
         Assertions.assertTrue(chc.ping());
     }
 
-    @Test
-    public void showTables() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void showTables(ClickHouseDeploymentType deploymentType) {
         String topic = createTopicName("simple_table_test");
         new CreateTableStatement(SINGLE_NUM_TABLE).tableName(topic).execute(chc);
         try {
             List<Table> table = chc.showTables(chc.getDatabase());
-            List<String> tableNames = table.stream().map(item -> item.getCleanName()).collect(Collectors.toList());
+            List<String> tableNames = table.stream().map(Table::getCleanName).collect(Collectors.toList());
             Assertions.assertTrue(tableNames.contains(topic));
         } finally {
-            ClickHouseTestHelpers.dropTable(chc, topic);
+            ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         }
     }
 
-    @Test
-    public void describeNestedFlattenedTable() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void describeNestedFlattenedTable(ClickHouseDeploymentType deploymentType) {
         String topic = createTopicName("nested_flattened_table_test");
         new CreateTableStatement()
                 .tableName(topic)
                 .column("num", "String")
                 .column("nested", "Nested (innerInt Int32, innerString String)")
-                .engine("MergeTree").orderByColumn("num").execute(chc);
+                .orderByColumn("num").execute(chc);
 
         try {
             Table table = chc.describeTable(chc.getDatabase(), topic);
             Assertions.assertEquals(3, table.getRootColumnsList().size());
         } finally {
-            ClickHouseTestHelpers.dropTable(chc, topic);
+            ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         }
     }
 
-    @Test
-    public void ignoreArrayWithNestedTable() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void ignoreArrayWithNestedTable(ClickHouseDeploymentType deploymentType) {
         String topic = createTopicName("nested_table_test");
         new CreateTableStatement()
                 .tableName(topic)
                 .column("num", "String")
                 .column("nested", "Array(Nested (innerInt Int32, innerString String))")
-                .engine("MergeTree").orderByColumn("num").execute(chc);
+                .orderByColumn("num").execute(chc);
 
         try {
             Table table = chc.describeTable(chc.getDatabase(), topic);
             Assertions.assertNull(table);
         } finally {
-            ClickHouseTestHelpers.dropTable(chc, topic);
+            ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         }
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
     @SinceClickHouseVersion("24.1")
-    public void describeNestedUnFlattenedTable() {
+    public void describeNestedUnFlattenedTable(ClickHouseDeploymentType deploymentType) {
         String nestedTopic = createTopicName("nested_unflattened_table_test");
         String normalTopic = createTopicName("normal_unflattened_table_test");
         String testUsername = createTestUsername("unflatten");
@@ -106,7 +112,7 @@ public class ClickHouseHelperClientTest extends ClickHouseBase {
                 .tableName(nestedTopic)
                 .column("num", "String")
                 .column("nested", "Nested (innerInt Int32, innerString String)")
-                .engine("MergeTree").orderByColumn("num").execute(chc);
+                .orderByColumn("num").execute(chc);
         new CreateTableStatement(SINGLE_NUM_TABLE).tableName(normalTopic).execute(chc);
 
         try {
@@ -116,14 +122,15 @@ public class ClickHouseHelperClientTest extends ClickHouseBase {
             Table normalTable = chc.describeTable(chc.getDatabase(), normalTopic);
             Assertions.assertEquals(1, normalTable.getRootColumnsList().size());
         } finally {
-            ClickHouseTestHelpers.dropTable(adminChc, nestedTopic);
-            ClickHouseTestHelpers.dropTable(adminChc, normalTopic);
+            ClickHouseTestHelpers.dropTable(chc, nestedTopic, deploymentType);
+            ClickHouseTestHelpers.dropTable(chc, normalTopic, deploymentType);
             ClickHouseTestHelpers.executeQueryIgnoreResult(adminChc, String.format("DROP USER IF EXISTS `%s`", testUsername));
         }
     }
 
-    @Test
-    public void ignoreSubColumnsOfAliasEphemeralAndMaterialized() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void ignoreSubColumnsOfAliasEphemeralAndMaterialized(ClickHouseDeploymentType deploymentType) {
         String topic = createTopicName("alias_ephemeral_subcol_test");
 
         new CreateTableStatement()
@@ -136,7 +143,7 @@ public class ClickHouseHelperClientTest extends ClickHouseBase {
                 .column("tuple_eph", "Tuple(s String, i Int64) EPHEMERAL")
                 .column("map_eph", "Map(String, UInt64) EPHEMERAL")
                 .column("nested_eph", "Nested(ID UInt32, Serial UInt32, InnerNested Nested(InnerId UInt32)) EPHEMERAL")
-                .engine("MergeTree").orderByColumn("off16").execute(chc);
+                .orderByColumn("off16").execute(chc);
 
         try {
             Table table = chc.describeTable(chc.getDatabase(), topic);
@@ -147,7 +154,7 @@ public class ClickHouseHelperClientTest extends ClickHouseBase {
             Assertions.assertEquals("off16", table.getAllColumnsList().get(0).getName());
             Assertions.assertEquals("off16", table.getRootColumnsList().get(0).getName());
         } finally {
-            ClickHouseTestHelpers.dropTable(chc, topic);
+            ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         }
     }
 }

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClientTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClientTest.java
@@ -46,7 +46,7 @@ public class ClickHouseHelperClientTest extends ClickHouseBase {
     @MethodSource("deploymentTypesForTests")
     public void showTables(ClickHouseDeploymentType deploymentType) {
         String topic = createTopicName("simple_table_test");
-        new CreateTableStatement(SINGLE_NUM_TABLE).tableName(topic).execute(chc);
+        new CreateTableStatement(SINGLE_NUM_TABLE).tableName(topic).deploymentType(deploymentType).execute(chc);
         try {
             List<Table> table = chc.showTables(chc.getDatabase());
             List<String> tableNames = table.stream().map(Table::getCleanName).collect(Collectors.toList());
@@ -64,6 +64,7 @@ public class ClickHouseHelperClientTest extends ClickHouseBase {
                 .tableName(topic)
                 .column("num", "String")
                 .column("nested", "Nested (innerInt Int32, innerString String)")
+                .deploymentType(deploymentType)
                 .orderByColumn("num").execute(chc);
 
         try {
@@ -82,6 +83,7 @@ public class ClickHouseHelperClientTest extends ClickHouseBase {
                 .tableName(topic)
                 .column("num", "String")
                 .column("nested", "Array(Nested (innerInt Int32, innerString String))")
+                .deploymentType(deploymentType)
                 .orderByColumn("num").execute(chc);
 
         try {
@@ -112,8 +114,9 @@ public class ClickHouseHelperClientTest extends ClickHouseBase {
                 .tableName(nestedTopic)
                 .column("num", "String")
                 .column("nested", "Nested (innerInt Int32, innerString String)")
+                .deploymentType(deploymentType)
                 .orderByColumn("num").execute(chc);
-        new CreateTableStatement(SINGLE_NUM_TABLE).tableName(normalTopic).execute(chc);
+        new CreateTableStatement(SINGLE_NUM_TABLE).tableName(normalTopic).deploymentType(deploymentType).execute(chc);
 
         try {
             Table nestedTable = chc.describeTable(chc.getDatabase(), nestedTopic);
@@ -143,6 +146,7 @@ public class ClickHouseHelperClientTest extends ClickHouseBase {
                 .column("tuple_eph", "Tuple(s String, i Int64) EPHEMERAL")
                 .column("map_eph", "Map(String, UInt64) EPHEMERAL")
                 .column("nested_eph", "Nested(ID UInt32, Serial UInt32, InnerNested Nested(InnerId UInt32)) EPHEMERAL")
+                .deploymentType(deploymentType)
                 .orderByColumn("off16").execute(chc);
 
         try {

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/mapping/TableTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/mapping/TableTest.java
@@ -4,8 +4,11 @@ import com.clickhouse.kafka.connect.ClickHouseSinkConnector;
 import com.clickhouse.kafka.connect.sink.ClickHouseBase;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseDeploymentType;
 import com.clickhouse.kafka.connect.sink.helper.CreateTableStatement;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
 import java.util.Map;
@@ -34,44 +37,46 @@ class TableTest extends ClickHouseBase {
         assertEquals(5, mapValueType.getPrecision());
     }
 
-    @Test
-    public void extractNullables() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void extractNullables(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String tableName = createTopicName("extract-table-test");
-        ClickHouseTestHelpers.dropTable(chc, tableName);
+        ClickHouseTestHelpers.dropTable(chc, tableName, deploymentType);
         new CreateTableStatement()
                 .tableName(tableName)
                 .column("off16", "Int16")
                 .column("date_number", "Nullable(Date)")
-                .engine("MergeTree").orderByColumn("off16").execute(chc);
+                .orderByColumn("off16").execute(chc);
 
         Table table = chc.describeTable(chc.getDatabase(), tableName);
         assertNotNull(table);
-        assertEquals(table.getRootColumnsList().size(), 2);
-        assertEquals(table.getAllColumnsList().size(), 3);
-        ClickHouseTestHelpers.dropTable(chc, tableName);
+        assertEquals(2, table.getRootColumnsList().size());
+        assertEquals(3, table.getAllColumnsList().size());
+        ClickHouseTestHelpers.dropTable(chc, tableName, deploymentType);
     }
 
-    @Test
-    public void extractCommentV1() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    public void extractCommentV1(ClickHouseDeploymentType deploymentType) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConnector.CLIENT_VERSION, "V1");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String tableName = createTopicName("extract-table-test");
-        ClickHouseTestHelpers.dropTable(chc, tableName);
+        ClickHouseTestHelpers.dropTable(chc, tableName, deploymentType);
         new CreateTableStatement()
                 .tableName(tableName)
                 .column("c", "String COMMENT '\\\\'")
                 .column("d", "String COMMENT '\\n'")
-                .engine("MergeTree()").orderByColumn("tuple()").execute(chc);
+                .orderByColumn("tuple()").execute(chc);
 
         Table table = chc.describeTable(chc.getDatabase(), tableName);
         assertNotNull(table);
         assertEquals(table.getRootColumnsList().size(), 2);
-        ClickHouseTestHelpers.dropTable(chc, tableName);
+        ClickHouseTestHelpers.dropTable(chc, tableName, deploymentType);
     }
 
     @Test

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/mapping/TableTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/mapping/TableTest.java
@@ -49,6 +49,7 @@ class TableTest extends ClickHouseBase {
                 .tableName(tableName)
                 .column("off16", "Int16")
                 .column("date_number", "Nullable(Date)")
+                .deploymentType(deploymentType)
                 .orderByColumn("off16").execute(chc);
 
         Table table = chc.describeTable(chc.getDatabase(), tableName);
@@ -71,6 +72,7 @@ class TableTest extends ClickHouseBase {
                 .tableName(tableName)
                 .column("c", "String COMMENT '\\\\'")
                 .column("d", "String COMMENT '\\n'")
+                .deploymentType(deploymentType)
                 .orderByColumn("tuple()").execute(chc);
 
         Table table = chc.describeTable(chc.getDatabase(), tableName);

--- a/src/test/java/com/clickhouse/kafka/connect/sink/dlq/FailureTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/dlq/FailureTest.java
@@ -6,6 +6,7 @@ import com.clickhouse.kafka.connect.sink.ClickHouseSinkConfig;
 import com.clickhouse.kafka.connect.sink.ClickHouseSinkTask;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseDeploymentType;
 import com.clickhouse.kafka.connect.sink.helper.CreateTableStatement;
 import com.clickhouse.kafka.connect.sink.helper.SchemaTestData;
 import com.clickhouse.kafka.connect.util.jmx.SinkTaskStatistics;
@@ -14,7 +15,8 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -35,17 +37,20 @@ public class FailureTest extends ClickHouseBase {
     static {
         System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "DEBUG");
     }
-    @Test
-    void testSchemaValidationFailure() throws Exception {
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("deploymentTypesForTests")
+    void testSchemaValidationFailure(ClickHouseDeploymentType deploymentType) throws Exception {
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("test_schema_validation_failure");
-        ClickHouseTestHelpers.dropTable(chc, topic);
+        ClickHouseTestHelpers.dropTable(chc, topic, deploymentType);
         new CreateTableStatement()
                 .tableName(topic)
+                .deploymentType(deploymentType)
                 .column("off16", "Int16").column("uint8", "UInt8").column("uint16", "UInt16")
                 .column("uint32", "UInt32").column("uint64", "UInt64")
-                .engine("MergeTree").orderByColumn("off16").execute(chc);
+                .orderByColumn("off16").execute(chc);
         Collection<SinkRecord> validRecordsPart1 = SchemaTestData.createUnsignedIntegers(topic, 1, 100);
         Collection<SinkRecord> invalidRecordsPart2 = createInvalidRecords(topic, 2, 100);
         Collection<SinkRecord> validRecordsPart3 =  SchemaTestData.createUnsignedIntegers(topic, 3, 100);
@@ -78,12 +83,12 @@ public class FailureTest extends ClickHouseBase {
         assertEquals(dlq.size(), ((Long)sentToDQL).longValue());
 
         task.stop();
-        assertEquals(200, ClickHouseTestHelpers.countRows(chc, topic));
+        assertEquals(200, ClickHouseTestHelpers.countRows(chc, topic, deploymentType));
         List<SinkRecord> sr = new ArrayList<>(200);
         sr.addAll(validRecordsPart1);
         sr.addAll(validRecordsPart3);
 
-        assertTrue(ClickHouseTestHelpers.validateRows(chc, topic, sr));
+        assertTrue(ClickHouseTestHelpers.validateRows(chc, topic, sr, deploymentType));
     }
 
     public static List<SinkRecord> createInvalidRecords(String topic, int partition, int totalRecords) {

--- a/src/testFixtures/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseTestHelpers.java
+++ b/src/testFixtures/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseTestHelpers.java
@@ -357,15 +357,6 @@ public class ClickHouseTestHelpers {
         }
     }
 
-    public static void runQuery(ClickHouseHelperClient chc, String query) {
-        try (Records ignored = chc.queryV2(query)) {
-            // success
-        } catch (Exception e) {
-            LOGGER.info("Failed to create table ", e);
-            throw new RuntimeException(e);
-        }
-    }
-
     public static void createDatabase(String database, ClickHouseHelperClient chc, ClickHouseDeploymentType deploymentType) {
         String clusterClause = deploymentType.isLocalCluster() ? " ON CLUSTER '" + deploymentType.clusterName + "'" : "";
         String createDatabaseQuery = "CREATE DATABASE IF NOT EXISTS `" + database + "`" + clusterClause;

--- a/src/testFixtures/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseTestHelpers.java
+++ b/src/testFixtures/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseTestHelpers.java
@@ -82,10 +82,10 @@ public class ClickHouseTestHelpers {
         }
     }
 
-    public static OperationMetrics dropTable(ClickHouseHelperClient chc, String tableName) {
+    public static OperationMetrics dropTable(ClickHouseHelperClient chc, String tableName, ClickHouseDeploymentType deploymentType) {
         for (int i = 0; i < 5; i++) {
             try {
-                OperationMetrics operationMetrics = dropTableLoop(chc, tableName);
+                OperationMetrics operationMetrics = dropTableLoop(chc, tableName, deploymentType);
                 if (operationMetrics != null) {
                     return operationMetrics;
                 }
@@ -103,8 +103,10 @@ public class ClickHouseTestHelpers {
         return null;
     }
 
-    private static OperationMetrics dropTableLoop(ClickHouseHelperClient chc, String tableName) {
-        String dropTable = String.format("DROP TABLE IF EXISTS `%s`", tableName);
+    private static OperationMetrics dropTableLoop(ClickHouseHelperClient chc, String tableName, ClickHouseDeploymentType deploymentType) {
+        String clusterClause = (deploymentType.isLocalCluster())
+                ? " ON CLUSTER '" + deploymentType.clusterName + "' SYNC" : "";
+        String dropTable = String.format("DROP TABLE IF EXISTS `%s`%s", tableName, clusterClause);
         try (Records records = chc.queryV2(dropTable)) {
             return records.getMetrics();
         } catch (Exception e) {
@@ -112,9 +114,10 @@ public class ClickHouseTestHelpers {
         }
     }
 
+    public static List<JSONObject> getAllRowsAsJson(ClickHouseHelperClient chc, String tableName, ClickHouseDeploymentType deploymentType) {
+        String from = buildFromClause(chc, tableName, deploymentType);
+        String query = "SELECT * FROM " + from;
 
-    public static List<JSONObject> getAllRowsAsJson(ClickHouseHelperClient chc, String tableName) {
-        String query = String.format("SELECT * FROM `%s`", tableName);
         QuerySettings querySettings = new QuerySettings();
         querySettings.setFormat(ClickHouseFormat.JSONEachRow);
         querySettings.serverSetting("select_sequential_consistency", "1");
@@ -132,6 +135,7 @@ public class ClickHouseTestHelpers {
         }
     }
 
+    // TODO: is this necessary?
     public static List<JSONObject> getAllRowsAsJsonCloud(ClickHouseHelperClient chc, String tableName) {
         String query = getClusterAllReplicasQuery(chc, tableName);
         QuerySettings querySettings = new QuerySettings();
@@ -187,10 +191,10 @@ public class ClickHouseTestHelpers {
         }
     }
 
-
-    public static OperationMetrics optimizeTable(ClickHouseHelperClient chc, String tableName) {
-        String queryCount = String.format("OPTIMIZE TABLE `%s`", tableName);
-
+    public static OperationMetrics optimizeTable(ClickHouseHelperClient chc, String tableName, ClickHouseDeploymentType deploymentType) {
+        String clusterClause = (deploymentType.isLocalCluster())
+                ? " ON CLUSTER '" + deploymentType.clusterName + "'" : "";
+        String queryCount = String.format("OPTIMIZE TABLE `%s`%s", tableName, clusterClause);
         try (Records records = chc.queryV2(queryCount)) {
             return records.getMetrics();
         } catch (Exception e) {
@@ -198,13 +202,14 @@ public class ClickHouseTestHelpers {
         }
     }
 
-    public static int countRows(ClickHouseHelperClient chc, String database, String topic) {
-        return countRows(chc, String.format("%s.%s", database, topic));
+    public static int countRows(ClickHouseHelperClient chc, String database, String topic, ClickHouseDeploymentType deploymentType) {
+        return countRows(chc, String.format("%s.%s", database, topic), deploymentType);
     }
+    public static int countRows(ClickHouseHelperClient chc, String tableName, ClickHouseDeploymentType deploymentType) {
+        optimizeTable(chc, tableName, deploymentType);
+        String from = buildFromClause(chc, tableName, deploymentType);
+        String queryCount = "SELECT COUNT(*) FROM " + from + " SETTINGS select_sequential_consistency = 1";
 
-    public static int countRows(ClickHouseHelperClient chc, String tableName) {
-        String queryCount = String.format("SELECT COUNT(*) FROM `%s` SETTINGS select_sequential_consistency = 1", tableName);
-        optimizeTable(chc, tableName);
         try (Records records = chc.queryV2(queryCount)) {
             // Note we probrbly need asInteger() here
             String value = records.iterator().next().getString(1);
@@ -215,8 +220,9 @@ public class ClickHouseTestHelpers {
         }
     }
 
-    public static int sumRows(ClickHouseHelperClient chc, String tableName, String column) {
-        String queryCount = String.format("SELECT SUM(`%s`) FROM `%s`", column, tableName);
+    public static int sumRows(ClickHouseHelperClient chc, String tableName, String column, ClickHouseDeploymentType deploymentType) {
+        String from = buildFromClause(chc, tableName, deploymentType);
+        String queryCount = "SELECT SUM(`" + column + "`) FROM " + from;
         try (Records records = chc.queryV2(queryCount)) {
             String value = records.iterator().next().getString(1);
             return (int) (Float.parseFloat(value));
@@ -225,8 +231,9 @@ public class ClickHouseTestHelpers {
         }
     }
 
-    public static int countRowsWithEmojis(ClickHouseHelperClient chc, String tableName) {
-        String queryCount = "SELECT COUNT(*) FROM `" + tableName + "` WHERE str LIKE '%\uD83D\uDE00%' SETTINGS select_sequential_consistency = 1";
+    public static int countRowsWithEmojis(ClickHouseHelperClient chc, String tableName, ClickHouseDeploymentType deploymentType) {
+        String from = buildFromClause(chc, tableName, deploymentType);
+        String queryCount = "SELECT COUNT(*) FROM " + from + " WHERE str LIKE '%\uD83D\uDE00%' SETTINGS select_sequential_consistency = 1";
         try (Records records = chc.queryV2(queryCount)) {
             String value = records.iterator().next().getString(1);
             return (int) (Float.parseFloat(value));
@@ -235,11 +242,22 @@ public class ClickHouseTestHelpers {
         }
     }
 
-    public static boolean validateRows(ClickHouseHelperClient chc, String topic, Collection<SinkRecord> sinkRecords) {
+    public static String buildFromClause(ClickHouseHelperClient chc, String tableName, ClickHouseDeploymentType deploymentType) {
+        if (deploymentType.isLocalCluster()) {
+            String escapedDatabase = escapeSingleQuotes(chc.getDatabase());
+            String escapedTableName = escapeSingleQuotes(tableName);
+            return String.format("cluster('%s', '%s', '%s')",
+                    deploymentType.clusterName, escapedDatabase, escapedTableName);
+        }
+        return "`" + tableName + "`";
+    }
+
+    public static boolean validateRows(ClickHouseHelperClient chc, String topic, Collection<SinkRecord> sinkRecords, ClickHouseDeploymentType deploymentType) {
         boolean match = false;
         QuerySettings querySettings = new QuerySettings();
         querySettings.setFormat(ClickHouseFormat.JSONStringsEachRow);
-        try (QueryResponse queryResponse = chc.getClient().query(String.format("SELECT * FROM `%s`", topic), querySettings).get(900, TimeUnit.SECONDS)) {
+        String from = buildFromClause(chc, topic, deploymentType);
+        try (QueryResponse queryResponse = chc.getClient().query(String.format("SELECT * FROM %s", from), querySettings).get(900, TimeUnit.SECONDS)) {
             Gson gson = new Gson();
 
             List<String> records = new ArrayList<>();
@@ -285,12 +303,19 @@ public class ClickHouseTestHelpers {
         return match;
     }
 
-    public static int countInsertQueries(ClickHouseHelperClient chc, String topic) throws Exception {
+    public static int countInsertQueries(ClickHouseHelperClient chc, String topic, ClickHouseDeploymentType deploymentType) throws Exception {
+        String from;
+        if (deploymentType.isLocalCluster()) {
+            from = String.format("clusterAllReplicas('%s', 'system', 'query_log', rand())", deploymentType.clusterName);
+        } else {
+            from = "system.query_log";
+        }
+
         String sql = String.format("SELECT COUNT(*) " +
-                "FROM system.query_log " +
+                "FROM %s " +
                 "WHERE type = 'QueryFinish' " +
                 "AND query_kind = 'Insert' " +
-                "AND executeQueryIgnoreResult ILIKE '%%%s%%'", topic);
+                "AND executeQueryIgnoreResult ILIKE '%%%s%%'", from, topic);
         try (Records records = chc.queryV2(sql)) {
             String value = records.iterator().next().getString(1);
             return Integer.parseInt(value);
@@ -341,8 +366,9 @@ public class ClickHouseTestHelpers {
         }
     }
 
-    public static void createDatabase(String database, ClickHouseHelperClient chc) {
-        String createDatabaseQuery = "CREATE DATABASE IF NOT EXISTS `" + database + "`";
+    public static void createDatabase(String database, ClickHouseHelperClient chc, ClickHouseDeploymentType deploymentType) {
+        String clusterClause = deploymentType.isLocalCluster() ? " ON CLUSTER '" + deploymentType.clusterName + "'" : "";
+        String createDatabaseQuery = "CREATE DATABASE IF NOT EXISTS `" + database + "`" + clusterClause;
         try (Records ignored = chc.queryV2(createDatabaseQuery)) {
             // success
         } catch (Exception e) {
@@ -351,8 +377,9 @@ public class ClickHouseTestHelpers {
         }
     }
 
-    public static void dropDatabase(ClickHouseHelperClient chc, String database) {
-        String dropDatabaseQuery = "DROP DATABASE IF EXISTS `" + database + "`";
+    public static void dropDatabase(ClickHouseHelperClient chc, String database, ClickHouseDeploymentType deploymentType) {
+        String clusterClause = deploymentType.isLocalCluster() ? " ON CLUSTER '" + deploymentType.clusterName + "'" : "";
+        String dropDatabaseQuery = "DROP DATABASE IF EXISTS `" + database + "`" + clusterClause;
         try (Records ignored = chc.queryV2(dropDatabaseQuery)) {
             // success
         } catch (Exception e) {
@@ -375,14 +402,14 @@ public class ClickHouseTestHelpers {
                 .build();
     }
 
-    public static void waitWhileCounting(ClickHouseHelperClient chc, String tableName, int sleepInSeconds) throws InterruptedException {
-        int count = countRows(chc, tableName);
+    public static void waitWhileCounting(ClickHouseHelperClient chc, String tableName, int sleepInSeconds, ClickHouseDeploymentType deploymentType) throws InterruptedException {
+        int count = countRows(chc, tableName, deploymentType);
         int lastCount = 0;
         int loopCount = 0;
 
         while (count != lastCount || loopCount < 5) {
             Thread.sleep(sleepInSeconds * 1000L);
-            count = countRows(chc, tableName);
+            count = countRows(chc, tableName, deploymentType);
             if (lastCount == count) {
                 loopCount++;
             } else {
@@ -393,6 +420,7 @@ public class ClickHouseTestHelpers {
         }
     }
 
+    // TODO: add deployment mode?
     public static void clearTable(ClickHouseHelperClient chc, String tableName) {
         String sql = "TRUNCATE TABLE " + tableName;
         LOGGER.info("Clear table: " + sql);

--- a/src/testFixtures/java/com/clickhouse/kafka/connect/sink/helper/CreateTableStatement.java
+++ b/src/testFixtures/java/com/clickhouse/kafka/connect/sink/helper/CreateTableStatement.java
@@ -11,10 +11,11 @@ import java.util.Map;
 public class CreateTableStatement {
     private String tableName;
     private LinkedHashMap<String, String> schema = new LinkedHashMap<>();
-    private String engine;
+    private String engine; // defaults to MergeTree/ReplicatedMergeTree if unset
     private String orderByColumn;
     private Map<String, Serializable> settings;
     private boolean ifNotExists = false;
+    private ClickHouseDeploymentType deploymentType = ClickHouseDeploymentType.STANDALONE;
 
     public CreateTableStatement() {}
 
@@ -25,6 +26,7 @@ public class CreateTableStatement {
         this.orderByColumn = template.orderByColumn;
         this.settings = template.settings;
         this.ifNotExists = template.ifNotExists;
+        this.deploymentType = template.deploymentType;
     }
 
     public CreateTableStatement tableName(String tableName) {
@@ -57,6 +59,11 @@ public class CreateTableStatement {
         return this;
     }
 
+    public CreateTableStatement deploymentType(ClickHouseDeploymentType deploymentType) {
+        this.deploymentType = deploymentType;
+        return this;
+    }
+
     public void execute(ClickHouseHelperClient chc) {
         var columns = new StringBuilder();
         for (Map.Entry<String, String> entry : schema.entrySet()) {
@@ -64,12 +71,17 @@ public class CreateTableStatement {
                 columns.append(", ");
             columns.append("`").append(entry.getKey()).append("` ").append(entry.getValue());
         }
+
         var sql = new StringBuilder();
         sql.append("CREATE TABLE ")
                 .append(ifNotExists ? "IF NOT EXISTS " : "")
-                .append("`").append(tableName).append("`").append(" ")
+                .append("`").append(tableName).append("`");
+        if (deploymentType.isLocalCluster()) {
+            sql.append(" ON CLUSTER '").append(deploymentType.clusterName).append("'");
+        }
+        sql.append(" ")
                 .append("(").append(columns).append(")").append(" ")
-                .append("Engine = ").append(engine);
+                .append("Engine = ").append(engine != null ? engine : deploymentType.getMergeTreeEngine());
         if (orderByColumn != null) {
             sql.append(" ORDER BY ").append(orderByColumn);
         }


### PR DESCRIPTION
# https://github.com/ClickHouse/clickhouse-kafka-connect/issues/643 PR 3/3
# WIP - not ready for review
## Summary

Follow up to https://github.com/ClickHouse/clickhouse-kafka-connect/pull/717 - this adds:
- parameterization to all relevant tests to run against local clusters
- cluster jobs to CI

closes: https://github.com/ClickHouse/clickhouse-kafka-connect/issues/716

## Validation

`CLICKHOUSE_CLUSTER_MODE=true ./gradlew test`
`CLICKHOUSE_CLUSTER_MODE=true ./gradlew integrationTest`

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
