### PR TITLE
Fix test error introduced in PR #740

### DIFF
--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterTest.java
@@ -331,7 +331,7 @@ public class ClickHouseWriterTest extends ClickHouseBase {
             // (which refreshes the in-memory Table schema to [extra, id, name]), and retries.
 
             // migrate schema backwards compatibly while writer is running
-            ClickHouseTestHelpers.executeQueryIgnoreResult(chc, "ALTER TABLE `" + topic + "` ADD COLUMN extra String DEFAULT '' FIRST");
+            ClickHouseTestHelpers.executeQueryIgnoreResult(chc, String.format("ALTER TABLE `" + topic + "`%s ADD COLUMN extra String DEFAULT '' FIRST", ClickHouseTestHelpers.getClusterClauseOrEmpty()));
 
             Schema oldSchema = SchemaBuilder.struct()
                     .field("id", Schema.INT32_SCHEMA)

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterTest.java
@@ -331,7 +331,7 @@ public class ClickHouseWriterTest extends ClickHouseBase {
             // (which refreshes the in-memory Table schema to [extra, id, name]), and retries.
 
             // migrate schema backwards compatibly while writer is running
-            ClickHouseTestHelpers.runQuery(chc, "ALTER TABLE `" + topic + "` ADD COLUMN extra String DEFAULT '' FIRST");
+            ClickHouseTestHelpers.executeQueryIgnoreResult(chc, "ALTER TABLE `" + topic + "` ADD COLUMN extra String DEFAULT '' FIRST");
 
             Schema oldSchema = SchemaBuilder.struct()
                     .field("id", Schema.INT32_SCHEMA)


### PR DESCRIPTION
## Summary
PR https://github.com/ClickHouse/clickhouse-kafka-connect/pull/740 introduced a test error that is breaking CI because the author (me) did not detect a merge conflict before hitting merge. This PR fixes it. 🙇

closes: https://github.com/ClickHouse/clickhouse-kafka-connect/issues/757