### PR TITLE
Refresh table mapping when connector encounters `Code: 131. DB::Exception: Too large string size` + log column-level updates

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -933,23 +933,23 @@ public class ClickHouseWriter implements DBWriter {
                 doInsertRawBinaryV1(records, table, queryId, supportDefaults);
             }
         } catch (ServerException e) {
-            LOGGER.error("Error inserting records", e);
             if (UPDATE_TABLE_ERROR_CODES_V2.contains(e.getCode()) && retry) {
                 LOGGER.warn("Error code {}. Trying to update table mapping because ClickHouse table schema may have evolved.", e.getCode());
                 Table tableTmp = urgentTableUpdate(table);
                 doInsertRawBinaryV2(records, tableTmp, queryId, tableTmp.hasDefaults());
             } else {
+                LOGGER.error("Error inserting records", e);
                 throw e;
             }
         } catch (Exception e) {
             // Note: this part will be removed once V1 is deprecated
-            LOGGER.error("Error inserting records", e);
             Optional<String> updateTableException = UPDATE_TABLE_EXCEPTION_STR_TO_ERROR_CODE.keySet().stream().filter(code -> e.getMessage().contains(code)).findFirst();
             if (e.getMessage() != null && updateTableException.isPresent() && retry) {
                 LOGGER.warn("Error code {}. Trying to update table mapping because ClickHouse table schema may have evolved.", UPDATE_TABLE_EXCEPTION_STR_TO_ERROR_CODE.get(updateTableException.get()));
                 Table tableTmp = urgentTableUpdate(table);
                 doInsertRawBinaryV1(records, tableTmp, queryId, tableTmp.hasDefaults());
             } else {
+                LOGGER.error("Error inserting records", e);
                 throw e;
             }
         }

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -936,7 +936,7 @@ public class ClickHouseWriter implements DBWriter {
             if (UPDATE_TABLE_ERROR_CODES_V2.contains(e.getCode()) && retry) {
                 LOGGER.warn("Error code {}. Trying to update table mapping because ClickHouse table schema may have evolved.", e.getCode());
                 Table tableTmp = urgentTableUpdate(table);
-                doInsertRawBinaryV2(records, tableTmp, queryId, tableTmp.hasDefaults());
+                doInsertRawBinary(records, tableTmp, queryId, tableTmp.hasDefaults(), false);
             } else {
                 LOGGER.error("Error inserting records", e);
                 throw e;
@@ -947,7 +947,7 @@ public class ClickHouseWriter implements DBWriter {
             if (e.getMessage() != null && updateTableException.isPresent() && retry) {
                 LOGGER.warn("Error code {}. Trying to update table mapping because ClickHouse table schema may have evolved.", UPDATE_TABLE_EXCEPTION_STR_TO_ERROR_CODE.get(updateTableException.get()));
                 Table tableTmp = urgentTableUpdate(table);
-                doInsertRawBinaryV1(records, tableTmp, queryId, tableTmp.hasDefaults());
+                doInsertRawBinary(records, tableTmp, queryId, tableTmp.hasDefaults(), false);
             } else {
                 LOGGER.error("Error inserting records", e);
                 throw e;

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -177,26 +177,6 @@ public class ClickHouseWriter implements DBWriter {
         }
     }
 
-    private void logDiffBetweenNewAndOldTable(Table oldTable, Table newTable) {
-        if (oldTable == null) {
-            LOGGER.info("New table discovered: {}", newTable.getFullName());
-            return;
-        }
-
-        final List<Column> oldColumns = oldTable.getAllColumnsList();
-        final List<Column> newColumns = newTable.getAllColumnsList();
-
-        int oldPos = 0;
-        int newPos = 0;
-
-        // TODO: for claude
-
-        // column count
-        // column position
-        // column name
-        // column types
-    }
-
     @Override
     public void stop() {
         LOGGER.debug("Stopping ClickHouseWriter");
@@ -953,7 +933,7 @@ public class ClickHouseWriter implements DBWriter {
                 doInsertRawBinaryV1(records, table, queryId, supportDefaults);
             }
         } catch (ServerException e) {
-            LOGGER.error("Error inserting records can cause by schema changes", e);
+            LOGGER.error("Error inserting records", e);
             if (UPDATE_TABLE_ERROR_CODES_V2.contains(e.getCode()) && retry) {
                 LOGGER.warn("Error code {}. Trying to update table mapping because ClickHouse table schema may have evolved.", e.getCode());
                 Table tableTmp = urgentTableUpdate(table);
@@ -992,6 +972,7 @@ public class ClickHouseWriter implements DBWriter {
         if (tableTmp == null) {
             throw new IllegalStateException("Unable to refresh table mapping for " + table.getDatabase() + "." + table.getName());
         }
+        Utils.logDiffBetweenNewAndOldTable(table, tableTmp);
         return tableTmp;
     }
 

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -34,7 +34,6 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.errors.RetriableException;
-import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,6 +85,8 @@ public class ClickHouseWriter implements DBWriter {
     private final SinkTaskStatistics statistics;
 
     private ScheduledExecutorService scheduledExecutor;
+    private static final Set<Integer> UPDATE_TABLE_ERROR_CODES_V2 = Set.of(33, 131);
+    @Deprecated private static final Map<String, Integer> UPDATE_TABLE_EXCEPTION_STR_TO_ERROR_CODE = Map.of("ClickHouseException: Code: 33", 33, "ClickHouseException: Code: 131", 131);
 
     public ClickHouseWriter(SinkTaskStatistics statistics) {
         this.mapping = new ConcurrentHashMap<>();
@@ -174,6 +175,26 @@ public class ClickHouseWriter implements DBWriter {
         } finally {
             this.isUpdateMappingRunning.set(false);
         }
+    }
+
+    private void logDiffBetweenNewAndOldTable(Table oldTable, Table newTable) {
+        if (oldTable == null) {
+            LOGGER.info("New table discovered: {}", newTable.getFullName());
+            return;
+        }
+
+        final List<Column> oldColumns = oldTable.getAllColumnsList();
+        final List<Column> newColumns = newTable.getAllColumnsList();
+
+        int oldPos = 0;
+        int newPos = 0;
+
+        // TODO: for claude
+
+        // column count
+        // column position
+        // column name
+        // column types
     }
 
     @Override
@@ -933,20 +954,21 @@ public class ClickHouseWriter implements DBWriter {
             }
         } catch (ServerException e) {
             LOGGER.error("Error inserting records can cause by schema changes", e);
-            if (e.getCode() == 33 && retry == true) {
-                LOGGER.error("Error code 33: ClickHouse server error. Trying to update table mapping.");
+            if (UPDATE_TABLE_ERROR_CODES_V2.contains(e.getCode()) && retry) {
+                LOGGER.warn("Error code {}. Trying to update table mapping because ClickHouse table schema may have evolved.", e.getCode());
                 Table tableTmp = urgentTableUpdate(table);
-                doInsertRawBinary(records, tableTmp, queryId, tableTmp.hasDefaults(), false);
+                doInsertRawBinaryV2(records, tableTmp, queryId, tableTmp.hasDefaults());
             } else {
                 throw e;
             }
         } catch (Exception e) {
             // Note: this part will be removed once V1 is deprecated
             LOGGER.error("Error inserting records", e);
-            if (e.getMessage() != null && e.getMessage().contains("ClickHouseException: Code: 33") && retry) {
-                LOGGER.error("Error code 33: ClickHouse server error. Trying to update table mapping.");
+            Optional<String> updateTableException = UPDATE_TABLE_EXCEPTION_STR_TO_ERROR_CODE.keySet().stream().filter(code -> e.getMessage().contains(code)).findFirst();
+            if (e.getMessage() != null && updateTableException.isPresent() && retry) {
+                LOGGER.warn("Error code {}. Trying to update table mapping because ClickHouse table schema may have evolved.", UPDATE_TABLE_EXCEPTION_STR_TO_ERROR_CODE.get(updateTableException.get()));
                 Table tableTmp = urgentTableUpdate(table);
-                doInsertRawBinary(records, tableTmp, queryId, tableTmp.hasDefaults(), false);
+                doInsertRawBinaryV1(records, tableTmp, queryId, tableTmp.hasDefaults());
             } else {
                 throw e;
             }
@@ -956,10 +978,10 @@ public class ClickHouseWriter implements DBWriter {
     private Table urgentTableUpdate(Table table) {
         Table tableTmp;
         if (updateMapping(table.getDatabase())) {
-            LOGGER.debug("urgentTableUpdate({}): update complete", table.getName());
+            LOGGER.warn("urgentTableUpdate({}): update complete", table.getName());
             tableTmp = getTable(table.getDatabase(), table.getName());
         } else {
-            LOGGER.debug("urgentTableUpdate({}): update still running", table.getName());
+            LOGGER.warn("urgentTableUpdate({}): update still running", table.getName());
             tableTmp = chc.describeTable(table.getDatabase(), table.getCleanName());
             if (tableTmp == null) {
                 LOGGER.error("Failed to describe table {}.{} via ClickHouseHelperClient.describeTable(); falling back to existing mapping.",

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/mapping/Table.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/mapping/Table.java
@@ -29,6 +29,7 @@ public class Table {
 
     private final List<Column> rootColumnsList;
     private final Map<String, Column> rootColumnsMap;
+    @Getter
     private final List<Column> allColumnsList;
     private final Map<String, Column> allColumnsMap;
 

--- a/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
+++ b/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
@@ -225,11 +225,12 @@ public class Utils {
     }
 
     public static void logDiffBetweenNewAndOldTable(Table oldTable, Table newTable) {
-        if (oldTable == null) {
-            LOGGER.info("New table discovered: {}", newTable.getFullName());
+        if (newTable == null) {
             return;
         }
-        if (newTable == null) {
+
+        if (oldTable == null) {
+            LOGGER.info("New table discovered: {}", newTable.getFullName());
             return;
         }
 

--- a/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
+++ b/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
@@ -2,6 +2,8 @@ package com.clickhouse.kafka.connect.util;
 
 import com.clickhouse.client.ClickHouseException;
 import com.clickhouse.kafka.connect.sink.data.Record;
+import com.clickhouse.kafka.connect.sink.db.mapping.Column;
+import com.clickhouse.kafka.connect.sink.db.mapping.Table;
 import com.clickhouse.kafka.connect.sink.dlq.ErrorReporter;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.errors.RetriableException;
@@ -220,5 +222,68 @@ public class Utils {
         result.add(sb.toString().trim());
 
         return result;
+    }
+
+    public static void logDiffBetweenNewAndOldTable(Table oldTable, Table newTable) {
+        if (oldTable == null) {
+            LOGGER.info("New table discovered: {}", newTable.getFullName());
+            return;
+        }
+        if (newTable == null) {
+            return;
+        }
+
+        List<String> diffs = computeColumnDiff(oldTable, newTable);
+        if (diffs.isEmpty()) {
+            return;
+        }
+
+        for (String diff : diffs) {
+            LOGGER.warn("Schema for table {} has changed: {}", newTable.getFullName(), diff);
+        }
+    }
+
+    public static List<String> computeColumnDiff(Table oldTable, Table newTable) {
+        List<Column> oldColumns = oldTable.getAllColumnsList();
+        List<Column> newColumns = newTable.getAllColumnsList();
+        int oldSize = oldColumns.size();
+        int newSize = newColumns.size();
+        int commonSize = Math.min(oldSize, newSize);
+
+        List<String> diffs = new ArrayList<>();
+
+        for (int i = 0; i < commonSize; i++) {
+            Column oldCol = oldColumns.get(i);
+            Column newCol = newColumns.get(i);
+            if (!columnsMatch(oldCol, newCol)) {
+                diffs.add(String.format("Column diff at position %d: old=[%s], new=[%s]",
+                        i, describeColumn(oldCol), describeColumn(newCol)));
+            }
+        }
+
+        for (int i = oldSize; i < newSize; i++) {
+            diffs.add(String.format("Column added at position %d: [%s]", i, describeColumn(newColumns.get(i))));
+        }
+
+        for (int i = newSize; i < oldSize; i++) {
+            diffs.add(String.format("Column removed at position %d: [%s]", i, describeColumn(oldColumns.get(i))));
+        }
+
+        return diffs;
+    }
+
+    // Limitation: two columns can match on (name, Type, nullable, precision, scale) but still differ in arrayType,
+    // mapValueType, tupleFields, enumValues, etc. TODO: extend this if needed in the future.
+    public static boolean columnsMatch(Column a, Column b) {
+        return a.getName().equals(b.getName())
+                && a.getType() == b.getType()
+                && a.isNullable() == b.isNullable()
+                && a.getPrecision() == b.getPrecision()
+                && a.getScale() == b.getScale();
+    }
+
+    public static String describeColumn(Column col) {
+        return String.format("name=%s, type=%s, nullable=%s, precision=%d, scale=%d",
+                col.getName(), col.getType(), col.isNullable(), col.getPrecision(), col.getScale());
     }
 }

--- a/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
+++ b/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
@@ -236,6 +236,7 @@ public class Utils {
 
         List<String> diffs = computeColumnDiff(oldTable, newTable);
         if (diffs.isEmpty()) {
+            LOGGER.info("No schema changes detected for table {}",  newTable.getFullName());
             return;
         }
 
@@ -276,6 +277,9 @@ public class Utils {
     // Limitation: two columns can match on (name, Type, nullable, precision, scale) but still differ in arrayType,
     // mapValueType, tupleFields, enumValues, etc. TODO: extend this if needed in the future.
     public static boolean columnsMatch(Column a, Column b) {
+        if (a == null || b == null) {
+            return false;
+        }
         return a.getName().equals(b.getName())
                 && a.getType() == b.getType()
                 && a.isNullable() == b.isNullable()

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterTest.java
@@ -4,6 +4,7 @@ import com.clickhouse.data.ClickHouseDataUpdater;
 import com.clickhouse.data.ClickHouseInputStream;
 import com.clickhouse.data.ClickHouseOutputStream;
 import com.clickhouse.data.ClickHousePipedOutputStream;
+import com.clickhouse.kafka.connect.ClickHouseSinkConnector;
 import com.clickhouse.kafka.connect.sink.ClickHouseBase;
 import com.clickhouse.kafka.connect.sink.ClickHouseSinkConfig;
 import com.clickhouse.kafka.connect.sink.data.Record;
@@ -23,9 +24,12 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.json.JSONObject;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,12 +42,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import static com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers.newDescriptor;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(FromVersionConditionExtension.class)
 public class ClickHouseWriterTest extends ClickHouseBase {
@@ -284,5 +283,108 @@ public class ClickHouseWriterTest extends ClickHouseBase {
         assertEquals(1, tuple.getInt("istextanswered"));
 
         ClickHouseTestHelpers.dropTable(chc, topic);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"V1", "V2"})
+    public void testSchemaRefreshedAfterCode131(String clientVersion) throws Exception {
+        Map<String, String> props = getBaseProps();
+        props.put(ClickHouseSinkConnector.CLIENT_VERSION, clientVersion);
+
+        ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
+        String topic = createTopicName("code131_refresh_" + clientVersion);
+        String fullyQualifiedTableName = Utils.escapeTableName(chc.getDatabase(), topic);
+
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        new CreateTableStatement()
+                .tableName(topic)
+                .column("id", "Int32")
+                .column("name", "String")
+                .engine("MergeTree")
+                .orderByColumn("id")
+                .execute(chc);
+
+        ClickHouseWriter writer = new ClickHouseWriter(new SinkTaskStatistics(0));
+        assertTrue(writer.start(new ClickHouseSinkConfig(props)));
+
+        try {
+            Table cachedBefore = writer.getMapping().get(fullyQualifiedTableName);
+            assertNotNull(cachedBefore);
+            assertEquals(2, cachedBefore.getRootColumnsList().size());
+            assertFalse(cachedBefore.getRootColumnsMap().containsKey("extra"));
+
+            // NOTE: there may be a better way to reproduce code 131 - below is one way implemented with AI assistance.
+            //
+            // The connector serializes RowBinary in the cached column order [id Int32, name String]:
+            //   id = -1            -> little-endian bytes 0xFF 0xFF 0xFF 0xFF (4 varint-continuation bytes)
+            //   name = "XXXXXXXX"  -> single varint length byte 0x08, then 8 ASCII 'X's
+            // First 5 bytes on the wire: [0xFF, 0xFF, 0xFF, 0xFF, 0x08].
+            //
+            // ClickHouse parses in the new column order [extra String, id Int32, name String], so it
+            // reads those same 5 bytes as the varint length prefix of `extra`:
+            //   value = 0x7F | (0x7F << 7) | (0x7F << 14) | (0x7F << 21) | (0x08 << 28) = 2,415,919,103
+            // which exceeds DBMS_MAX_STRING_SIZE (1 GiB = 1,073,741,824) -> server throws
+            // TOO_LARGE_STRING_SIZE (131).
+            //
+            // ClickHouseWriter.doInsertRawBinary catches the exception, calls urgentTableUpdate
+            // (which refreshes the in-memory Table schema to [extra, id, name]), and retries.
+
+            // migrate schema backwards compatibly while writer is running
+            ClickHouseTestHelpers.runQuery(chc, "ALTER TABLE `" + topic + "` ADD COLUMN extra String DEFAULT '' FIRST");
+
+            Schema oldSchema = SchemaBuilder.struct()
+                    .field("id", Schema.INT32_SCHEMA)
+                    .field("name", Schema.STRING_SCHEMA)
+                    .build();
+            Struct value = new Struct(oldSchema).put("id", -1).put("name", "XXXXXXXX");
+            SinkRecord sr = new SinkRecord(topic, 0, null, null, oldSchema, value, 0,
+                    System.currentTimeMillis(), TimestampType.CREATE_TIME);
+            Record record = Record.convert(sr, false, ".", chc.getDatabase());
+
+            // Verify the server actually returns code 131
+            Exception thrown = assertThrows(Exception.class, () ->
+                    writer.doInsertRawBinary(List.of(record), cachedBefore,
+                            new QueryIdentifier(topic, "code131-direct-" + System.nanoTime()),
+                            cachedBefore.hasDefaults(), false));
+            assertTrue(exceptionChainContains(thrown, "Code: 131"),
+                    "Expected ClickHouse error Code: 131 in exception chain, got: " + thrown);
+
+            Assertions.assertDoesNotThrow(() -> writer.doInsert(List.of(record), new QueryIdentifier(topic, "code131-" + System.nanoTime())));
+
+            Table cachedAfter = writer.getMapping().get(fullyQualifiedTableName);
+            assertNotNull(cachedAfter);
+            assertEquals(3, cachedAfter.getRootColumnsList().size());
+            assertTrue(cachedAfter.getRootColumnsMap().containsKey("extra"));
+
+            assertEquals(1, ClickHouseTestHelpers.countRows(chc, topic));
+
+            // Verify the refreshed mapping by inserting record with the new schema
+            Schema newSchema = SchemaBuilder.struct()
+                    .field("id", Schema.INT32_SCHEMA)
+                    .field("name", Schema.STRING_SCHEMA)
+                    .field("extra", Schema.STRING_SCHEMA)
+                    .build();
+            Struct newValue = new Struct(newSchema).put("id", -1).put("name", "XXXXXXXX").put("extra", "XXXXXXXX");
+            SinkRecord sr2 = new SinkRecord(topic, 0, null, null, newSchema, newValue, 1,
+                    System.currentTimeMillis(), TimestampType.CREATE_TIME);
+            Record record2 = Record.convert(sr2, false, ".", chc.getDatabase());
+            writer.doInsert(List.of(record2), new QueryIdentifier(topic, "code131-new-schema-" + System.nanoTime()));
+
+            assertEquals(2, ClickHouseTestHelpers.countRows(chc, topic));
+            assertEquals(3, writer.getMapping().get(fullyQualifiedTableName).getRootColumnsList().size());
+        } finally {
+            writer.stop();
+            ClickHouseTestHelpers.dropTable(chc, topic);
+        }
+    }
+
+    private static boolean exceptionChainContains(Throwable t, String target) {
+        while (t != null) {
+            if (t.getMessage() != null && t.getMessage().contains(target)) {
+                return true;
+            }
+            t = t.getCause();
+        }
+        return false;
     }
 }

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterTest.java
@@ -313,8 +313,7 @@ public class ClickHouseWriterTest extends ClickHouseBase {
             assertEquals(2, cachedBefore.getRootColumnsList().size());
             assertFalse(cachedBefore.getRootColumnsMap().containsKey("extra"));
 
-            // NOTE: there may be a better way to reproduce code 131 - below is one way implemented with AI assistance.
-            //
+            // Code 131 reproduction explanation:
             // The connector serializes RowBinary in the cached column order [id Int32, name String]:
             //   id = -1            -> little-endian bytes 0xFF 0xFF 0xFF 0xFF (4 varint-continuation bytes)
             //   name = "XXXXXXXX"  -> single varint length byte 0x08, then 8 ASCII 'X's

--- a/src/test/java/com/clickhouse/kafka/connect/sink/util/UtilsTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/util/UtilsTest.java
@@ -1,6 +1,8 @@
 package com.clickhouse.kafka.connect.sink.util;
 
 import com.clickhouse.client.ClickHouseException;
+import com.clickhouse.kafka.connect.sink.db.mapping.Column;
+import com.clickhouse.kafka.connect.sink.db.mapping.Table;
 import com.clickhouse.kafka.connect.util.Utils;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.junit.jupiter.api.DisplayName;
@@ -8,7 +10,10 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
+import static com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers.newDescriptor;
+import static com.clickhouse.kafka.connect.util.Utils.computeColumnDiff;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class UtilsTest {
@@ -46,5 +51,125 @@ public class UtilsTest {
             Exception timeout = new IOException("Write timed out after 30000 ms");
             Utils.handleException(timeout, false, new ArrayList<>());
         });
+    }
+
+    private static Table tableWith(String tableName, String[]... colSpecs) {
+        Table table = new Table("default", tableName);
+        for (String[] spec : colSpecs) {
+            table.addColumn(Column.extractColumn(newDescriptor(spec[0], spec[1])));
+        }
+        return table;
+    }
+
+    @Test
+    public void identicalTablesProduceNoDiffTest() {
+        Table oldTable = tableWith("t", new String[]{"a", "Int32"}, new String[]{"b", "String"});
+        Table newTable = tableWith("t", new String[]{"a", "Int32"}, new String[]{"b", "String"});
+
+        List<String> diffs = computeColumnDiff(oldTable, newTable);
+
+        assertTrue(diffs.isEmpty(), "Expected no diffs, got: " + diffs);
+    }
+
+    @Test
+    public void detectTypeChangeAtPositionTest() {
+        Table oldTable = tableWith("t", new String[]{"a", "Int32"}, new String[]{"b", "String"});
+        Table newTable = tableWith("t", new String[]{"a", "Int32"}, new String[]{"b", "Int64"});
+
+        List<String> diffs = computeColumnDiff(oldTable, newTable);
+
+        assertEquals(1, diffs.size(), "Expected exactly one diff, got: " + diffs);
+        String diff = diffs.get(0);
+        assertTrue(diff.contains("position 1"), "Diff should mention position 1: " + diff);
+        assertTrue(diff.contains("STRING"), "Diff should mention old STRING type: " + diff);
+        assertTrue(diff.contains("INT64"), "Diff should mention new INT64 type: " + diff);
+    }
+
+    @Test
+    public void detectColumnAddedAtEndTest() {
+        Table oldTable = tableWith("t", new String[]{"a", "Int32"});
+        Table newTable = tableWith("t", new String[]{"a", "Int32"}, new String[]{"new_col", "String"});
+
+        List<String> diffs = computeColumnDiff(oldTable, newTable);
+
+        assertEquals(1, diffs.size(), "Expected exactly one diff, got: " + diffs);
+        String diff = diffs.get(0);
+        assertTrue(diff.contains("Column added at position 1"), "Diff should describe addition: " + diff);
+        assertTrue(diff.contains("new_col"), "Diff should mention the new column name: " + diff);
+    }
+
+    @Test
+    public void detectColumnRemovedFromEndTest() {
+        Table oldTable = tableWith("t", new String[]{"a", "Int32"}, new String[]{"gone", "String"});
+        Table newTable = tableWith("t", new String[]{"a", "Int32"});
+
+        List<String> diffs = computeColumnDiff(oldTable, newTable);
+
+        assertEquals(1, diffs.size(), "Expected exactly one diff, got: " + diffs);
+        String diff = diffs.get(0);
+        assertTrue(diff.contains("Column removed at position 1"), "Diff should describe removal: " + diff);
+        assertTrue(diff.contains("gone"), "Diff should mention the removed column name: " + diff);
+    }
+
+    @Test
+    public void detectNullableChangeTest() {
+        Table oldTable = tableWith("t", new String[]{"a", "Int32"});
+        Table newTable = tableWith("t", new String[]{"a", "Nullable(Int32)"});
+
+        List<String> diffs = computeColumnDiff(oldTable, newTable);
+
+        assertEquals(1, diffs.size(), "Expected exactly one diff, got: " + diffs);
+        String diff = diffs.get(0);
+        assertTrue(diff.contains("position 0"), "Diff should mention position 0: " + diff);
+        assertTrue(diff.contains("nullable=false") && diff.contains("nullable=true"),
+                "Diff should mention nullable transition: " + diff);
+    }
+
+    @Test
+    public void detectPrecisionAndScaleChangeTest() {
+        Table oldTable = tableWith("t", new String[]{"d", "Decimal(5, 2)"});
+        Table newTable = tableWith("t", new String[]{"d", "Decimal(7, 3)"});
+
+        List<String> diffs = computeColumnDiff(oldTable, newTable);
+
+        assertEquals(1, diffs.size(), "Expected exactly one diff, got: " + diffs);
+        String diff = diffs.get(0);
+        assertTrue(diff.contains("precision=5") && diff.contains("precision=7"),
+                "Diff should mention precision transition: " + diff);
+        assertTrue(diff.contains("scale=2") && diff.contains("scale=3"),
+                "Diff should mention scale transition: " + diff);
+    }
+
+    @Test
+    public void detectMultipleChangesAcrossPositionsTest() {
+        Table oldTable = tableWith("t",
+                new String[]{"a", "Int32"},
+                new String[]{"b", "String"},
+                new String[]{"c", "Float64"});
+        Table newTable = tableWith("t",
+                new String[]{"a", "Int64"},               // pos 0: type change Int32 -> Int64
+                new String[]{"renamed_b", "String"},      // pos 1: name change b -> renamed_b
+                new String[]{"c", "Float64"},             // pos 2: unchanged
+                new String[]{"new_col", "UInt8"});        // pos 3: addition
+
+        List<String> diffs = computeColumnDiff(oldTable, newTable);
+
+        assertEquals(3, diffs.size(), "Expected exactly three diffs, got: " + diffs);
+
+        String posZeroDiff = diffs.get(0);
+        assertTrue(posZeroDiff.contains("position 0"), "First diff should mention position 0: " + posZeroDiff);
+        assertTrue(posZeroDiff.contains("INT32") && posZeroDiff.contains("INT64"),
+                "First diff should mention INT32->INT64: " + posZeroDiff);
+
+        String posOneDiff = diffs.get(1);
+        assertTrue(posOneDiff.contains("position 1"), "Second diff should mention position 1: " + posOneDiff);
+        assertTrue(posOneDiff.contains("name=b") && posOneDiff.contains("name=renamed_b"),
+                "Second diff should mention name transition: " + posOneDiff);
+
+        String posThreeDiff = diffs.get(2);
+        assertTrue(posThreeDiff.contains("Column added at position 3"),
+                "Third diff should describe addition: " + posThreeDiff);
+        assertTrue(posThreeDiff.contains("new_col"),
+                "Third diff should mention the new column name: " + posThreeDiff);
     }
 }


### PR DESCRIPTION
## Summary

When the downstream CH table schema is migrated, a running connector may hit the runtime exception `Code: 131. DB::Exception: Too large string size`. Currently, the connector interprets this as a non-retryable exception and dumps the affected record(s) to the DLQ (if one is configured). Instead, it should try to update the table mapping for the given downstream table and retry inserting the row. If the retry fails, the row is likely malformed and only then should it be written to the DLQ.

Also, log column changes in `urgentTableUpdate`, if any.

closes: https://github.com/ClickHouse/clickhouse-kafka-connect/issues/751

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG