### PR TITLE
[tests] Update ClickHouse version matrix in tests. 

### DIFF
--- a/.github/actions/use-clickhouse-java/action.yaml
+++ b/.github/actions/use-clickhouse-java/action.yaml
@@ -1,0 +1,37 @@
+name: Use ClickHouse Java client override
+description: >-
+  Points the build at a specific ClickHouse Java client by overriding the version in the Gradle
+  version catalog (gradle/libs.versions.toml). When the client was built from a branch it is first
+  installed into the local Maven repository so Gradle can resolve it.
+inputs:
+  version:
+    description: 'ClickHouse Java client version to use. Empty means use the catalog default.'
+    required: false
+    default: ''
+  built:
+    description: 'Whether a branch build was uploaded by the setup job and must be installed locally.'
+    required: false
+    default: 'false'
+runs:
+  using: composite
+  steps:
+    - name: Download built ClickHouse Java client
+      if: inputs.built == 'true'
+      uses: actions/download-artifact@v4
+      with:
+        name: clickhouse-java-m2
+        path: clickhouse-java-m2
+    - name: Install built client into local Maven repository
+      if: inputs.built == 'true'
+      shell: bash
+      run: |
+        mkdir -p "$HOME/.m2/repository/com"
+        cp -r clickhouse-java-m2/clickhouse "$HOME/.m2/repository/com/"
+    - name: Override ClickHouse Java client version in version catalog
+      if: inputs.version != ''
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        sed -i -E "s|^clickHouseDriver = \".*\"|clickHouseDriver = \"${VERSION}\"|" gradle/libs.versions.toml
+        grep '^clickHouseDriver' gradle/libs.versions.toml

--- a/.github/workflows/test-head.yaml
+++ b/.github/workflows/test-head.yaml
@@ -10,24 +10,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        clickhouse: [ "head" ]
-    name: ClickHouse ${{ matrix.clickhouse }} tests
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'adopt'
-          architecture: x64
-      - name: Setup and execute Gradle 'test' task
-        uses: gradle/gradle-build-action@v2
-        env:
-          CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
-        with:
-          arguments: test
+  # Run the CI test suite against the head (nightly) build of the ClickHouse server.
+  clickhouse-head:
+    name: ClickHouse head
+    uses: ./.github/workflows/tests.yaml
+    with:
+      clickhouse_version: head
+    secrets: inherit
 
+  # Build the head of clickhouse-java from source and run the CI test suite against it.
+  clickhouse-java-head:
+    name: clickhouse-java head
+    uses: ./.github/workflows/tests.yaml
+    with:
+      clickhouse_version: latest
+      clickhouse_java: main
+      run_cloud_tests: true
+    secrets: inherit

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
         client: ["V1", "V2"]
         # note: LTS releases and latest stable builds can be found here: https://github.com/ClickHouse/ClickHouse/pulls?q=is%3Aopen+is%3Apr+label%3Arelease
         clickhouse: ["24.8", "25.2", "25.8", "26.3", "latest"]
-        java: ["11", "17", "21", "25"]
+        java: ["17", "21", "25"]
     name: ClickHouse Standalone ${{ matrix.clickhouse }} Client version ${{ matrix.client }} tests
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3
       - name: Run Tests
@@ -44,7 +45,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: result standalone_${{ matrix.client }}_${{ matrix.clickhouse }}_runid_${{ github.run_id }}
+          name: result standalone_${{ matrix.client }}_${{ matrix.clickhouse }}_jdk_${{ matrix.java }}_runid_${{ github.run_id }}
           path: |
             **/build/reports/tests
           retention-days: 5

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,6 @@ on:
       - 'LICENSE'
       - 'docs/**'
 
-# note: LTS releases and latest stable builds can be found here: https://github.com/ClickHouse/ClickHouse/pulls?q=is%3Aopen+is%3Apr+label%3Arelease
 jobs:
   standalone-tests:
     runs-on: ubuntu-latest
@@ -24,15 +23,16 @@ jobs:
       fail-fast: false
       matrix:
         client: ["V1", "V2"]
-        clickhouse: ["25.3", "25.8", "25.10", "25.11", "25.12", "latest"]
+        # note: LTS releases and latest stable builds can be found here: https://github.com/ClickHouse/ClickHouse/pulls?q=is%3Aopen+is%3Apr+label%3Arelease
+        clickhouse: ["24.8", "25.2", "25.8", "26.3", "latest"]
+        java: ["11", "17", "21", "25"]
     name: ClickHouse Standalone ${{ matrix.clickhouse }} Client version ${{ matrix.client }} tests
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3
       - name: Run Tests
@@ -100,7 +100,7 @@ jobs:
       fail-fast: false
       matrix:
         client: [ "V1", "V2" ]
-        clickhouse: [ "25.3", "25.8", "25.10", "25.11", "25.12", "latest" ]
+        clickhouse: ["24.8", "25.2", "25.8", "26.3", "latest"]
         cluster_name: [ "three_shards_one_replica_each", "one_shard_three_replicas" ]
     name: ClickHouse Cluster ${{ matrix.cluster_name }} ${{ matrix.clickhouse }} Client version ${{ matrix.client }} tests
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,36 @@ name: ClickHouse Kafka Connect Tests CI
 
 on:
   workflow_dispatch:
