### PR TITLE
feat: Debezium CDC envelope support with LSN-based versioning for ReplacingMergeTree

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
@@ -56,6 +56,7 @@ public class ClickHouseSinkConfig {
     public static final String BUFFER_FLUSH_TIME = "bufferFlushTime";
     public static final String CLICKHOUSE_CLIENT_INSERT_TIMEOUT_MS = "clickhouseClientInsertTimeoutMs";
     public static final String REPORT_INSERTED_OFFSETS = "reportInsertedOffsets";
+    public static final String DEBEZIUM_CDC_ENABLED = "debeziumCDCEnabled";
     public static final String ERROR_TOLERANCE_ALL = "all";
     public static final String ERROR_TOLERANCE_NONE = "none";
     public static final String AUTO_EVOLVE = "auto.evolve";
@@ -117,6 +118,7 @@ public class ClickHouseSinkConfig {
     private final long bufferFlushTime;
     private final long clickhouseClientInsertTimeoutMs;
     private final boolean reportInsertedOffsets;
+    private final boolean debeziumCDCEnabled;
     private final boolean autoEvolve;
     private final int autoEvolveDdlRefreshRetries;
     private final boolean autoEvolveStructToJson;
@@ -302,6 +304,7 @@ public class ClickHouseSinkConfig {
         this.bufferFlushTime = Long.parseLong(props.getOrDefault(BUFFER_FLUSH_TIME, bufferFlushTimeDefault.toString()));
         this.clickhouseClientInsertTimeoutMs = Long.parseLong(props.getOrDefault(CLICKHOUSE_CLIENT_INSERT_TIMEOUT_MS, clickhouseClientInsertTimeoutMsDefault.toString()));
         this.reportInsertedOffsets = Boolean.parseBoolean(props.getOrDefault(REPORT_INSERTED_OFFSETS, reportInsertedOffsetsDefault.toString()));
+        this.debeziumCDCEnabled = Boolean.parseBoolean(props.getOrDefault(DEBEZIUM_CDC_ENABLED, "false"));
         this.sslSocketSni = props.getOrDefault(SSL_SOCKET_SNI, "");
         this.clusterName = props.getOrDefault(CLUSTER_NAME, "");
 
@@ -668,6 +671,19 @@ public class ClickHouseSinkConfig {
                 ++orderInGroup,
                 ConfigDef.Width.SHORT,
                 "Bypass field cleanup."
+        );
+        configDef.define(DEBEZIUM_CDC_ENABLED,
+                ConfigDef.Type.BOOLEAN,
+                false,
+                ConfigDef.Importance.MEDIUM,
+                "Enable Debezium CDC envelope processing. When true, records whose schema name ends with"
+                        + " '.Envelope' are routed through DebeziumRecordConvertor, which extracts op/before/after,"
+                        + " injects _version (from source.lsn / gtid / change_lsn) and is_deleted columns."
+                        + " Requires a ReplacingMergeTree(_version, is_deleted) target table. default: false",
+                group,
+                ++orderInGroup,
+                ConfigDef.Width.SHORT,
+                "Enable Debezium CDC envelope processing."
         );
         configDef.define(IGNORE_PARTITIONS_WHEN_BATCHING,
                 ConfigDef.Type.BOOLEAN,

--- a/src/main/java/com/clickhouse/kafka/connect/sink/ProxySinkTask.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ProxySinkTask.java
@@ -83,7 +83,8 @@ public final class ProxySinkTask {
                 .map(v -> Record.convert(v,
                         clickHouseSinkConfig.isEnableDbTopicSplit(),
                         clickHouseSinkConfig.getDbTopicSplitChar(),
-                        clickHouseSinkConfig.getDatabase() ))
+                        clickHouseSinkConfig.getDatabase(),
+                        clickHouseSinkConfig.isDebeziumCDCEnabled()))
                 .collect(Collectors.groupingBy(!clickHouseSinkConfig.isExactlyOnce() && clickHouseSinkConfig.isIgnorePartitionsWhenBatching()
                         ? Record::getTopic : Record::getTopicAndPartition));
 

--- a/src/main/java/com/clickhouse/kafka/connect/sink/data/Record.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/data/Record.java
@@ -1,5 +1,6 @@
 package com.clickhouse.kafka.connect.sink.data;
 
+import com.clickhouse.kafka.connect.sink.data.convert.DebeziumRecordConvertor;
 import com.clickhouse.kafka.connect.sink.data.convert.EmptyRecordConvertor;
 import com.clickhouse.kafka.connect.sink.data.convert.RecordConvertor;
 import com.clickhouse.kafka.connect.sink.data.convert.SchemaRecordConvertor;
@@ -52,11 +53,15 @@ public class Record {
     private static final RecordConvertor schemalessRecordConvertor = new SchemalessRecordConvertor();
     private static final RecordConvertor emptyRecordConvertor = new EmptyRecordConvertor();
     private static final RecordConvertor stringRecordConvertor = new StringRecordConvertor();
+    private static final RecordConvertor debeziumRecordConvertor = new DebeziumRecordConvertor();
     private static RecordConvertor getConvertor(Schema schema, Object data) {
         if (data == null ) {
             return emptyRecordConvertor;
         }
         if (schema != null && data instanceof Struct) {
+            if (schema.name() != null && schema.name().endsWith(".Envelope")) {
+                return debeziumRecordConvertor;
+            }
             return schemaRecordConvertor;
         }
         if (data instanceof Map) {

--- a/src/main/java/com/clickhouse/kafka/connect/sink/data/Record.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/data/Record.java
@@ -54,12 +54,12 @@ public class Record {
     private static final RecordConvertor emptyRecordConvertor = new EmptyRecordConvertor();
     private static final RecordConvertor stringRecordConvertor = new StringRecordConvertor();
     private static final RecordConvertor debeziumRecordConvertor = new DebeziumRecordConvertor();
-    private static RecordConvertor getConvertor(Schema schema, Object data) {
-        if (data == null ) {
+    private static RecordConvertor getConvertor(Schema schema, Object data, boolean debeziumCDCEnabled) {
+        if (data == null) {
             return emptyRecordConvertor;
         }
         if (schema != null && data instanceof Struct) {
-            if (schema.name() != null && schema.name().endsWith(".Envelope")) {
+            if (debeziumCDCEnabled && schema.name() != null && schema.name().endsWith(".Envelope")) {
                 return debeziumRecordConvertor;
             }
             return schemaRecordConvertor;
@@ -70,11 +70,18 @@ public class Record {
         if (data instanceof String) {
             return stringRecordConvertor;
         }
-        throw new DataException(String.format("No converter was found due to unexpected object type %s", data.getClass().getName()));
+        throw new DataException(
+                String.format("No converter was found due to unexpected object type %s", data.getClass().getName()));
     }
 
-    public static Record convert(SinkRecord sinkRecord, boolean splitDBTopic, String dbTopicSeparatorChar,String database) {
-        RecordConvertor recordConvertor = getConvertor(sinkRecord.valueSchema(), sinkRecord.value());
+    public static Record convert(
+            SinkRecord sinkRecord,
+            boolean splitDBTopic,
+            String dbTopicSeparatorChar,
+            String database,
+            boolean debeziumCDCEnabled) {
+        RecordConvertor recordConvertor =
+                getConvertor(sinkRecord.valueSchema(), sinkRecord.value(), debeziumCDCEnabled);
         return recordConvertor.convert(sinkRecord, splitDBTopic, dbTopicSeparatorChar, database);
     }
 

--- a/src/main/java/com/clickhouse/kafka/connect/sink/data/SchemaType.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/data/SchemaType.java
@@ -3,5 +3,6 @@ package com.clickhouse.kafka.connect.sink.data;
 public enum SchemaType {
     SCHEMA,
     SCHEMA_LESS,
-    STRING_SCHEMA
+    STRING_SCHEMA,
+    DEBEZIUM_CDC
 }

--- a/src/main/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertor.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertor.java
@@ -58,7 +58,8 @@ public class DebeziumRecordConvertor extends RecordConvertor {
     private static final String FIELD_LSN        = "lsn";
     private static final String FIELD_GTID       = "gtid";
     private static final String FIELD_POS        = "pos";
-    private static final String FIELD_CHANGE_LSN = "change_lsn";   // SQL Server
+    private static final String FIELD_CHANGE_LSN  = "change_lsn";   // SQL Server streaming
+    private static final String FIELD_COMMIT_LSN  = "commit_lsn";   // SQL Server snapshot + streaming fallback
 
     private static final String OP_DELETE   = "d";
     private static final String OP_TRUNCATE = "t";
@@ -208,6 +209,15 @@ public class DebeziumRecordConvertor extends RecordConvertor {
         }
     }
 
+    private static long packSqlServerLsn(String lsn) {
+        String[] parts = lsn.split(":");
+        if (parts.length != 3) return 0L;
+        long p1 = Long.parseLong(parts[0].trim(), 16) & 0xFFFFFFL;     // 24 bits
+        long p2 = Long.parseLong(parts[1].trim(), 16) & 0xFFFFFFFFL;   // 32 bits
+        long p3 = Long.parseLong(parts[2].trim(), 16) & 0xFFL;         //  8 bits
+        return (p1 << 40) | (p2 << 8) | p3;
+    }
+
     private static String bytesToHex(byte[] bytes) {
         StringBuilder sb = new StringBuilder(bytes.length * 2);
         for (byte b : bytes) sb.append(String.format("%02x", b));
@@ -250,22 +260,31 @@ public class DebeziumRecordConvertor extends RecordConvertor {
         }
 
         // SQL Server: change_lsn = "00085734:000fd88d:0003" (VLF:block:entry)
+        // Null during snapshot (op=r); commit_lsn is used as fallback in that case.
         // Pack into 64 bits: 24 bits VLF | 32 bits block | 8 bits entry
         // Preserves correct LSN ordering within the 64-bit space.
         try {
             Object changeLsn = source.get(FIELD_CHANGE_LSN);
             if (changeLsn instanceof String) {
-                String[] parts = ((String) changeLsn).split(":");
-                if (parts.length == 3) {
-                    long p1 = Long.parseLong(parts[0].trim(), 16) & 0xFFFFFFL;     // 24 bits
-                    long p2 = Long.parseLong(parts[1].trim(), 16) & 0xFFFFFFFFL;   // 32 bits
-                    long p3 = Long.parseLong(parts[2].trim(), 16) & 0xFFL;         //  8 bits
-                    return (p1 << 40) | (p2 << 8) | p3;
-                }
+                long packed = packSqlServerLsn((String) changeLsn);
+                if (packed > 0) return packed;
             }
         } catch (Exception e) {
             LOGGER.debug(
                     "Could not parse source.change_lsn — not a SQL Server source or unexpected format: {}",
+                    e.getMessage());
+        }
+
+        // SQL Server fallback: commit_lsn is always present (streaming + snapshot).
+        try {
+            Object commitLsn = source.get(FIELD_COMMIT_LSN);
+            if (commitLsn instanceof String) {
+                long packed = packSqlServerLsn((String) commitLsn);
+                if (packed > 0) return packed;
+            }
+        } catch (Exception e) {
+            LOGGER.debug(
+                    "Could not parse source.commit_lsn — not a SQL Server source or unexpected format: {}",
                     e.getMessage());
         }
 

--- a/src/main/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertor.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertor.java
@@ -16,9 +16,7 @@ import org.slf4j.LoggerFactory;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -69,14 +67,10 @@ public class DebeziumRecordConvertor extends RecordConvertor {
     private static final String COL_IS_DELETED = "is_deleted";
 
     // Debezium logical type names
-    private static final String LOGICAL_ZONED_TIMESTAMP  = "io.debezium.time.ZonedTimestamp";
     private static final String LOGICAL_MICRO_TIMESTAMP  = "io.debezium.time.MicroTimestamp";
     private static final String LOGICAL_TIMESTAMP        = "org.apache.kafka.connect.data.Timestamp";
     private static final String LOGICAL_DATE             = "io.debezium.time.Date";
     private static final String LOGICAL_DECIMAL          = "org.apache.kafka.connect.data.Decimal";
-
-    private static final DateTimeFormatter DATETIME_FMT =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS").withZone(ZoneOffset.UTC);
 
     @Override
     public Record doConvert(SinkRecord sinkRecord, String topic, String database) {
@@ -181,18 +175,18 @@ public class DebeziumRecordConvertor extends RecordConvertor {
                 return raw;
 
             case INT64:
-                // Microseconds since epoch → datetime string
+                // doWriteDates handles Date natively in the INT64 branch.
+                // For MicroTimestamp, normalize to microseconds Long so DateTime64(6) gets the right unit.
                 if (LOGICAL_MICRO_TIMESTAMP.equals(logicalName)) {
-                    long micros = ((Number) raw).longValue();
-                    Instant instant = Instant.ofEpochSecond(
-                            micros / 1_000_000L,
-                            (micros % 1_000_000L) * 1_000L);
-                    return DATETIME_FMT.format(instant);
+                    if (raw instanceof java.util.Date) {
+                        return ((java.util.Date) raw).getTime() * 1_000L;
+                    }
+                    return raw; // already Long microseconds
                 }
-                // Milliseconds since epoch → datetime string
+                // For Timestamp, normalize to Date so doWriteDates uses doWriteDate(stream, date, precision).
                 if (LOGICAL_TIMESTAMP.equals(logicalName)) {
-                    long millis = ((Number) raw).longValue();
-                    return DATETIME_FMT.format(Instant.ofEpochMilli(millis));
+                    if (raw instanceof java.util.Date) return raw;
+                    return new java.util.Date(((Number) raw).longValue());
                 }
                 return raw;
 

--- a/src/main/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertor.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertor.java
@@ -233,7 +233,7 @@ public class DebeziumRecordConvertor extends RecordConvertor {
         // PostgreSQL: lsn is a Long
         try {
             Object lsn = source.get(FIELD_LSN);
-            if (lsn instanceof Long) return BigInteger.valueOf((Long) lsn);
+            if (lsn instanceof Number) return BigInteger.valueOf(((Number) lsn).longValue());
         } catch (Exception e) {
             LOGGER.debug("Could not read source.lsn — not a PostgreSQL source or field absent: {}", e.getMessage());
         }
@@ -252,7 +252,7 @@ public class DebeziumRecordConvertor extends RecordConvertor {
         // MySQL fallback: binlog position
         try {
             Object pos = source.get(FIELD_POS);
-            if (pos instanceof Long) return BigInteger.valueOf((Long) pos);
+            if (pos instanceof Number) return BigInteger.valueOf(((Number) pos).longValue());
         } catch (Exception e) {
             LOGGER.debug("Could not read source.pos — not a MySQL source or field absent: {}", e.getMessage());
         }

--- a/src/main/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertor.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertor.java
@@ -226,7 +226,9 @@ public class DebeziumRecordConvertor extends RecordConvertor {
         try {
             Object lsn = source.get(FIELD_LSN);
             if (lsn instanceof Long) return (Long) lsn;
-        } catch (Exception ignored) {}
+        } catch (Exception e) {
+            LOGGER.debug("Could not read source.lsn — not a PostgreSQL source or field absent: {}", e.getMessage());
+        }
 
         // MySQL: gtid = "uuid:N" — extract the sequence number N
         try {
@@ -235,13 +237,17 @@ public class DebeziumRecordConvertor extends RecordConvertor {
                 String[] parts = ((String) gtid).split(":");
                 if (parts.length == 2) return Long.parseLong(parts[1].trim());
             }
-        } catch (Exception ignored) {}
+        } catch (Exception e) {
+            LOGGER.debug("Could not parse source.gtid — not a MySQL source or unexpected format: {}", e.getMessage());
+        }
 
         // MySQL fallback: binlog position
         try {
             Object pos = source.get(FIELD_POS);
             if (pos instanceof Long) return (Long) pos;
-        } catch (Exception ignored) {}
+        } catch (Exception e) {
+            LOGGER.debug("Could not read source.pos — not a MySQL source or field absent: {}", e.getMessage());
+        }
 
         // SQL Server: change_lsn = "00085734:000fd88d:0003" (VLF:block:entry)
         // Pack into 64 bits: 24 bits VLF | 32 bits block | 8 bits entry
@@ -257,7 +263,11 @@ public class DebeziumRecordConvertor extends RecordConvertor {
                     return (p1 << 40) | (p2 << 8) | p3;
                 }
             }
-        } catch (Exception ignored) {}
+        } catch (Exception e) {
+            LOGGER.debug(
+                    "Could not parse source.change_lsn — not a SQL Server source or unexpected format: {}",
+                    e.getMessage());
+        }
 
         LOGGER.warn("Could not extract version from Debezium source struct — defaulting to 0");
         return 0L;

--- a/src/main/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertor.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertor.java
@@ -3,8 +3,6 @@ package com.clickhouse.kafka.connect.sink.data.convert;
 import com.clickhouse.kafka.connect.sink.data.Data;
 import com.clickhouse.kafka.connect.sink.data.Record;
 import com.clickhouse.kafka.connect.sink.data.SchemaType;
-import com.clickhouse.kafka.connect.sink.kafka.OffsetContainer;
-import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -100,13 +98,13 @@ public class DebeziumRecordConvertor extends RecordConvertor {
 
         Map<String, Data> jsonMap = toDebeziumJsonMap(dataStruct);
 
-        long version = extractVersion(envelope);
-        jsonMap.put(COL_VERSION,    new Data(Schema.INT64_SCHEMA, version));
+        BigInteger version = extractVersion(envelope);
+        jsonMap.put(COL_VERSION,    new Data(Schema.BYTES_SCHEMA, version));
         jsonMap.put(COL_IS_DELETED, new Data(Schema.INT8_SCHEMA, isDelete ? (byte) 1 : (byte) 0));
 
         // Include synthetic fields in the fields list so validateDataSchema() can look them up.
         List<Field> fields = new ArrayList<>(dataStruct.schema().fields());
-        fields.add(new Field(COL_VERSION,    fields.size(), SchemaBuilder.int64().build()));
+        fields.add(new Field(COL_VERSION,    fields.size(), SchemaBuilder.bytes().build()));
         fields.add(new Field(COL_IS_DELETED, fields.size(), SchemaBuilder.int8().build()));
 
         return Record.newRecord(SchemaType.DEBEZIUM_CDC,
@@ -228,14 +226,14 @@ public class DebeziumRecordConvertor extends RecordConvertor {
      * Extracts the replication position from the Debezium source struct.
      * Priority: PostgreSQL LSN → MySQL GTID sequence number → MySQL binlog pos.
      */
-    private long extractVersion(Struct envelope) {
+    private BigInteger extractVersion(Struct envelope) {
         Struct source = envelope.getStruct(FIELD_SOURCE);
-        if (source == null) return 0L;
+        if (source == null) return BigInteger.ZERO;
 
         // PostgreSQL: lsn is a Long
         try {
             Object lsn = source.get(FIELD_LSN);
-            if (lsn instanceof Long) return (Long) lsn;
+            if (lsn instanceof Long) return BigInteger.valueOf((Long) lsn);
         } catch (Exception e) {
             LOGGER.debug("Could not read source.lsn — not a PostgreSQL source or field absent: {}", e.getMessage());
         }
@@ -245,7 +243,7 @@ public class DebeziumRecordConvertor extends RecordConvertor {
             Object gtid = source.get(FIELD_GTID);
             if (gtid instanceof String) {
                 String[] parts = ((String) gtid).split(":");
-                if (parts.length == 2) return Long.parseLong(parts[1].trim());
+                if (parts.length == 2) return BigInteger.valueOf(Long.parseLong(parts[1].trim()));
             }
         } catch (Exception e) {
             LOGGER.debug("Could not parse source.gtid — not a MySQL source or unexpected format: {}", e.getMessage());
@@ -254,41 +252,38 @@ public class DebeziumRecordConvertor extends RecordConvertor {
         // MySQL fallback: binlog position
         try {
             Object pos = source.get(FIELD_POS);
-            if (pos instanceof Long) return (Long) pos;
+            if (pos instanceof Long) return BigInteger.valueOf((Long) pos);
         } catch (Exception e) {
             LOGGER.debug("Could not read source.pos — not a MySQL source or field absent: {}", e.getMessage());
         }
 
-        // SQL Server: change_lsn = "00085734:000fd88d:0003" (VLF:block:entry)
-        // Null during snapshot (op=r); commit_lsn is used as fallback in that case.
-        // Pack into 64 bits: 24 bits VLF | 32 bits block | 8 bits entry
-        // Preserves correct LSN ordering within the 64-bit space.
+        // SQL Server: composite version = (commit_lsn << 64) | change_lsn
+        // commit_lsn is always present; change_lsn is null during snapshot (op=r).
+        // Higher commit_lsn always wins; within same commit, higher change_lsn wins.
         try {
-            Object changeLsn = source.get(FIELD_CHANGE_LSN);
-            if (changeLsn instanceof String) {
-                long packed = packSqlServerLsn((String) changeLsn);
-                if (packed > 0) return packed;
-            }
-        } catch (Exception e) {
-            LOGGER.debug(
-                    "Could not parse source.change_lsn — not a SQL Server source or unexpected format: {}",
-                    e.getMessage());
-        }
-
-        // SQL Server fallback: commit_lsn is always present (streaming + snapshot).
-        try {
+            long commitPacked = 0L;
             Object commitLsn = source.get(FIELD_COMMIT_LSN);
             if (commitLsn instanceof String) {
-                long packed = packSqlServerLsn((String) commitLsn);
-                if (packed > 0) return packed;
+                commitPacked = packSqlServerLsn((String) commitLsn);
+            }
+
+            long changePacked = 0L;
+            Object changeLsn = source.get(FIELD_CHANGE_LSN);
+            if (changeLsn instanceof String) {
+                changePacked = packSqlServerLsn((String) changeLsn);
+            }
+
+            if (commitPacked > 0 || changePacked > 0) {
+                BigInteger high = BigInteger.valueOf(commitPacked).shiftLeft(64);
+                BigInteger low  = BigInteger.valueOf(changePacked).and(
+                        BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE));
+                return high.or(low);
             }
         } catch (Exception e) {
-            LOGGER.debug(
-                    "Could not parse source.commit_lsn — not a SQL Server source or unexpected format: {}",
-                    e.getMessage());
+            LOGGER.debug("Could not parse SQL Server LSN fields: {}", e.getMessage());
         }
 
         LOGGER.warn("Could not extract version from Debezium source struct — defaulting to 0");
-        return 0L;
+        return BigInteger.ZERO;
     }
 }

--- a/src/main/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertor.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertor.java
@@ -57,9 +57,10 @@ public class DebeziumRecordConvertor extends RecordConvertor {
     private static final String FIELD_BEFORE = "before";
     private static final String FIELD_AFTER  = "after";
     private static final String FIELD_SOURCE = "source";
-    private static final String FIELD_LSN    = "lsn";
-    private static final String FIELD_GTID   = "gtid";
-    private static final String FIELD_POS    = "pos";
+    private static final String FIELD_LSN        = "lsn";
+    private static final String FIELD_GTID       = "gtid";
+    private static final String FIELD_POS        = "pos";
+    private static final String FIELD_CHANGE_LSN = "change_lsn";   // SQL Server
 
     private static final String OP_DELETE   = "d";
     private static final String OP_TRUNCATE = "t";
@@ -246,6 +247,22 @@ public class DebeziumRecordConvertor extends RecordConvertor {
         try {
             Object pos = source.get(FIELD_POS);
             if (pos instanceof Long) return (Long) pos;
+        } catch (Exception ignored) {}
+
+        // SQL Server: change_lsn = "00085734:000fd88d:0003" (VLF:block:entry)
+        // Pack into 64 bits: 24 bits VLF | 32 bits block | 8 bits entry
+        // Preserves correct LSN ordering within the 64-bit space.
+        try {
+            Object changeLsn = source.get(FIELD_CHANGE_LSN);
+            if (changeLsn instanceof String) {
+                String[] parts = ((String) changeLsn).split(":");
+                if (parts.length == 3) {
+                    long p1 = Long.parseLong(parts[0].trim(), 16) & 0xFFFFFFL;     // 24 bits
+                    long p2 = Long.parseLong(parts[1].trim(), 16) & 0xFFFFFFFFL;   // 32 bits
+                    long p3 = Long.parseLong(parts[2].trim(), 16) & 0xFFL;         //  8 bits
+                    return (p1 << 40) | (p2 << 8) | p3;
+                }
+            }
         } catch (Exception ignored) {}
 
         LOGGER.warn("Could not extract version from Debezium source struct — defaulting to 0");

--- a/src/main/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertor.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertor.java
@@ -1,0 +1,254 @@
+package com.clickhouse.kafka.connect.sink.data.convert;
+
+import com.clickhouse.kafka.connect.sink.data.Data;
+import com.clickhouse.kafka.connect.sink.data.Record;
+import com.clickhouse.kafka.connect.sink.data.SchemaType;
+import com.clickhouse.kafka.connect.sink.kafka.OffsetContainer;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Converts Debezium CDC envelope records into flat Records suitable for
+ * insertion into a ClickHouse ReplacingMergeTree(_version, is_deleted) table.
+ *
+ * Detection: activated when the SinkRecord value schema name ends with ".Envelope".
+ *
+ * Routing:
+ *   op = "c" / "r" / "u" → after struct, is_deleted = 0
+ *   op = "d"             → before struct, is_deleted = 1
+ *   op = "t"             → skip (truncate not supported)
+ *
+ * Injected columns:
+ *   _version   UInt64  — source.lsn (PostgreSQL) or parsed source.gtid (MySQL)
+ *   is_deleted UInt8   — 0 for upserts, 1 for deletes
+ *
+ * Type conversions (mirrors Altinity ClickHouseDataTypeMapper):
+ *   STRING (no logical type)                 → String (pass-through)
+ *   STRING + ZonedTimestamp                  → String (ISO8601 normalized)
+ *   INT64  + MicroTimestamp / Timestamp      → String datetime
+ *   INT32  + Date                            → java.sql.Date
+ *   BYTES  + Decimal                         → BigDecimal
+ *   BYTES  (no logical type)                 → String (hex)
+ *   STRING (numeric, no logical type)        → String kept, BigDecimal attempted in writer
+ */
+public class DebeziumRecordConvertor extends RecordConvertor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DebeziumRecordConvertor.class);
+
+    private static final String FIELD_OP     = "op";
+    private static final String FIELD_BEFORE = "before";
+    private static final String FIELD_AFTER  = "after";
+    private static final String FIELD_SOURCE = "source";
+    private static final String FIELD_LSN    = "lsn";
+    private static final String FIELD_GTID   = "gtid";
+    private static final String FIELD_POS    = "pos";
+
+    private static final String OP_DELETE   = "d";
+    private static final String OP_TRUNCATE = "t";
+
+    private static final String COL_VERSION    = "_version";
+    private static final String COL_IS_DELETED = "is_deleted";
+
+    // Debezium logical type names
+    private static final String LOGICAL_ZONED_TIMESTAMP  = "io.debezium.time.ZonedTimestamp";
+    private static final String LOGICAL_MICRO_TIMESTAMP  = "io.debezium.time.MicroTimestamp";
+    private static final String LOGICAL_TIMESTAMP        = "org.apache.kafka.connect.data.Timestamp";
+    private static final String LOGICAL_DATE             = "io.debezium.time.Date";
+    private static final String LOGICAL_DECIMAL          = "org.apache.kafka.connect.data.Decimal";
+
+    private static final DateTimeFormatter DATETIME_FMT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS").withZone(ZoneOffset.UTC);
+
+    @Override
+    public Record doConvert(SinkRecord sinkRecord, String topic, String database) {
+        Struct envelope = (Struct) sinkRecord.value();
+        String op = envelope.getString(FIELD_OP);
+
+        if (op == null || op.equalsIgnoreCase(OP_TRUNCATE)) {
+            LOGGER.debug("Skipping Debezium record with op={} for topic={}", op, topic);
+            return Record.newRecord(SchemaType.DEBEZIUM_CDC,
+                    topic, sinkRecord.kafkaPartition(), sinkRecord.kafkaOffset(),
+                    Collections.emptyList(), Collections.emptyMap(), database, sinkRecord);
+        }
+
+        boolean isDelete = op.equalsIgnoreCase(OP_DELETE);
+        Struct dataStruct = isDelete
+                ? envelope.getStruct(FIELD_BEFORE)
+                : envelope.getStruct(FIELD_AFTER);
+
+        if (dataStruct == null) {
+            LOGGER.warn("Debezium record op={} has null {} struct — skipping. topic={}",
+                    op, isDelete ? FIELD_BEFORE : FIELD_AFTER, topic);
+            return Record.newRecord(SchemaType.DEBEZIUM_CDC,
+                    topic, sinkRecord.kafkaPartition(), sinkRecord.kafkaOffset(),
+                    Collections.emptyList(), Collections.emptyMap(), database, sinkRecord);
+        }
+
+        Map<String, Data> jsonMap = toDebeziumJsonMap(dataStruct);
+
+        long version = extractVersion(envelope);
+        jsonMap.put(COL_VERSION,    new Data(Schema.INT64_SCHEMA, version));
+        jsonMap.put(COL_IS_DELETED, new Data(Schema.INT8_SCHEMA, isDelete ? (byte) 1 : (byte) 0));
+
+        // Include synthetic fields in the fields list so validateDataSchema() can look them up.
+        List<Field> fields = new ArrayList<>(dataStruct.schema().fields());
+        fields.add(new Field(COL_VERSION,    fields.size(), SchemaBuilder.int64().build()));
+        fields.add(new Field(COL_IS_DELETED, fields.size(), SchemaBuilder.int8().build()));
+
+        return Record.newRecord(SchemaType.DEBEZIUM_CDC,
+                topic, sinkRecord.kafkaPartition(), sinkRecord.kafkaOffset(),
+                fields, jsonMap, database, sinkRecord);
+    }
+
+    /**
+     * Converts a Debezium after/before Struct into Map<String, Data> with
+     * type-aware conversion for each Debezium logical type — mirrors the
+     * conversion logic in Altinity's ClickHouseDataTypeMapper.
+     */
+    private Map<String, Data> toDebeziumJsonMap(Struct struct) {
+        Map<String, Data> result = new HashMap<>();
+        for (Field field : struct.schema().fields()) {
+            String name       = field.name();
+            Schema schema     = field.schema();
+            Schema.Type type  = schema.type();
+            String logicalName = schema.name();
+            Object raw        = struct.get(field);
+
+            if (raw == null) {
+                result.put(name, new Data(schema, null));
+                continue;
+            }
+
+            try {
+                result.put(name, new Data(schema, convertValue(type, logicalName, raw)));
+            } catch (Exception e) {
+                LOGGER.warn("Could not convert field [{}] type={} logical={} — keeping raw value. Error: {}",
+                        name, type, logicalName, e.getMessage());
+                result.put(name, new Data(schema, raw));
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Converts a single field value from its Debezium Java type to the Java type
+     * that ClickHouseWriter.doWriteColValue() expects for each ClickHouse column type.
+     */
+    private Object convertValue(Schema.Type type, String logicalName, Object raw) {
+        switch (type) {
+            case BYTES:
+                // Decimal logical type → BigDecimal
+                if (LOGICAL_DECIMAL.equals(logicalName)) {
+                    if (raw instanceof BigDecimal) return raw;
+                    if (raw instanceof byte[])      return new BigDecimal(new BigInteger((byte[]) raw));
+                    if (raw instanceof ByteBuffer) {
+                        ByteBuffer buf = (ByteBuffer) raw;
+                        byte[] bytes = new byte[buf.remaining()];
+                        buf.get(bytes);
+                        buf.rewind();
+                        return new BigDecimal(new BigInteger(bytes));
+                    }
+                    return new BigDecimal(raw.toString());
+                }
+                // Raw bytes → hex string
+                if (raw instanceof byte[])    return bytesToHex((byte[]) raw);
+                if (raw instanceof ByteBuffer) {
+                    ByteBuffer buf = (ByteBuffer) raw;
+                    byte[] bytes = new byte[buf.remaining()];
+                    buf.get(bytes);
+                    buf.rewind();
+                    return bytesToHex(bytes);
+                }
+                return raw;
+
+            case INT64:
+                // Microseconds since epoch → datetime string
+                if (LOGICAL_MICRO_TIMESTAMP.equals(logicalName)) {
+                    long micros = ((Number) raw).longValue();
+                    Instant instant = Instant.ofEpochSecond(
+                            micros / 1_000_000L,
+                            (micros % 1_000_000L) * 1_000L);
+                    return DATETIME_FMT.format(instant);
+                }
+                // Milliseconds since epoch → datetime string
+                if (LOGICAL_TIMESTAMP.equals(logicalName)) {
+                    long millis = ((Number) raw).longValue();
+                    return DATETIME_FMT.format(Instant.ofEpochMilli(millis));
+                }
+                return raw;
+
+            case INT32:
+                // Days since epoch → java.sql.Date
+                if (LOGICAL_DATE.equals(logicalName)) {
+                    return java.sql.Date.valueOf(
+                            java.time.LocalDate.ofEpochDay(((Number) raw).longValue()));
+                }
+                return raw;
+
+            case STRING:
+                // ZonedTimestamp is already a valid ISO8601 string — pass through as-is.
+                // doWriteDates handles string input for DateTime64 columns.
+                return raw;
+
+            default:
+                return raw;
+        }
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) sb.append(String.format("%02x", b));
+        return sb.toString();
+    }
+
+    /**
+     * Extracts the replication position from the Debezium source struct.
+     * Priority: PostgreSQL LSN → MySQL GTID sequence number → MySQL binlog pos.
+     */
+    private long extractVersion(Struct envelope) {
+        Struct source = envelope.getStruct(FIELD_SOURCE);
+        if (source == null) return 0L;
+
+        // PostgreSQL: lsn is a Long
+        try {
+            Object lsn = source.get(FIELD_LSN);
+            if (lsn instanceof Long) return (Long) lsn;
+        } catch (Exception ignored) {}
+
+        // MySQL: gtid = "uuid:N" — extract the sequence number N
+        try {
+            Object gtid = source.get(FIELD_GTID);
+            if (gtid instanceof String) {
+                String[] parts = ((String) gtid).split(":");
+                if (parts.length == 2) return Long.parseLong(parts[1].trim());
+            }
+        } catch (Exception ignored) {}
+
+        // MySQL fallback: binlog position
+        try {
+            Object pos = source.get(FIELD_POS);
+            if (pos instanceof Long) return (Long) pos;
+        } catch (Exception ignored) {}
+
+        LOGGER.warn("Could not extract version from Debezium source struct — defaulting to 0");
+        return 0L;
+    }
+}

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -494,10 +494,12 @@ public class ClickHouseWriter implements DBWriter {
                 case INT16:
                 case INT32:
                 case INT64:
+                case INT128:
                 case UINT8:
                 case UINT16:
                 case UINT32:
                 case UINT64:
+                case UINT128:
                 case FLOAT32:
                 case FLOAT64:
                 case BOOLEAN:
@@ -788,6 +790,12 @@ public class ClickHouseWriter implements DBWriter {
                     break;
                 case Enum16:
                     BinaryStreamUtils.writeEnum16(stream, col.convertEnumValues((String) value).intValue());
+                    break;
+                case INT128:
+                    BinaryStreamUtils.writeInt128(stream, (java.math.BigInteger) value);
+                    break;
+                case UINT128:
+                    BinaryStreamUtils.writeUnsignedInt128(stream, (java.math.BigInteger) value);
                     break;
             }
         }

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -20,6 +20,7 @@ import com.clickhouse.data.format.BinaryStreamUtils;
 import com.clickhouse.kafka.connect.sink.ClickHouseSinkConfig;
 import com.clickhouse.kafka.connect.sink.data.Data;
 import com.clickhouse.kafka.connect.sink.data.Record;
+import com.clickhouse.kafka.connect.sink.data.SchemaType;
 import com.clickhouse.kafka.connect.sink.data.StructToJsonMap;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
 import com.clickhouse.kafka.connect.sink.db.mapping.Column;
@@ -238,6 +239,7 @@ public class ClickHouseWriter implements DBWriter {
         LOGGER.debug("Trying to insert [{}] records to table name [{}] (QueryId: [{}])", records.size(), table.getName(), queryId.getQueryId());
         switch (first.getSchemaType()) {
             case SCHEMA:
+            case DEBEZIUM_CDC:
                 if (csc.isBypassRowBinary()) {
                     doInsertJson(records, table, queryId);
                 } else {
@@ -321,7 +323,7 @@ public class ClickHouseWriter implements DBWriter {
                                     continue;
                                 }
 
-                                if (("DECIMAL".equalsIgnoreCase(colTypeName) && objSchema.name().equals("org.apache.kafka.connect.data.Decimal")))
+                                if (("DECIMAL".equalsIgnoreCase(colTypeName) && "org.apache.kafka.connect.data.Decimal".equals(objSchema.name())))
                                     continue;
 
                                 if (type == Type.JSON) {
@@ -519,7 +521,10 @@ public class ClickHouseWriter implements DBWriter {
                         BinaryStreamUtils.writeNull(stream);
                         return;
                     } else {
-                        BigDecimal decimal = (BigDecimal) value.getObject();
+                        Object rawDecimal = value.getObject();
+                        BigDecimal decimal = (rawDecimal instanceof BigDecimal)
+                                ? (BigDecimal) rawDecimal
+                                : new BigDecimal(rawDecimal.toString());
                         BinaryStreamUtils.writeDecimal(stream, decimal, col.getPrecision(), col.getScale());
                     }
                     break;
@@ -987,7 +992,9 @@ public class ClickHouseWriter implements DBWriter {
         String topic = first.getSinkRecord().topic();
         String partition = first.getSinkRecord().kafkaPartition().toString();
 
-        if (!csc.isBypassSchemaValidation() && !validateDataSchema(table, first, false))
+        if (!csc.isBypassSchemaValidation()
+                && first.getSchemaType() != SchemaType.DEBEZIUM_CDC
+                && !validateDataSchema(table, first, false))
             throw new RuntimeException("Data schema validation failed.");
         // Let's test first record
         // Do we have all elements from the table inside the record
@@ -1049,7 +1056,9 @@ public class ClickHouseWriter implements DBWriter {
         String topic = first.getSinkRecord().topic();
         String partition = first.getSinkRecord().kafkaPartition().toString();
 
-        if (!csc.isBypassSchemaValidation() && !validateDataSchema(table, first, false))
+        if (!csc.isBypassSchemaValidation()
+                && first.getSchemaType() != SchemaType.DEBEZIUM_CDC
+                && !validateDataSchema(table, first, false))
             throw new RuntimeException("Data schema validation failed.");
         // Let's test first record
         // Do we have all elements from the table inside the record
@@ -1147,6 +1156,10 @@ public class ClickHouseWriter implements DBWriter {
                                     data.put(field.name(), struct.get(field));//Doesn't handle multi-level object depth
                                 }
                                 break;
+                            case DEBEZIUM_CDC:
+                                data = new HashMap<>(record.getJsonMap().size());
+                                record.getJsonMap().forEach((k, v) -> data.put(k, v.getObject()));
+                                break;
                             default:
                                 data = (Map<String, Object>) record.getSinkRecord().value();
                                 break;
@@ -1223,6 +1236,10 @@ public class ClickHouseWriter implements DBWriter {
                         for (Field field : struct.schema().fields()) {
                             data.put(field.name(), struct.get(field));//Doesn't handle multi-level object depth
                         }
+                        break;
+                    case DEBEZIUM_CDC:
+                        data = new HashMap<>(record.getJsonMap().size());
+                        record.getJsonMap().forEach((k, v) -> data.put(k, v.getObject()));
                         break;
                     default:
                         data = (Map<String, Object>) record.getSinkRecord().value();

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -792,10 +792,14 @@ public class ClickHouseWriter implements DBWriter {
                     BinaryStreamUtils.writeEnum16(stream, col.convertEnumValues((String) value).intValue());
                     break;
                 case INT128:
-                    BinaryStreamUtils.writeInt128(stream, (java.math.BigInteger) value);
+                    BinaryStreamUtils.writeInt128(stream, value instanceof java.math.BigInteger
+                            ? (java.math.BigInteger) value
+                            : new java.math.BigInteger(value.toString()));
                     break;
                 case UINT128:
-                    BinaryStreamUtils.writeUnsignedInt128(stream, (java.math.BigInteger) value);
+                    BinaryStreamUtils.writeUnsignedInt128(stream, value instanceof java.math.BigInteger
+                            ? (java.math.BigInteger) value
+                            : new java.math.BigInteger(value.toString()));
                     break;
             }
         }

--- a/src/test/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertorTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertorTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Date;
 import java.util.Map;
@@ -45,6 +46,7 @@ public class DebeziumRecordConvertorTest {
                 .field("gtid", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("pos", Schema.OPTIONAL_INT64_SCHEMA)
                 .field("change_lsn", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("commit_lsn", Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
     }
 
@@ -194,7 +196,7 @@ public class DebeziumRecordConvertorTest {
 
         Record record = convert(envelope);
 
-        assertEquals(12345L, record.getJsonMap().get("_version").getObject());
+        assertEquals(BigInteger.valueOf(12345L), record.getJsonMap().get("_version").getObject());
     }
 
     @Test
@@ -219,13 +221,14 @@ public class DebeziumRecordConvertorTest {
 
         Record record = convert(envelope);
 
-        assertEquals(100L, record.getJsonMap().get("_version").getObject());
+        assertEquals(BigInteger.valueOf(100L), record.getJsonMap().get("_version").getObject());
     }
 
     @Test
     @DisplayName("SQL Server change_lsn is bit-packed into _version")
     void version_sqlServerChangeLsn() {
         Schema sourceWithChangeLsn = SchemaBuilder.struct().optional()
+                .field("commit_lsn", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("change_lsn", Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
         Schema row = rowSchema(SchemaBuilder.int32().name("id"));
@@ -235,7 +238,9 @@ public class DebeziumRecordConvertorTest {
                 .field("after", row)
                 .field("source", sourceWithChangeLsn)
                 .build();
-        Struct source = new Struct(sourceWithChangeLsn).put("change_lsn", "00000001:00000002:0003");
+        Struct source = new Struct(sourceWithChangeLsn)
+                .put("commit_lsn", null)
+                .put("change_lsn", "00000001:00000002:0003");
         Struct after = new Struct(row).put("id", 1);
         Struct envelope = new Struct(env)
                 .put("op", "c")
@@ -244,8 +249,9 @@ public class DebeziumRecordConvertorTest {
 
         Record record = convert(envelope);
 
-        // p1=0x000001 (24bits) << 40 | p2=0x00000002 (32bits) << 8 | p3=0x03 (8bits)
-        long expected = (1L << 40) | (2L << 8) | 3L;
+        // commit_lsn absent → commitPacked=0; change_lsn packed into low 64 bits
+        long changePacked = (1L << 40) | (2L << 8) | 3L;
+        BigInteger expected = BigInteger.ZERO.shiftLeft(64).or(BigInteger.valueOf(changePacked));
         assertEquals(expected, record.getJsonMap().get("_version").getObject());
     }
 
@@ -274,8 +280,9 @@ public class DebeziumRecordConvertorTest {
 
         Record record = convert(envelope);
 
-        // p1=0x6f<<40 | p2=0xab7<<8 | p3=0x03
-        long expected = (0x6fL << 40) | (0xab7L << 8) | 0x03L;
+        // commit_lsn="0000006f:00000ab7:0003" packed into high 64 bits; change_lsn=null → 0 in low 64 bits
+        long commitPacked = (0x6fL << 40) | (0xab7L << 8) | 0x03L;
+        BigInteger expected = BigInteger.valueOf(commitPacked).shiftLeft(64);
         assertEquals(expected, record.getJsonMap().get("_version").getObject());
     }
 
@@ -296,7 +303,7 @@ public class DebeziumRecordConvertorTest {
 
         Record record = convert(envelope);
 
-        assertEquals(0L, record.getJsonMap().get("_version").getObject());
+        assertEquals(BigInteger.ZERO, record.getJsonMap().get("_version").getObject());
     }
 
     // ===========================================================================
@@ -465,7 +472,7 @@ public class DebeziumRecordConvertorTest {
 
         assertTrue(fieldsByName.containsKey("_version"));
         assertTrue(fieldsByName.containsKey("is_deleted"));
-        assertEquals(Schema.Type.INT64, fieldsByName.get("_version").schema().type());
+        assertEquals(Schema.Type.BYTES, fieldsByName.get("_version").schema().type());
         assertEquals(Schema.Type.INT8, fieldsByName.get("is_deleted").schema().type());
     }
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertorTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertorTest.java
@@ -250,6 +250,36 @@ public class DebeziumRecordConvertorTest {
     }
 
     @Test
+    @DisplayName("SQL Server snapshot: change_lsn=null falls back to commit_lsn for _version")
+    void version_sqlServerSnapshot_commitLsnFallback() {
+        Schema sqlServerSource = SchemaBuilder.struct().optional()
+                .field("change_lsn", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("commit_lsn", Schema.OPTIONAL_STRING_SCHEMA)
+                .build();
+        Schema row = rowSchema(SchemaBuilder.int32().name("id"));
+        Schema env = SchemaBuilder.struct().name("server.db.orders.Envelope")
+                .field("op", Schema.STRING_SCHEMA)
+                .field("before", row)
+                .field("after", row)
+                .field("source", sqlServerSource)
+                .build();
+        Struct source = new Struct(sqlServerSource)
+                .put("change_lsn", null)
+                .put("commit_lsn", "0000006f:00000ab7:0003");
+        Struct after = new Struct(row).put("id", 1);
+        Struct envelope = new Struct(env)
+                .put("op", "r")
+                .put("after", after)
+                .put("source", source);
+
+        Record record = convert(envelope);
+
+        // p1=0x6f<<40 | p2=0xab7<<8 | p3=0x03
+        long expected = (0x6fL << 40) | (0xab7L << 8) | 0x03L;
+        assertEquals(expected, record.getJsonMap().get("_version").getObject());
+    }
+
+    @Test
     @DisplayName("null source struct defaults _version to 0")
     void version_noSource_defaultsToZero() {
         Schema row = rowSchema(SchemaBuilder.int32().name("id"));

--- a/src/test/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertorTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/data/convert/DebeziumRecordConvertorTest.java
@@ -1,0 +1,478 @@
+package com.clickhouse.kafka.connect.sink.data.convert;
+
+import com.clickhouse.kafka.connect.sink.data.Record;
+import com.clickhouse.kafka.connect.sink.data.SchemaType;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.Date;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DebeziumRecordConvertorTest {
+
+    private static final String TOPIC = "server.db.orders.Envelope";
+    private static final String DATABASE = "test_db";
+
+    // --- Schema builders ---
+
+    private static Schema rowSchema(SchemaBuilder... fields) {
+        SchemaBuilder b = SchemaBuilder.struct();
+        for (SchemaBuilder f : fields) {
+            b.field(f.name(), f.build());
+        }
+        return b.build();
+    }
+
+    private static Schema sourceSchema() {
+        return SchemaBuilder.struct().optional()
+                .field("lsn", Schema.OPTIONAL_INT64_SCHEMA)
+                .field("gtid", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("pos", Schema.OPTIONAL_INT64_SCHEMA)
+                .field("change_lsn", Schema.OPTIONAL_STRING_SCHEMA)
+                .build();
+    }
+
+    private static Schema envelopeSchema(Schema rowSchema) {
+        return SchemaBuilder.struct().name("server.db.orders.Envelope")
+                .field("op", Schema.STRING_SCHEMA)
+                .field("before", rowSchema)
+                .field("after", rowSchema)
+                .field("source", sourceSchema())
+                .build();
+    }
+
+    private static Struct sourceStruct(Schema schema, Long lsn) {
+        Struct s = new Struct(schema);
+        s.put("lsn", lsn);
+        return s;
+    }
+
+    private static SinkRecord sinkRecord(Struct envelope) {
+        return new SinkRecord(TOPIC, 0, null, null,
+                envelope.schema(), envelope, 42L,
+                System.currentTimeMillis(), TimestampType.CREATE_TIME);
+    }
+
+    // --- Helpers ---
+
+    private static Record convert(Struct envelope) {
+        return new DebeziumRecordConvertor().doConvert(sinkRecord(envelope), TOPIC, DATABASE);
+    }
+
+    // ===========================================================================
+    // Op routing
+    // ===========================================================================
+
+    @Test
+    @DisplayName("op=c routes to after struct with is_deleted=0")
+    void opCreate_routesToAfter() {
+        Schema row = rowSchema(SchemaBuilder.int32().name("id"));
+        Schema env = envelopeSchema(row);
+        Struct after = new Struct(row).put("id", 1);
+        Struct envelope = new Struct(env)
+                .put("op", "c")
+                .put("after", after)
+                .put("source", sourceStruct(sourceSchema(), 100L));
+
+        Record record = convert(envelope);
+
+        assertEquals(SchemaType.DEBEZIUM_CDC, record.getSchemaType());
+        assertEquals(1, record.getJsonMap().get("id").getObject());
+        assertEquals((byte) 0, record.getJsonMap().get("is_deleted").getObject());
+    }
+
+    @Test
+    @DisplayName("op=u routes to after struct with is_deleted=0")
+    void opUpdate_routesToAfter() {
+        Schema row = rowSchema(SchemaBuilder.int32().name("id"));
+        Schema env = envelopeSchema(row);
+        Struct after = new Struct(row).put("id", 2);
+        Struct envelope = new Struct(env)
+                .put("op", "u")
+                .put("after", after)
+                .put("source", sourceStruct(sourceSchema(), 200L));
+
+        Record record = convert(envelope);
+
+        assertEquals((byte) 0, record.getJsonMap().get("is_deleted").getObject());
+        assertEquals(2, record.getJsonMap().get("id").getObject());
+    }
+
+    @Test
+    @DisplayName("op=r (read/snapshot) routes to after struct with is_deleted=0")
+    void opRead_routesToAfter() {
+        Schema row = rowSchema(SchemaBuilder.int32().name("id"));
+        Schema env = envelopeSchema(row);
+        Struct after = new Struct(row).put("id", 3);
+        Struct envelope = new Struct(env)
+                .put("op", "r")
+                .put("after", after)
+                .put("source", sourceStruct(sourceSchema(), 300L));
+
+        Record record = convert(envelope);
+
+        assertEquals((byte) 0, record.getJsonMap().get("is_deleted").getObject());
+    }
+
+    @Test
+    @DisplayName("op=d routes to before struct with is_deleted=1")
+    void opDelete_routesToBefore() {
+        Schema row = rowSchema(SchemaBuilder.int32().name("id"));
+        Schema env = envelopeSchema(row);
+        Struct before = new Struct(row).put("id", 5);
+        Struct envelope = new Struct(env)
+                .put("op", "d")
+                .put("before", before)
+                .put("source", sourceStruct(sourceSchema(), 500L));
+
+        Record record = convert(envelope);
+
+        assertEquals((byte) 1, record.getJsonMap().get("is_deleted").getObject());
+        assertEquals(5, record.getJsonMap().get("id").getObject());
+    }
+
+    @Test
+    @DisplayName("op=t (truncate) produces empty record")
+    void opTruncate_producesEmptyRecord() {
+        Schema row = rowSchema(SchemaBuilder.int32().name("id"));
+        Schema env = envelopeSchema(row);
+        Struct envelope = new Struct(env)
+                .put("op", "t")
+                .put("source", sourceStruct(sourceSchema(), 600L));
+
+        Record record = convert(envelope);
+
+        assertTrue(record.getJsonMap().isEmpty());
+        assertTrue(record.getFields().isEmpty());
+    }
+
+    @Test
+    @DisplayName("null after struct on op=c produces empty record")
+    void nullAfterStruct_producesEmptyRecord() {
+        Schema row = rowSchema(SchemaBuilder.int32().name("id"));
+        Schema env = envelopeSchema(row);
+        Struct envelope = new Struct(env)
+                .put("op", "c")
+                .put("source", sourceStruct(sourceSchema(), 700L));
+        // after is intentionally not set → null
+
+        Record record = convert(envelope);
+
+        assertTrue(record.getJsonMap().isEmpty());
+    }
+
+    // ===========================================================================
+    // _version extraction
+    // ===========================================================================
+
+    @Test
+    @DisplayName("PostgreSQL lsn Long is used as _version")
+    void version_postgresLsn() {
+        Schema row = rowSchema(SchemaBuilder.int32().name("id"));
+        Schema env = envelopeSchema(row);
+        Struct after = new Struct(row).put("id", 1);
+        Struct envelope = new Struct(env)
+                .put("op", "c")
+                .put("after", after)
+                .put("source", sourceStruct(sourceSchema(), 12345L));
+
+        Record record = convert(envelope);
+
+        assertEquals(12345L, record.getJsonMap().get("_version").getObject());
+    }
+
+    @Test
+    @DisplayName("MySQL gtid 'uuid:N' sequence number is used as _version")
+    void version_mysqlGtid() {
+        Schema sourceWithGtid = SchemaBuilder.struct().optional()
+                .field("gtid", Schema.OPTIONAL_STRING_SCHEMA)
+                .build();
+        Schema row = rowSchema(SchemaBuilder.int32().name("id"));
+        Schema env = SchemaBuilder.struct().name("server.db.orders.Envelope")
+                .field("op", Schema.STRING_SCHEMA)
+                .field("before", row)
+                .field("after", row)
+                .field("source", sourceWithGtid)
+                .build();
+        Struct source = new Struct(sourceWithGtid).put("gtid", "3E11FA47-71CA-11E1-9E33-C80AA9429562:100");
+        Struct after = new Struct(row).put("id", 1);
+        Struct envelope = new Struct(env)
+                .put("op", "c")
+                .put("after", after)
+                .put("source", source);
+
+        Record record = convert(envelope);
+
+        assertEquals(100L, record.getJsonMap().get("_version").getObject());
+    }
+
+    @Test
+    @DisplayName("SQL Server change_lsn is bit-packed into _version")
+    void version_sqlServerChangeLsn() {
+        Schema sourceWithChangeLsn = SchemaBuilder.struct().optional()
+                .field("change_lsn", Schema.OPTIONAL_STRING_SCHEMA)
+                .build();
+        Schema row = rowSchema(SchemaBuilder.int32().name("id"));
+        Schema env = SchemaBuilder.struct().name("server.db.orders.Envelope")
+                .field("op", Schema.STRING_SCHEMA)
+                .field("before", row)
+                .field("after", row)
+                .field("source", sourceWithChangeLsn)
+                .build();
+        Struct source = new Struct(sourceWithChangeLsn).put("change_lsn", "00000001:00000002:0003");
+        Struct after = new Struct(row).put("id", 1);
+        Struct envelope = new Struct(env)
+                .put("op", "c")
+                .put("after", after)
+                .put("source", source);
+
+        Record record = convert(envelope);
+
+        // p1=0x000001 (24bits) << 40 | p2=0x00000002 (32bits) << 8 | p3=0x03 (8bits)
+        long expected = (1L << 40) | (2L << 8) | 3L;
+        assertEquals(expected, record.getJsonMap().get("_version").getObject());
+    }
+
+    @Test
+    @DisplayName("null source struct defaults _version to 0")
+    void version_noSource_defaultsToZero() {
+        Schema row = rowSchema(SchemaBuilder.int32().name("id"));
+        // source field present in schema but value is null — realistic for some connectors
+        Schema env = SchemaBuilder.struct().name("server.db.orders.Envelope")
+                .field("op", Schema.STRING_SCHEMA)
+                .field("before", row)
+                .field("after", row)
+                .field("source", sourceSchema())
+                .build();
+        Struct after = new Struct(row).put("id", 1);
+        Struct envelope = new Struct(env).put("op", "c").put("after", after);
+        // source intentionally not set → null
+
+        Record record = convert(envelope);
+
+        assertEquals(0L, record.getJsonMap().get("_version").getObject());
+    }
+
+    // ===========================================================================
+    // Type conversions
+    // ===========================================================================
+
+    @Test
+    @DisplayName("BYTES + Decimal logical type converts to BigDecimal")
+    void typeConversion_decimal_fromBytes() {
+        Schema decimalSchema = Decimal.schema(2);
+        Schema row = SchemaBuilder.struct().field("price", decimalSchema).build();
+        Schema env = envelopeSchema(row);
+        BigDecimal expected = new BigDecimal("12.34");
+        Struct after = new Struct(row).put("price", expected);
+        Struct envelope = new Struct(env)
+                .put("op", "c").put("after", after)
+                .put("source", sourceStruct(sourceSchema(), 1L));
+
+        Record record = convert(envelope);
+
+        Object val = record.getJsonMap().get("price").getObject();
+        assertInstanceOf(BigDecimal.class, val);
+        assertEquals(0, expected.compareTo((BigDecimal) val));
+    }
+
+    @Test
+    @DisplayName("BYTES without logical type converts to hex string")
+    void typeConversion_rawBytes_toHex() {
+        Schema row = SchemaBuilder.struct().field("hash", Schema.BYTES_SCHEMA).build();
+        Schema env = envelopeSchema(row);
+        Struct after = new Struct(row).put("hash", new byte[]{(byte) 0xDE, (byte) 0xAD});
+        Struct envelope = new Struct(env)
+                .put("op", "c").put("after", after)
+                .put("source", sourceStruct(sourceSchema(), 1L));
+
+        Record record = convert(envelope);
+
+        assertEquals("dead", record.getJsonMap().get("hash").getObject());
+    }
+
+    @Test
+    @DisplayName("BYTES ByteBuffer without logical type converts to hex string")
+    void typeConversion_rawByteBuffer_toHex() {
+        Schema row = SchemaBuilder.struct().field("hash", Schema.BYTES_SCHEMA).build();
+        Schema env = envelopeSchema(row);
+        Struct after = new Struct(row).put("hash", ByteBuffer.wrap(new byte[]{(byte) 0xBE, (byte) 0xEF}));
+        Struct envelope = new Struct(env)
+                .put("op", "c").put("after", after)
+                .put("source", sourceStruct(sourceSchema(), 1L));
+
+        Record record = convert(envelope);
+
+        assertEquals("beef", record.getJsonMap().get("hash").getObject());
+    }
+
+    @Test
+    @DisplayName("INT64 + Timestamp (java.util.Date) normalizes to Date")
+    void typeConversion_timestampAsDate() {
+        Schema tsSchema = Timestamp.builder().build();
+        Schema row = SchemaBuilder.struct().field("created_at", tsSchema).build();
+        Schema env = envelopeSchema(row);
+        Date now = new Date(1_700_000_000_000L);
+        Struct after = new Struct(row).put("created_at", now);
+        Struct envelope = new Struct(env)
+                .put("op", "c").put("after", after)
+                .put("source", sourceStruct(sourceSchema(), 1L));
+
+        Record record = convert(envelope);
+
+        Object val = record.getJsonMap().get("created_at").getObject();
+        assertInstanceOf(Date.class, val);
+        assertEquals(now, val);
+    }
+
+    @Test
+    @DisplayName("INT64 + Timestamp (Long millis) normalizes to Date")
+    void typeConversion_timestampAsLong() {
+        Schema tsSchema = Timestamp.builder().build();
+        Schema row = SchemaBuilder.struct().field("created_at", tsSchema).build();
+        Schema env = envelopeSchema(row);
+        long millis = 1_700_000_000_000L;
+        Struct after = new Struct(row).put("created_at", new Date(millis));
+        Struct envelope = new Struct(env)
+                .put("op", "c").put("after", after)
+                .put("source", sourceStruct(sourceSchema(), 1L));
+
+        Record record = convert(envelope);
+
+        Object val = record.getJsonMap().get("created_at").getObject();
+        assertInstanceOf(Date.class, val);
+        assertEquals(millis, ((Date) val).getTime());
+    }
+
+    @Test
+    @DisplayName("INT64 + MicroTimestamp (Long micros) passes through as Long")
+    void typeConversion_microTimestampAsLong() {
+        Schema microTsSchema = SchemaBuilder.int64().name("io.debezium.time.MicroTimestamp").build();
+        Schema row = SchemaBuilder.struct().field("ts_micros", microTsSchema).build();
+        Schema env = envelopeSchema(row);
+        long micros = 1_700_000_000_000_000L;
+        Struct after = new Struct(row).put("ts_micros", micros);
+        Struct envelope = new Struct(env)
+                .put("op", "c").put("after", after)
+                .put("source", sourceStruct(sourceSchema(), 1L));
+
+        Record record = convert(envelope);
+
+        assertEquals(micros, record.getJsonMap().get("ts_micros").getObject());
+    }
+
+    @Test
+    @DisplayName("INT32 + Date (days since epoch) converts to java.sql.Date")
+    void typeConversion_dateAsDays() {
+        Schema dateSchema = SchemaBuilder.int32().name("io.debezium.time.Date").build();
+        Schema row = SchemaBuilder.struct().field("event_date", dateSchema).build();
+        Schema env = envelopeSchema(row);
+        Struct after = new Struct(row).put("event_date", 19000); // days since 1970-01-01
+        Struct envelope = new Struct(env)
+                .put("op", "c").put("after", after)
+                .put("source", sourceStruct(sourceSchema(), 1L));
+
+        Record record = convert(envelope);
+
+        Object val = record.getJsonMap().get("event_date").getObject();
+        assertInstanceOf(java.sql.Date.class, val);
+        assertEquals(java.time.LocalDate.ofEpochDay(19000), ((java.sql.Date) val).toLocalDate());
+    }
+
+    @Test
+    @DisplayName("null field value is preserved as null in jsonMap")
+    void nullFieldValue_preservedAsNull() {
+        Schema row = SchemaBuilder.struct()
+                .field("id", Schema.INT32_SCHEMA)
+                .field("note", Schema.OPTIONAL_STRING_SCHEMA)
+                .build();
+        Schema env = envelopeSchema(row);
+        Struct after = new Struct(row).put("id", 1).put("note", null);
+        Struct envelope = new Struct(env)
+                .put("op", "c").put("after", after)
+                .put("source", sourceStruct(sourceSchema(), 1L));
+
+        Record record = convert(envelope);
+
+        assertNotNull(record.getJsonMap().get("note"));
+        assertNull(record.getJsonMap().get("note").getObject());
+    }
+
+    // ===========================================================================
+    // Synthetic fields injected into fields list
+    // ===========================================================================
+
+    @Test
+    @DisplayName("_version and is_deleted appear in fields list")
+    void syntheticFields_presentInFieldsList() {
+        Schema row = rowSchema(SchemaBuilder.int32().name("id"));
+        Schema env = envelopeSchema(row);
+        Struct after = new Struct(row).put("id", 1);
+        Struct envelope = new Struct(env)
+                .put("op", "c").put("after", after)
+                .put("source", sourceStruct(sourceSchema(), 99L));
+
+        Record record = convert(envelope);
+
+        Map<String, Field> fieldsByName = new java.util.HashMap<>();
+        for (Field f : record.getFields()) fieldsByName.put(f.name(), f);
+
+        assertTrue(fieldsByName.containsKey("_version"));
+        assertTrue(fieldsByName.containsKey("is_deleted"));
+        assertEquals(Schema.Type.INT64, fieldsByName.get("_version").schema().type());
+        assertEquals(Schema.Type.INT8, fieldsByName.get("is_deleted").schema().type());
+    }
+
+    // ===========================================================================
+    // opt-in: disabled by default
+    // ===========================================================================
+
+    @Test
+    @DisplayName("Envelope schema without debeziumCDCEnabled routes to SchemaRecordConvertor")
+    void optIn_disabled_routesToSchemaConvertor() {
+        Schema row = rowSchema(SchemaBuilder.int32().name("id"));
+        Schema env = envelopeSchema(row);
+        Struct after = new Struct(row).put("id", 1);
+        Struct envelope = new Struct(env)
+                .put("op", "c").put("after", after)
+                .put("source", sourceStruct(sourceSchema(), 1L));
+
+        SinkRecord sinkRecord = sinkRecord(envelope);
+        // debeziumCDCEnabled=false — envelope goes through SchemaRecordConvertor, not Debezium
+        Record record = Record.convert(sinkRecord, false, "_", DATABASE, false);
+
+        assertEquals(SchemaType.SCHEMA, record.getSchemaType());
+    }
+
+    @Test
+    @DisplayName("Envelope schema with debeziumCDCEnabled=true routes to DebeziumRecordConvertor")
+    void optIn_enabled_routesToDebeziumConvertor() {
+        Schema row = rowSchema(SchemaBuilder.int32().name("id"));
+        Schema env = envelopeSchema(row);
+        Struct after = new Struct(row).put("id", 1);
+        Struct envelope = new Struct(env)
+                .put("op", "c").put("after", after)
+                .put("source", sourceStruct(sourceSchema(), 1L));
+
+        SinkRecord sinkRecord = sinkRecord(envelope);
+        Record record = Record.convert(sinkRecord, false, "_", DATABASE, true);
+
+        assertEquals(SchemaType.DEBEZIUM_CDC, record.getSchemaType());
+    }
+}

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterTest.java
@@ -340,7 +340,7 @@ public class ClickHouseWriterTest extends ClickHouseBase {
             Struct value = new Struct(oldSchema).put("id", -1).put("name", "XXXXXXXX");
             SinkRecord sr = new SinkRecord(topic, 0, null, null, oldSchema, value, 0,
                     System.currentTimeMillis(), TimestampType.CREATE_TIME);
-            Record record = Record.convert(sr, false, ".", chc.getDatabase());
+            Record record = Record.convert(sr, false, ".", chc.getDatabase(), false);
 
             // Verify the server actually returns code 131
             Exception thrown = assertThrows(Exception.class, () ->
@@ -368,7 +368,7 @@ public class ClickHouseWriterTest extends ClickHouseBase {
             Struct newValue = new Struct(newSchema).put("id", -1).put("name", "XXXXXXXX").put("extra", "XXXXXXXX");
             SinkRecord sr2 = new SinkRecord(topic, 0, null, null, newSchema, newValue, 1,
                     System.currentTimeMillis(), TimestampType.CREATE_TIME);
-            Record record2 = Record.convert(sr2, false, ".", chc.getDatabase());
+            Record record2 = Record.convert(sr2, false, ".", chc.getDatabase(), false);
             writer.doInsert(List.of(record2), new QueryIdentifier(topic, "code131-new-schema-" + System.nanoTime()));
 
             assertEquals(2, ClickHouseTestHelpers.countRows(chc, topic));

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterTest.java
@@ -263,7 +263,7 @@ public class ClickHouseWriterTest extends ClickHouseBase {
                 0,
                 System.currentTimeMillis(),
                 TimestampType.CREATE_TIME);
-        Record record = Record.convert(sinkRecord, false, ".", chc.getDatabase());
+        Record record = Record.convert(sinkRecord, false, ".", chc.getDatabase(), false);
 
         runWithWriter(props, (chw) -> {
             try {


### PR DESCRIPTION
## Summary

This PR adds first-class Debezium CDC envelope support to the connector, enabling it to work directly with Debezium-produced topics without requiring \`ExtractNewRecordState\` SMT.

### The problem

When consuming Debezium CDC topics, the connector currently treats the full envelope (\`before\`/\`after\`/\`op\`/\`source\`) as an opaque record. This breaks for CDC use cases where:
- The target table only has the actual row columns (not the envelope wrapper fields)
- Deletes and updates need routing logic (\`op=d\` → use \`before\`, \`op=u\` → use \`after\`)
- A \`_version\` column needs to be populated from the replication position for \`ReplacingMergeTree\` deduplication

### The solution

A new opt-in config flag \`debeziumCDCEnabled\` (default \`false\`) activates the \`DebeziumRecordConvertor\` when the SinkRecord value schema name ends with \`.Envelope\`. This is a safe, backward-compatible addition — existing integrations are unaffected unless the flag is explicitly enabled.

## Changes

### New file: \`DebeziumRecordConvertor.java\`
- Activated when \`debeziumCDCEnabled=true\` and schema name ends with \`.Envelope\`
- Routes by \`op\` field: \`c/r/u\` → \`after\` struct, \`d\` → \`before\` struct, \`t\` → skip
- Extracts replication position and injects as \`_version UInt128\`:
  - PostgreSQL: \`source.lsn\` (Long)
  - MySQL: \`source.gtid\` sequence number, fallback to \`source.pos\`
  - SQL Server: composite \`(commit_lsn << 64) | change_lsn\` packed into \`UInt128\` — \`commit_lsn\` is always present including during initial snapshot (\`op=r\`) where \`change_lsn\` is null; \`change_lsn\` acts as tie-breaker within the same commit
- Injects \`is_deleted UInt8\` (0 for upserts, 1 for deletes)
- Full Debezium type conversion: \`BYTES+Decimal→BigDecimal\`, \`INT64+Timestamp→Date\`, \`INT64+MicroTimestamp→Long microseconds\`, \`INT32+Date→java.sql.Date\`, \`BYTES→hex string\`
- All exceptions in version extraction are logged at DEBUG level

### \`ClickHouseSinkConfig.java\`
- Added \`debeziumCDCEnabled\` boolean config (default \`false\`)

### \`Record.java\`
- \`getConvertor()\` and \`convert()\` accept \`debeziumCDCEnabled\` flag
- Routes to \`DebeziumRecordConvertor\` only when flag is \`true\` AND schema name ends with \`.Envelope\`

### \`SchemaType.java\`
- Added \`DEBEZIUM_CDC\` enum value

### \`ClickHouseWriter.java\`
- Added \`INT128\`/\`UINT128\` support in \`doWriteColValue\` and \`doWritePrimitive\`
- Handles \`String\` input for \`UInt128\`/\`Int128\` columns (for \`decimal.handling.mode=string\`)

### Tests
- 22 unit tests in \`DebeziumRecordConvertorTest\` covering op routing, version extraction (PostgreSQL/MySQL/SQL Server streaming + snapshot), type conversions, null fields, and opt-in flag behavior

## Target table DDL

```sql
CREATE TABLE cdc_table (
    -- your row columns --
    _version  UInt128,
    is_deleted UInt8
) ENGINE = ReplacingMergeTree(_version, is_deleted)
ORDER BY (primary_key);
```

## Configuration

```json
{
  "debeziumCDCEnabled": "true"
}
```