### PR TITLE
Add clusterName setting

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
@@ -742,7 +742,7 @@ public class ClickHouseSinkConfig {
         configDef.define(CLUSTER_NAME,
                 ConfigDef.Type.STRING,
                 "",
-                ConfigDef.Importance.LOW,
+                ConfigDef.Importance.MEDIUM,
                 "Cluster name to include in all distributed DDL queries run by the connector",
                 ddlGroup,
                 ++ddlOrderInGroup,

--- a/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
@@ -61,7 +61,7 @@ public class ClickHouseSinkConfig {
     public static final String AUTO_EVOLVE_DDL_REFRESH_RETRIES = "auto.evolve.ddl.refresh.retries";
     public static final String AUTO_EVOLVE_STRUCT_TO_JSON = "auto.evolve.struct.to.json";
     public static final String CONNECTOR_RETRY_TIMEOUT = "errors.retry.timeout";
-    public static final String CLUSTER_NAME_FOR_DISTRIBUTED_DDL = "clusterNameForDistributedDDL";
+    public static final String CLUSTER_NAME = "clusterName";
 
     public static final long MINIMAL_RETRY_TIMEOUT_THR_WARN = TimeUnit.SECONDS.toMillis(10);
     public static final String SSL_SOCKET_SNI = "ssl_socket_sni";
@@ -119,7 +119,7 @@ public class ClickHouseSinkConfig {
     private final boolean autoEvolveStructToJson;
     private final boolean binaryFormatWrtiteJsonAsString;
     private final String sslSocketSni;
-    private final String clusterNameForDistributedDDL;
+    private final String clusterName;
 
     public enum InsertFormats {
         NONE,
@@ -299,7 +299,7 @@ public class ClickHouseSinkConfig {
         this.bufferFlushTime = Long.parseLong(props.getOrDefault(BUFFER_FLUSH_TIME, bufferFlushTimeDefault.toString()));
         this.reportInsertedOffsets = Boolean.parseBoolean(props.getOrDefault(REPORT_INSERTED_OFFSETS, reportInsertedOffsetsDefault.toString()));
         this.sslSocketSni = props.getOrDefault(SSL_SOCKET_SNI, "");
-        this.clusterNameForDistributedDDL = props.getOrDefault(CLUSTER_NAME_FOR_DISTRIBUTED_DDL, "");
+        this.clusterName = props.getOrDefault(CLUSTER_NAME, "");
 
         if (this.bufferCount > 0) {
             LOGGER.info("Internal buffering enabled: bufferCount={}, bufferFlushTime={}ms", this.bufferCount, this.bufferFlushTime);
@@ -739,7 +739,7 @@ public class ClickHouseSinkConfig {
                 ConfigDef.Width.SHORT,
                 "Map STRUCT to JSON"
         );
-        configDef.define(CLUSTER_NAME_FOR_DISTRIBUTED_DDL,
+        configDef.define(CLUSTER_NAME,
                 ConfigDef.Type.STRING,
                 "",
                 ConfigDef.Importance.LOW,

--- a/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
@@ -61,6 +61,7 @@ public class ClickHouseSinkConfig {
     public static final String AUTO_EVOLVE_DDL_REFRESH_RETRIES = "auto.evolve.ddl.refresh.retries";
     public static final String AUTO_EVOLVE_STRUCT_TO_JSON = "auto.evolve.struct.to.json";
     public static final String CONNECTOR_RETRY_TIMEOUT = "errors.retry.timeout";
+    public static final String CLUSTER_NAME_FOR_DISTRIBUTED_DDL = "clusterNameForDistributedDDL";
 
     public static final long MINIMAL_RETRY_TIMEOUT_THR_WARN = TimeUnit.SECONDS.toMillis(10);
     public static final String SSL_SOCKET_SNI = "ssl_socket_sni";
@@ -118,6 +119,7 @@ public class ClickHouseSinkConfig {
     private final boolean autoEvolveStructToJson;
     private final boolean binaryFormatWrtiteJsonAsString;
     private final String sslSocketSni;
+    private final String clusterNameForDistributedDDL;
 
     public enum InsertFormats {
         NONE,
@@ -297,6 +299,7 @@ public class ClickHouseSinkConfig {
         this.bufferFlushTime = Long.parseLong(props.getOrDefault(BUFFER_FLUSH_TIME, bufferFlushTimeDefault.toString()));
         this.reportInsertedOffsets = Boolean.parseBoolean(props.getOrDefault(REPORT_INSERTED_OFFSETS, reportInsertedOffsetsDefault.toString()));
         this.sslSocketSni = props.getOrDefault(SSL_SOCKET_SNI, "");
+        this.clusterNameForDistributedDDL = props.getOrDefault(CLUSTER_NAME_FOR_DISTRIBUTED_DDL, "");
 
         if (this.bufferCount > 0) {
             LOGGER.info("Internal buffering enabled: bufferCount={}, bufferFlushTime={}ms", this.bufferCount, this.bufferFlushTime);
@@ -735,6 +738,16 @@ public class ClickHouseSinkConfig {
                 ++ddlOrderInGroup,
                 ConfigDef.Width.SHORT,
                 "Map STRUCT to JSON"
+        );
+        configDef.define(CLUSTER_NAME_FOR_DISTRIBUTED_DDL,
+                ConfigDef.Type.STRING,
+                "",
+                ConfigDef.Importance.LOW,
+                "Cluster name to include in all distributed DDL queries run by the connector",
+                ddlGroup,
+                ++ddlOrderInGroup,
+                ConfigDef.Width.SHORT,
+                "Cluster name for distributed DDL"
         );
         return configDef;
     }

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -898,7 +898,7 @@ public class ClickHouseWriter implements DBWriter {
         }
 
         if (!columnDefs.isEmpty()) {
-            chc.alterTableAddColumns(table.getDatabase(), table.getCleanName(), columnDefs, csc.getClickhouseSettings());
+            chc.alterTableAddColumns(table.getDatabase(), table.getCleanName(), columnDefs, csc.getClickhouseSettings(), csc.getClusterNameForDistributedDDL());
             LOGGER.info("Schema evolution complete for table {}. Added columns: {}", table.getName(), columnDefs);
             table = refreshTableAfterDDL(table, missingColumns);
         }

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -1433,6 +1433,7 @@ public class ClickHouseWriter implements DBWriter {
                 .setTimeout(csc.getTimeout())
                 .setRetry(csc.getRetry())
                 .setSslSocketSni(csc.getSslSocketSni())
+                .setClusterClause(csc.getClusterName())
                 .build();
 
         ClickHouseNode server = chcTmp.getServer();

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -34,7 +34,6 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.errors.RetriableException;
-import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,6 +112,7 @@ public class ClickHouseWriter implements DBWriter {
                 .setRetry(csc.getRetry())
                 .useClientV2(useClientV2)
                 .setSslSocketSni(csc.getSslSocketSni())
+                .setClusterClause(csc.getClusterName())
                 .build();
 
         if (!chc.ping()) {
@@ -898,7 +898,7 @@ public class ClickHouseWriter implements DBWriter {
         }
 
         if (!columnDefs.isEmpty()) {
-            chc.alterTableAddColumns(table.getDatabase(), table.getCleanName(), columnDefs, csc.getClickhouseSettings(), csc.getClusterNameForDistributedDDL());
+            chc.alterTableAddColumns(table.getDatabase(), table.getCleanName(), columnDefs, csc.getClickhouseSettings());
             LOGGER.info("Schema evolution complete for table {}. Added columns: {}", table.getName(), columnDefs);
             table = refreshTableAfterDDL(table, missingColumns);
         }

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
@@ -622,7 +622,7 @@ public class ClickHouseHelperClient implements AutoCloseable {
         }
 
         public ClickHouseClientBuilder setClusterClause(String clusterName) {
-            this.clusterClause = !clusterName.isEmpty() ? " ON CLUSTER '" + clusterName + "'" : "";
+            this.clusterClause = (clusterName == null || clusterName.isEmpty()) ? "" : " ON CLUSTER '" + clusterName + "'";
             return this;
         }
 

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
@@ -64,6 +64,7 @@ public class ClickHouseHelperClient implements AutoCloseable {
     @Getter
     private boolean useClientV2 = false;
     private final String sslSocketSni;
+    private final String clusterClause;
 
     public ClickHouseHelperClient(ClickHouseClientBuilder builder) {
         this.hostname = builder.hostname;
@@ -80,6 +81,7 @@ public class ClickHouseHelperClient implements AutoCloseable {
         this.proxyPort = builder.proxyPort;
         this.useClientV2 = builder.useClientV2;
         this.sslSocketSni = builder.sslSocketSni;
+        this.clusterClause = builder.clusterClause;
         // We are creating two clients, one for V1 and one for V2
         this.client = createClientV2();
         this.server = createClientV1();
@@ -471,11 +473,10 @@ public class ClickHouseHelperClient implements AutoCloseable {
         return table;
     }
 
-    public void alterTableAddColumns(String database, String tableName, List<String> columnDefs, Map<String, String> clickhouseSettings, String clusterNameForDistributedDDL) {
+    public void alterTableAddColumns(String database, String tableName, List<String> columnDefs, Map<String, String> clickhouseSettings) {
         String addClauses = columnDefs.stream()
                 .map(colDef -> "ADD COLUMN IF NOT EXISTS " + colDef)
                 .collect(Collectors.joining(", "));
-        String clusterClause = !clusterNameForDistributedDDL.isEmpty() ? " ON CLUSTER '" + clusterNameForDistributedDDL + "'" : "";
         String sql = String.format("ALTER TABLE `%s`.`%s`%s %s", database, tableName, clusterClause, addClauses);
         LOGGER.info("Executing DDL: {}", sql);
         if (useClientV2) {
@@ -564,6 +565,7 @@ public class ClickHouseHelperClient implements AutoCloseable {
         private int proxyPort = -1;
         private boolean useClientV2 = true;
         private String sslSocketSni = "";
+        private String clusterClause = "";
 
         public ClickHouseClientBuilder(String hostname, int port, ClickHouseProxyType proxyType, String proxyHost, int proxyPort) {
             this.hostname = hostname;
@@ -616,6 +618,11 @@ public class ClickHouseHelperClient implements AutoCloseable {
 
         public ClickHouseClientBuilder setSslSocketSni(String sni) {
             this.sslSocketSni = sni;
+            return this;
+        }
+
+        public ClickHouseClientBuilder setClusterClause(String clusterName) {
+            this.clusterClause = " ON CLUSTER '" + clusterName + "'";
             return this;
         }
 

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
@@ -471,11 +471,12 @@ public class ClickHouseHelperClient implements AutoCloseable {
         return table;
     }
 
-    public void alterTableAddColumns(String database, String tableName, List<String> columnDefs, Map<String, String> clickhouseSettings) {
+    public void alterTableAddColumns(String database, String tableName, List<String> columnDefs, Map<String, String> clickhouseSettings, String clusterNameForDistributedDDL) {
         String addClauses = columnDefs.stream()
                 .map(colDef -> "ADD COLUMN IF NOT EXISTS " + colDef)
                 .collect(Collectors.joining(", "));
-        String sql = String.format("ALTER TABLE `%s`.`%s` %s", database, tableName, addClauses);
+        String clusterClause = !clusterNameForDistributedDDL.isEmpty() ? " ON CLUSTER '" + clusterNameForDistributedDDL + "'" : "";
+        String sql = String.format("ALTER TABLE `%s`.`%s`%s %s", database, tableName, clusterClause, addClauses);
         LOGGER.info("Executing DDL: {}", sql);
         if (useClientV2) {
             alterTableAddColumnV2(sql, clickhouseSettings);

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
@@ -477,7 +477,7 @@ public class ClickHouseHelperClient implements AutoCloseable {
         String addClauses = columnDefs.stream()
                 .map(colDef -> "ADD COLUMN IF NOT EXISTS " + colDef)
                 .collect(Collectors.joining(", "));
-        String sql = String.format("ALTER TABLE `%s`.`%s`%s %s", database, tableName, clusterClause, addClauses);
+        String sql = String.format("ALTER TABLE `%s`.`%s`%s%s", database, tableName, clusterClause, addClauses);
         LOGGER.info("Executing DDL: {}", sql);
         if (useClientV2) {
             alterTableAddColumnV2(sql, clickhouseSettings);
@@ -622,7 +622,7 @@ public class ClickHouseHelperClient implements AutoCloseable {
         }
 
         public ClickHouseClientBuilder setClusterClause(String clusterName) {
-            this.clusterClause = (clusterName == null || clusterName.isEmpty()) ? "" : " ON CLUSTER '" + clusterName + "'";
+            this.clusterClause = (clusterName == null || clusterName.isEmpty()) ? "" : " ON CLUSTER '" + clusterName + "' ";
             return this;
         }
 

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
@@ -622,7 +622,7 @@ public class ClickHouseHelperClient implements AutoCloseable {
         }
 
         public ClickHouseClientBuilder setClusterClause(String clusterName) {
-            this.clusterClause = " ON CLUSTER '" + clusterName + "'";
+            this.clusterClause = !clusterName.isEmpty() ? " ON CLUSTER '" + clusterName + "'" : "";
             return this;
         }
 


### PR DESCRIPTION
## Summary

Discovered via #738

When running against a local ClickHouse cluster (**not cloud**), the auto table schema evolving codepath runs `ALTER TABLE <> ADD COLUMN IF NOT EXISTS <>` without an ON CLUSTER clause, which is needed for table changes to be replicated to all nodes in the cluster. As a result, the table schema cannot be refreshed consistently because two nodes may have different schemas for the same table depending on which node received the `ALTER TABLE` ddl.

To fix this, introduce a new sink setting `clusterName` and pass it to the `ALTER TABLE` ddl. Any future DDL's the connector executes that require an `ON CLUSTER` clause should use this setting.

closes: #738

**NOTE: a follow up PR (either [this one](https://github.com/ClickHouse/clickhouse-kafka-connect/pull/740) or another) will run the auto schema evo tests against clickhouse cluster w/ the clusterNameForDistributedDDL setting. Stay tuned for that. 📺** 