### PR TITLE
[Integration tests] replace manual busy wait in ExactlyOnceTest with Awaitility

### DIFF
--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseCloudAPI.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseCloudAPI.java
@@ -64,7 +64,7 @@ public class ClickHouseCloudAPI {
         String serviceId = properties.getProperty(CLICKHOUSE_CLOUD_SERVICE_ID);
         stopInstance(serviceId);
         Awaitility.await("service stopped")
-                .atMost(Duration.ofMinutes(10))
+                .atMost(Duration.ofMinutes(20))
                 .pollDelay(Duration.ofSeconds(2))
                 .pollInterval(FixedPollInterval.fixed(5, TimeUnit.SECONDS))
                 .until(() -> "STOPPED".equals(getServiceState(serviceId)));
@@ -72,7 +72,7 @@ public class ClickHouseCloudAPI {
 
         startInstance(serviceId);
         Awaitility.await("service started")
-                .atMost(Duration.ofMinutes(10))
+                .atMost(Duration.ofMinutes(20))
                 .pollDelay(Duration.ofSeconds(2))
                 .pollInterval(FixedPollInterval.fixed(5, TimeUnit.SECONDS))
                 .until(() -> "RUNNING".equals(getServiceState(serviceId)));

--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseCloudAPI.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseCloudAPI.java
@@ -33,6 +33,8 @@ public class ClickHouseCloudAPI {
     private static final String CLICKHOUSE_CLOUD_API_SECRET = "clickhouse.cloud.secret";
     private static final String CLICKHOUSE_CLOUD_SERVICE_ID = "clickhouse.cloud.serviceId";
     private static final String SERVICE_RESTART_TIMEOUT = "serviceRestartTimeout";
+    private static final long POLL_DELAY_SECONDS = 2L;
+    private static final long POLL_INTERVAL_SECONDS = 5L;
     private final long serviceRestartTimeout;
 
     public ClickHouseCloudAPI(Properties properties) {
@@ -70,16 +72,16 @@ public class ClickHouseCloudAPI {
         stopInstance(serviceId);
         Awaitility.await("service stopped")
                 .atMost(Duration.ofMinutes(serviceRestartTimeout))
-                .pollDelay(Duration.ofSeconds(2))
-                .pollInterval(FixedPollInterval.fixed(5, TimeUnit.SECONDS))
+                .pollDelay(Duration.ofSeconds(POLL_DELAY_SECONDS))
+                .pollInterval(FixedPollInterval.fixed(POLL_INTERVAL_SECONDS, TimeUnit.SECONDS))
                 .until(() -> "STOPPED".equals(getServiceState(serviceId)));
         LOGGER.info("Service {} stopped", serviceId);
 
         startInstance(serviceId);
         Awaitility.await("service started")
                 .atMost(Duration.ofMinutes(serviceRestartTimeout))
-                .pollDelay(Duration.ofSeconds(2))
-                .pollInterval(FixedPollInterval.fixed(5, TimeUnit.SECONDS))
+                .pollDelay(Duration.ofSeconds(POLL_DELAY_SECONDS))
+                .pollInterval(FixedPollInterval.fixed(POLL_INTERVAL_SECONDS, TimeUnit.SECONDS))
                 .until(() -> "RUNNING".equals(getServiceState(serviceId)));
 
         LOGGER.info("Service {} restarted", serviceId);

--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseCloudAPI.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseCloudAPI.java
@@ -3,6 +3,9 @@ package com.clickhouse.kafka.connect.sink.helper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+import org.testcontainers.shaded.org.awaitility.pollinterval.FibonacciPollInterval;
+import org.testcontainers.shaded.org.awaitility.pollinterval.FixedPollInterval;
 
 import java.io.IOException;
 import java.net.ProxySelector;
@@ -11,10 +14,12 @@ import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -54,40 +59,25 @@ public class ClickHouseCloudAPI {
     }
 
 
-    public String restartService() throws URISyntaxException, IOException, InterruptedException {
+    public void restartService() throws URISyntaxException, IOException, InterruptedException {
         LOGGER.info("Restarting service...");
         String serviceId = properties.getProperty(CLICKHOUSE_CLOUD_SERVICE_ID);
-        //1. Stop Instance
         stopInstance(serviceId);
+        Awaitility.await("service stopped")
+                .atMost(Duration.ofMinutes(10))
+                .pollDelay(Duration.ofSeconds(2))
+                .pollInterval(FixedPollInterval.fixed(5, TimeUnit.SECONDS))
+                .until(() -> "STOPPED".equals(getServiceState(serviceId)));
+        LOGGER.info("Service {} stopped", serviceId);
 
-        //2. Wait
-        String serviceState = getServiceState(serviceId);
-        int loopCount = 0;
-        final int maxRetries = 60;
-        while(!serviceState.equals("STOPPED") && loopCount < maxRetries) {
-            LOGGER.debug("Service State: {}", serviceState);
-            Thread.sleep(5 * 1000);
-            serviceState = getServiceState(serviceId);
-            loopCount++;
-        }
-
-        //3. Start Instance
         startInstance(serviceId);
-        serviceState = getServiceState(serviceId);
-        loopCount = 0;
-        while(!serviceState.equals("RUNNING")) {
-            LOGGER.debug("Service State: {}", serviceState);
-            Thread.sleep(5 * 1000);
-            serviceState = getServiceState(serviceId);
+        Awaitility.await("service started")
+                .atMost(Duration.ofMinutes(10))
+                .pollDelay(Duration.ofSeconds(2))
+                .pollInterval(FixedPollInterval.fixed(5, TimeUnit.SECONDS))
+                .until(() -> "RUNNING".equals(getServiceState(serviceId)));
 
-            if (loopCount >= maxRetries) {
-                fail("Failed to restart service in time.");
-            }
-            loopCount++;
-        }
-
-        LOGGER.info("Service restarted");
-        return serviceState;
+        LOGGER.info("Service {} restarted", serviceId);
     }
 
     private HttpResponse<String> executeRequest(String url, String method, HttpRequest.BodyPublisher body) throws URISyntaxException, IOException, InterruptedException {

--- a/src/integrationTest/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseCloudAPI.java
+++ b/src/integrationTest/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseCloudAPI.java
@@ -32,9 +32,14 @@ public class ClickHouseCloudAPI {
     private static final String CLICKHOUSE_CLOUD_API_KEY = "clickhouse.cloud.apiKey";
     private static final String CLICKHOUSE_CLOUD_API_SECRET = "clickhouse.cloud.secret";
     private static final String CLICKHOUSE_CLOUD_SERVICE_ID = "clickhouse.cloud.serviceId";
+    private static final String SERVICE_RESTART_TIMEOUT = "serviceRestartTimeout";
+    private final long serviceRestartTimeout;
 
     public ClickHouseCloudAPI(Properties properties) {
         this.properties = properties;
+
+        String timeoutStr = properties.getProperty(SERVICE_RESTART_TIMEOUT);
+        this.serviceRestartTimeout = timeoutStr == null ? 20L : Long.parseLong(timeoutStr);
     }
 
     public HttpResponse<String> stopInstance(String serviceId) throws URISyntaxException, IOException, InterruptedException {
@@ -64,7 +69,7 @@ public class ClickHouseCloudAPI {
         String serviceId = properties.getProperty(CLICKHOUSE_CLOUD_SERVICE_ID);
         stopInstance(serviceId);
         Awaitility.await("service stopped")
-                .atMost(Duration.ofMinutes(20))
+                .atMost(Duration.ofMinutes(serviceRestartTimeout))
                 .pollDelay(Duration.ofSeconds(2))
                 .pollInterval(FixedPollInterval.fixed(5, TimeUnit.SECONDS))
                 .until(() -> "STOPPED".equals(getServiceState(serviceId)));
@@ -72,7 +77,7 @@ public class ClickHouseCloudAPI {
 
         startInstance(serviceId);
         Awaitility.await("service started")
-                .atMost(Duration.ofMinutes(20))
+                .atMost(Duration.ofMinutes(serviceRestartTimeout))
                 .pollDelay(Duration.ofSeconds(2))
                 .pollInterval(FixedPollInterval.fixed(5, TimeUnit.SECONDS))
                 .until(() -> "RUNNING".equals(getServiceState(serviceId)));


### PR DESCRIPTION
## Summary
checkSpottyNetwork and checkSpottyNetworkMulti both restart the cloud service - but, they busy wait for 5 minutes and fail if the service has not restarted by then. This is flaky and has already broken the nightly tests a few times.

Replace the manually defined busy wait with [Awaitility](https://github.com/awaitility/awaitility). This doesn't 100% guarantee tests will not flake since the test is still bound by the service restart time, but it will reduce the odds of flakiness. It also gives us the following advantages:

- readable timeout configuration
- thread sleep interruption safety
- (optional) exponential backoff

closes: #746 