+    inputs:
+      clickhouse_version:
+        description: 'ClickHouse server version to test against (e.g. latest or head). Leave empty for the default matrix.'
+        required: false
+        type: string
+        default: ''
+      clickhouse_java:
+        description: 'ClickHouse Java client to test against: a published artifact version (e.g. 0.9.8) or a clickhouse-java branch to build from (e.g. main). Leave empty to use the version from the catalog.'
+        required: false
+        type: string
+        default: ''
+      run_cloud_tests:
+        description: 'Also run the ClickHouse Cloud tests (always run on PR/main CI regardless of this flag).'
+        required: false
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      clickhouse_version:
+        required: false
+        type: string
+        default: ''
+      clickhouse_java:
+        required: false
+        type: string
+        default: ''
+      run_cloud_tests:
+        required: false
+        type: boolean
+        default: false
   push:
     branches:
       - main
@@ -16,7 +46,73 @@ on:
       - 'docs/**'
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      clickhouse_versions: ${{ steps.config.outputs.clickhouse_versions }}
+      clickhouse_java_version: ${{ steps.resolve.outputs.version }}
+      clickhouse_java_built: ${{ steps.resolve.outputs.built }}
+    steps:
+      - name: Resolve configuration
+        id: config
+        run: |
+          if [[ -n "${{ inputs.clickhouse_version }}" ]]; then
+            echo 'clickhouse_versions=["${{ inputs.clickhouse_version }}"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'clickhouse_versions=["24.8","25.2","25.8","26.3","latest"]' >> "$GITHUB_OUTPUT"
+          fi
+          # A numeric value is a published artifact version; anything else is a branch to build.
+          JAVA='${{ inputs.clickhouse_java }}'
+          if [[ "$JAVA" =~ ^[0-9] ]]; then
+            echo "artifact_version=$JAVA" >> "$GITHUB_OUTPUT"
+            echo "build_ref=" >> "$GITHUB_OUTPUT"
+          else
+            echo "artifact_version=" >> "$GITHUB_OUTPUT"
+            echo "build_ref=$JAVA" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Set up JDK 17
+        if: steps.config.outputs.build_ref != ''
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Build ClickHouse Java client from '${{ steps.config.outputs.build_ref }}'
+        if: steps.config.outputs.build_ref != ''
+        run: |
+          set -euo pipefail
+          git clone --depth 1 --branch "${{ steps.config.outputs.build_ref }}" \
+            https://github.com/ClickHouse/clickhouse-java.git "$RUNNER_TEMP/clickhouse-java"
+          cd "$RUNNER_TEMP/clickhouse-java"
+          mvn -B -q -DskipTests -Dmaven.javadoc.skip=true -Dgpg.skip=true clean install
+          VERSION="$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)"
+          if [[ "$VERSION" == *'${'* || -z "$VERSION" ]]; then
+            VERSION="$(mvn -q -DforceStdout help:evaluate -Dexpression=revision)"
+          fi
+          echo "Built clickhouse-java version: $VERSION"
+          echo "BUILT_VERSION=$VERSION" >> "$GITHUB_ENV"
+          mkdir -p "$GITHUB_WORKSPACE/clickhouse-java-m2"
+          cp -r "$HOME/.m2/repository/com/clickhouse" "$GITHUB_WORKSPACE/clickhouse-java-m2/"
+      - name: Upload built ClickHouse Java client
+        if: steps.config.outputs.build_ref != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: clickhouse-java-m2
+          path: clickhouse-java-m2
+          retention-days: 1
+      - name: Resolve ClickHouse Java client version
+        id: resolve
+        run: |
+          if [[ -n "${BUILT_VERSION:-}" ]]; then
+            echo "version=$BUILT_VERSION" >> "$GITHUB_OUTPUT"
+            echo "built=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${{ steps.config.outputs.artifact_version }}" >> "$GITHUB_OUTPUT"
+            echo "built=false" >> "$GITHUB_OUTPUT"
+          fi
+
   standalone-tests:
+    needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -24,7 +120,7 @@ jobs:
       matrix:
         client: ["V1", "V2"]
         # note: LTS releases and latest stable builds can be found here: https://github.com/ClickHouse/ClickHouse/pulls?q=is%3Aopen+is%3Apr+label%3Arelease
-        clickhouse: ["24.8", "25.2", "25.8", "26.3", "latest"]
+        clickhouse: ${{ fromJSON(needs.setup.outputs.clickhouse_versions) }}
         java: ["17", "21", "25"]
     name: ClickHouse Standalone ${{ matrix.clickhouse }} Client version ${{ matrix.client }} tests
     steps:
@@ -36,6 +132,11 @@ jobs:
           distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3
+      - name: Use ClickHouse Java client override
+        uses: ./.github/actions/use-clickhouse-java
+        with:
+          version: ${{ needs.setup.outputs.clickhouse_java_version }}
+          built: ${{ needs.setup.outputs.clickhouse_java_built }}
       - name: Run Tests
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
@@ -50,6 +151,9 @@ jobs:
             **/build/reports/tests
           retention-days: 5
   cloud-tests:
+    needs: setup
+    # Always run on regular PR/main CI; on manual/reusable runs only when opted in.
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || inputs.run_cloud_tests
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -78,6 +182,12 @@ jobs:
           distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3
+      - name: Use ClickHouse Java client override
+        if: env.SKIP_STEP != 'true'
+        uses: ./.github/actions/use-clickhouse-java
+        with:
+          version: ${{ needs.setup.outputs.clickhouse_java_version }}
+          built: ${{ needs.setup.outputs.clickhouse_java_built }}
       - name: Run Tests
         if: env.SKIP_STEP != 'true'
         env:
@@ -95,13 +205,14 @@ jobs:
             **/build/reports/tests
           retention-days: 5
   cluster-tests:
+    needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         client: [ "V1", "V2" ]
-        clickhouse: ["24.8", "25.2", "25.8", "26.3", "latest"]
+        clickhouse: ${{ fromJSON(needs.setup.outputs.clickhouse_versions) }}
         cluster_name: [ "three_shards_one_replica_each", "one_shard_three_replicas" ]
     name: ClickHouse Cluster ${{ matrix.cluster_name }} ${{ matrix.clickhouse }} Client version ${{ matrix.client }} tests
     steps:
@@ -113,6 +224,11 @@ jobs:
           distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3
+      - name: Use ClickHouse Java client override
+        uses: ./.github/actions/use-clickhouse-java
+        with:
+          version: ${{ needs.setup.outputs.clickhouse_java_version }}
+          built: ${{ needs.setup.outputs.clickhouse_java_built }}
       - name: Run Tests
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaProxyTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaProxyTest.java
@@ -1,6 +1,7 @@
 package com.clickhouse.kafka.connect.sink;
 
 import com.clickhouse.client.ClickHouseProtocol;
+import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
 import com.clickhouse.kafka.connect.sink.helper.*;
 import com.clickhouse.kafka.connect.test.junit.extension.FromVersionConditionExtension;
@@ -433,7 +434,7 @@ public class ClickHouseSinkTaskWithSchemaProxyTest extends ClickHouseBase {
                 .column("off16", "Int16")
                 .column("payload", "Tuple(fields Map(String, Variant(Float64, Int64, String)), tags Map(String, String))")
                 .engine("MergeTree").orderByColumn("off16")
-                .settings(Map.of("allow_experimental_variant_type", 1))
+                .settings(Map.of(ClientConfigProperties.serverSetting("allow_experimental_variant_type"), 1))
                 .tableName(topic).execute(chc);
 
         Collection<SinkRecord> sr = SchemaTestData.createTupleLikeInfluxValueData(topic, 1);

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
@@ -2165,12 +2165,13 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
 
     // STRUCT field auto-evolved as JSON column when auto.evolve.struct.to.json=true
     @Test
+    @SinceClickHouseVersion("25.2")
     public void autoEvolveStructToJsonCreatesJsonColumn() {
         Assumptions.assumeFalse(isCluster, "Test is disabled against cluster until issue #738 is resolved");
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.AUTO_EVOLVE, "true");
         props.put(ClickHouseSinkConfig.AUTO_EVOLVE_STRUCT_TO_JSON, "true");
-        props.put(ClickHouseSinkConfig.CLICKHOUSE_SETTINGS, "input_format_binary_read_json_as_string=1");
+        props.put(ClickHouseSinkConfig.CLICKHOUSE_SETTINGS, "input_format_binary_read_json_as_string=1,enable_json_type=1");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = "auto_evolve_struct_to_json_test";
@@ -2198,12 +2199,13 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
 
     // V1 records (no struct) inserted first, then V2 records (with struct) trigger JSON column creation.
     @Test
+    @SinceClickHouseVersion("25.2")
     public void autoEvolveStructToJsonMixedBatchOlderRecordsGetDefault() {
         Assumptions.assumeFalse(isCluster, "Test is disabled against cluster until issue #738 is resolved");
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConfig.AUTO_EVOLVE, "true");
         props.put(ClickHouseSinkConfig.AUTO_EVOLVE_STRUCT_TO_JSON, "true");
-        props.put(ClickHouseSinkConfig.CLICKHOUSE_SETTINGS, "input_format_binary_read_json_as_string=1");
+        props.put(ClickHouseSinkConfig.CLICKHOUSE_SETTINGS, "input_format_binary_read_json_as_string=1,enable_json_type=1");
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
 
         String topic = "auto_evolve_struct_json_mixed_test";


### PR DESCRIPTION
## Summary
- Updates ClickHouse version matrix to test against LTS and latest version within 2 year window
- Fixes tests settings to run against old LTS versions
- Added testing with Java LTS versions: 17, 21, 25
- Adds build against CH and Java client HEAD 

Test run on HEAD https://github.com/ClickHouse/clickhouse-kafka-connect/actions/runs/29053481021
Java client test fails where expected (known issue) 

Related: https://github.com/ClickHouse/clickhouse-kafka-connect/issues/759

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
