### PR TITLE
Remove redundant logging

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/mapping/Table.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/mapping/Table.java
@@ -129,8 +129,7 @@ public class Table {
                     case VARIANT:
                         return;
                     default:
-                        LOGGER.warn("Unhandled complex type '{}' as a child of an array or unexpected subcolumn (parent name: '{}', child name: '{}').",
-                                parentArrayType.getType(), parent.getName(), child.getName() );
+                        // nothing to do here. Only complex types require update of parent record with element types.
                         return;
                 }
             case MAP:
@@ -188,10 +187,11 @@ public class Table {
                 parent.getTupleFields().add(child);
                 return;
             default:
+                // Log for troubleshooting what types were reached this point. Most of them should be ignored.
                 if (child.getName().endsWith(".null")) {
                     LOGGER.debug("Ignoring complex column: {}", child);
                 } else {
-                    LOGGER.warn("Unsupported complex parent type: {} (parent name: '{}')",
+                    LOGGER.debug("Ignoring complex parent type: {} (parent name: '{}')",
                             parent.getType(), parent.getName());
                 }
         }


### PR DESCRIPTION
## Summary
Today's `Table` code requests table description in the way each field is described by several rows. In this case information about Array's element type is in another row then array column definition and logic need to update it once base element type found. This triggers warning about some other types that not require processing. Code should be refactored. 
This PR removes warning that doesn't indicate a problem by creates a noise. 

No tests were updated because changes are seen only in log. 

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
