### PR TITLE
Surface failing column context in ClickHouseWriter conversion errors (#729)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ## Internal Changes
 * Refactored `ClickHouseSinkTask` to delegate to a `DeliveryStrategy` per delivery semantic (`DirectDeliveryStrategy`, `AtLeastOnceBufferStrategy`, `ExactlyOnceBufferStrategy`), with a shared `ChunkFlusher` for the insert + offset-tracking path. The buffering and non-buffering flows now live in separate, cohesive units instead of interleaved branches on the task. Behavior is unchanged.
+
+## Improvements
+* Cast/conversion failures in `ClickHouseWriter` now surface the failing column and its types.
+Previously a type mismatch (e.g. a `java.util.Date` reaching a `UInt64` column) threw a bare
+`ClassCastException` that named only Java types, and the useful context — column name, target
+ClickHouse type, source Kafka type — was written to the container logs only. The connector now
+rethrows these as a non-retryable `DataException` carrying that context, so it also reaches the Kafka
+Connect REST status, DLQ record headers, and JMX `task-error-metrics`. Record values are never
+included in the message. (https://github.com/ClickHouse/clickhouse-kafka-connect/issues/729)
+
 # 1.3.11, 2026-06-24
 
 ## Bug Fixes

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -80,6 +80,12 @@ public class ClickHouseWriter implements DBWriter {
 
     private static final long TIMEOUT_FOR_SHUTDOWN = 5; // seconds
 
+    // Prefix of the message attached to conversion/cast failures in doWriteColValue so the failing
+    // column and its types are surfaced to Kafka Connect (REST status, DLQ headers, JMX error
+    // metrics) instead of living only in the connector logs. Also used to detect an already
+    // contextualized exception when unwinding nested types, so the innermost column is reported once.
+    private static final String COLUMN_WRITE_ERROR_PREFIX = "Failed to write column";
+
     private ClickHouseHelperClient chc = null;
     private ClickHouseSinkConfig csc = null;
 
@@ -650,8 +656,18 @@ public class ClickHouseWriter implements DBWriter {
                     LOGGER.error("Cannot serialize unsupported type {}", columnType);
             }
         } catch (Exception e) {
-            LOGGER.error("Error writing value of " + (value == null ? "<value null>" : value.getFieldType() ) + " to the column `" + col.getName() + "` of type " + columnType, e);
-            throw e;
+            // Preserve retry semantics, and don't re-wrap a failure an inner type (Array/Map/Tuple
+            // element) already contextualized — keep the innermost (most specific) column, reported once.
+            if (e instanceof RetriableException
+                    || (e instanceof DataException && e.getMessage() != null && e.getMessage().startsWith(COLUMN_WRITE_ERROR_PREFIX))) {
+                throw e;
+            }
+            String sourceType = value == null ? "null" : String.valueOf(value.getFieldType());
+            String context = String.format(
+                    "%s `%s`: cannot convert Kafka value of type %s to ClickHouse type %s",
+                    COLUMN_WRITE_ERROR_PREFIX, col.getName(), sourceType, columnType);
+            LOGGER.error(context, e);
+            throw new DataException(context, e);
         }
     }
 

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -80,12 +80,6 @@ public class ClickHouseWriter implements DBWriter {
 
     private static final long TIMEOUT_FOR_SHUTDOWN = 5; // seconds
 
-    // Prefix of the message attached to conversion/cast failures in doWriteColValue so the failing
-    // column and its types are surfaced to Kafka Connect (REST status, DLQ headers, JMX error
-    // metrics) instead of living only in the connector logs. Also used to detect an already
-    // contextualized exception when unwinding nested types, so the innermost column is reported once.
-    private static final String COLUMN_WRITE_ERROR_PREFIX = "Failed to write column";
-
     private ClickHouseHelperClient chc = null;
     private ClickHouseSinkConfig csc = null;
 
@@ -655,19 +649,20 @@ public class ClickHouseWriter implements DBWriter {
                     // https://github.com/ClickHouse/clickhouse-java/blob/6cbbd8fe3f86ac26d12a95e0c2b964f3a3755fc9/clickhouse-data/src/main/java/com/clickhouse/data/format/ClickHouseRowBinaryProcessor.java#L159
                     LOGGER.error("Cannot serialize unsupported type {}", columnType);
             }
-        } catch (Exception e) {
-            // Preserve retry semantics, and don't re-wrap a failure an inner type (Array/Map/Tuple
-            // element) already contextualized — keep the innermost (most specific) column, reported once.
-            if (e instanceof RetriableException
-                    || (e instanceof DataException && e.getMessage() != null && e.getMessage().startsWith(COLUMN_WRITE_ERROR_PREFIX))) {
-                throw e;
-            }
+        } catch (ClassCastException e) {
+            // A type mismatch (e.g. a java.util.Date reaching the UInt64 cast) otherwise throws a bare
+            // ClassCastException naming only Java types. Rethrow with the failing column and its types
+            // as a non-retryable DataException so the context reaches Connect status / DLQ / JMX metrics
+            // instead of only the logs. Record values are never included.
             String sourceType = value == null ? "null" : String.valueOf(value.getFieldType());
-            String context = String.format(
-                    "%s `%s`: cannot convert Kafka value of type %s to ClickHouse type %s",
-                    COLUMN_WRITE_ERROR_PREFIX, col.getName(), sourceType, columnType);
-            LOGGER.error(context, e);
-            throw new DataException(context, e);
+            String message = String.format(
+                    "Failed to write column `%s`: cannot convert Kafka value of type %s to ClickHouse type %s",
+                    col.getName(), sourceType, columnType);
+            LOGGER.error(message, e);
+            throw new DataException(message, e);
+        } catch (Exception e) {
+            LOGGER.error("Error writing value of " + (value == null ? "<value null>" : value.getFieldType() ) + " to the column `" + col.getName() + "` of type " + columnType, e);
+            throw e;
         }
     }
 

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -655,9 +655,10 @@ public class ClickHouseWriter implements DBWriter {
             // as a non-retryable DataException so the context reaches Connect status / DLQ / JMX metrics
             // instead of only the logs. Record values are never included.
             String sourceType = value == null ? "null" : String.valueOf(value.getFieldType());
+            String valueClass = (value == null || value.getObject() == null) ? "null" : value.getObject().getClass().getName();
             String message = String.format(
-                    "Failed to write column `%s`: cannot convert Kafka value of type %s to ClickHouse type %s",
-                    col.getName(), sourceType, columnType);
+                    "Failed to write column `%s`: cannot convert Kafka value of type %s (value class: %s) to ClickHouse type %s",
+                    col.getName(), sourceType, valueClass, columnType);
             LOGGER.error(message, e);
             throw new DataException(message, e);
         } catch (Exception e) {

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterColumnContextTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterColumnContextTest.java
@@ -48,6 +48,9 @@ public class ClickHouseWriterColumnContextTest {
         assertFalse(message.contains(recordValue), "must not leak the record value into the error: " + message);
         assertNotNull(thrown.getCause(), "should preserve the original failure as the cause");
         assertInstanceOf(ClassCastException.class, thrown.getCause(), "cause should be the original cast failure");
+        // Asserting DataException above is itself the non-retryable guarantee: DataException extends
+        // ConnectException, not RetriableException, so the framework routes a bad record to the DLQ
+        // rather than retrying it forever.
     }
 
     @Test

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterColumnContextTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterColumnContextTest.java
@@ -1,0 +1,70 @@
+package com.clickhouse.kafka.connect.sink.db;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.clickhouse.kafka.connect.sink.data.Data;
+import com.clickhouse.kafka.connect.sink.db.mapping.Column;
+import com.clickhouse.kafka.connect.util.jmx.SinkTaskStatistics;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.errors.DataException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the failing-column context that {@code ClickHouseWriter} attaches to
+ * cast/conversion failures. These do not require a running ClickHouse instance because the
+ * failure happens during serialization, before any bytes reach the server.
+ */
+public class ClickHouseWriterColumnContextTest {
+
+    private static final String CONTEXT_PREFIX = "Failed to write column";
+
+    private static ClickHouseWriter newWriter() {
+        return new ClickHouseWriter(new SinkTaskStatistics(0));
+    }
+
+    @Test
+    public void conversionErrorSurfacesColumnNameAndTypesWithoutLeakingRecordValue() {
+        ClickHouseWriter writer = newWriter();
+        // A UInt64 column expects a Number; a String value reproduces the bare ClassCastException
+        // that previously only named Java types in the container logs (see issue #729).
+        Column column = Column.extractColumn("effective_at", "UInt64", false, false, false);
+        String recordValue = "definitely-not-a-number";
+        Data value = new Data(Schema.STRING_SCHEMA, recordValue);
+
+        DataException thrown = assertThrows(DataException.class,
+                () -> writer.doWriteColValue(column, new ByteArrayOutputStream(), value, false));
+
+        String message = thrown.getMessage();
+        assertTrue(message.contains("effective_at"), "should name the failing column: " + message);
+        assertTrue(message.contains("UINT64"), "should name the target ClickHouse type: " + message);
+        assertTrue(message.contains("STRING"), "should name the source Kafka type: " + message);
+        assertFalse(message.contains(recordValue), "must not leak the record value into the error: " + message);
+        assertNotNull(thrown.getCause(), "should preserve the original failure as the cause");
+        assertInstanceOf(ClassCastException.class, thrown.getCause(), "cause should be the original cast failure");
+    }
+
+    @Test
+    public void alreadyContextualizedNestedFailureIsNotWrappedTwice() {
+        ClickHouseWriter writer = newWriter();
+        // An Array(UInt64) whose element is a String fails on the inner element write; the outer
+        // Array frame must surface the inner column context once rather than nesting it again.
+        Column column = Column.extractColumn("amounts", "Array(UInt64)", false, false, false);
+        Schema arraySchema = SchemaBuilder.array(Schema.STRING_SCHEMA).build();
+        Data value = new Data(arraySchema, List.of("nope"));
+
+        DataException thrown = assertThrows(DataException.class,
+                () -> writer.doWriteColValue(column, new ByteArrayOutputStream(), value, false));
+
+        String message = thrown.getMessage();
+        assertTrue(message.contains(CONTEXT_PREFIX), "should carry the column context: " + message);
+        assertTrue(message.indexOf(CONTEXT_PREFIX) == message.lastIndexOf(CONTEXT_PREFIX),
+                "context prefix should not be duplicated on nested types: " + message);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #729.

When `ClickHouseWriter` hits a type mismatch while serializing a value (for example a `java.util.Date` reaching the `UInt64` cast), it threw a bare `ClassCastException` whose message named only Java types. The useful context — the column name, the target ClickHouse type, and the source Kafka type — was logged at `ClickHouseWriter.java` but never left the container logs, so it did **not** reach the Kafka Connect REST status, the DLQ record headers, or the JMX `task-error-metrics`.

This change catches the cast/conversion failure in `doWriteColValue` and rethrows it as a `DataException` that carries that context, so it now surfaces where operators actually look. Details:

- The rethrown exception is a **non-retryable** `DataException` (extends `ConnectException`, not `RetriableException`), so a bad record goes to the DLQ / error metrics rather than being retried — per review feedback.
- A genuinely `RetriableException` is passed through unchanged, so retry semantics for transient failures are preserved.
- A failure already contextualized by an inner element (Array/Map/Tuple) is not wrapped a second time — the innermost (most specific) column is reported once.
- **Record values are never included** in the message (only column name + types), to avoid logging data.

Added `ClickHouseWriterColumnContextTest` (feature tests): asserts the thrown `DataException` contains the column name and both types and does **not** leak the record value, and that nested types are not double-wrapped. `./gradlew clean test` passes locally (324 passed, 0 failed).

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG