### PR TITLE
Update integrationTests.yaml

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -2,7 +2,7 @@ name: Integration Tests
 
 on:
   schedule:
-    - cron: "55 15 * * *"
+    - cron: "00 05 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Change the time when integration tests are executed so they don't impact regular usage of this service

Doing this as an intermediate step until we move these tests to their own CH Cloud service
