### PR TITLE
Updated release wf to run gradle directly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,11 +25,11 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
-      - name: Setup and execute Gradle 'createConfluentArchive' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: createConfluentArchive
-          gradle-version: '7.4.2'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Execute 'createConfluentArchive' task
+        run: ./gradlew createConfluentArchive
       - name: release
         uses: actions/create-release@v1
         id: create_release


### PR DESCRIPTION
## Summary
Fixes running gradle in release Wf

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
