### PR TITLE
[data] RowBinaryWithNamesAndTypes support

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
@@ -64,6 +64,7 @@ public class ClickHouseSinkConfig {
     public static final String AUTO_EVOLVE_STRUCT_TO_JSON = "auto.evolve.struct.to.json";
     public static final String CONNECTOR_RETRY_TIMEOUT = "errors.retry.timeout";
     public static final String CLUSTER_NAME = "clusterName";
+    public static final String USE_ROW_BINARY_WITH_NAMES_AND_TYPES = "useRowBinaryWithNamesAndTypes";
 
     public static final long MINIMAL_RETRY_TIMEOUT_THR_WARN = TimeUnit.SECONDS.toMillis(10);
     public static final String SSL_SOCKET_SNI = "ssl_socket_sni";
@@ -84,6 +85,7 @@ public class ClickHouseSinkConfig {
     public static final Long bufferFlushTimeDefault = 0L;
     public static final Long clickhouseClientInsertTimeoutMsDefault = TimeUnit.MINUTES.toMillis(4);
     public static final Boolean reportInsertedOffsetsDefault = Boolean.FALSE;
+    public static final Boolean useRowBinaryWithNamesAndTypesDefault = Boolean.FALSE;
 
     private final String hostname;
     private final int port;
@@ -125,6 +127,7 @@ public class ClickHouseSinkConfig {
     private final boolean binaryFormatWrtiteJsonAsString;
     private final String sslSocketSni;
     private final String clusterName;
+    private final boolean useRowBinaryWithNamesAndTypes;
 
     public enum InsertFormats {
         NONE,
@@ -307,6 +310,7 @@ public class ClickHouseSinkConfig {
         this.debeziumCDCEnabled = Boolean.parseBoolean(props.getOrDefault(DEBEZIUM_CDC_ENABLED, "false"));
         this.sslSocketSni = props.getOrDefault(SSL_SOCKET_SNI, "");
         this.clusterName = props.getOrDefault(CLUSTER_NAME, "");
+        this.useRowBinaryWithNamesAndTypes = Boolean.parseBoolean(props.getOrDefault(USE_ROW_BINARY_WITH_NAMES_AND_TYPES, useRowBinaryWithNamesAndTypesDefault.toString()));
 
         if (this.bufferCount > 0) {
             LOGGER.info("Internal buffering enabled: bufferCount={}, bufferFlushTime={}ms", this.bufferCount, this.bufferFlushTime);
@@ -623,6 +627,16 @@ public class ClickHouseSinkConfig {
                 ++orderInGroup,
                 ConfigDef.Width.SHORT,
                 "Bypass RowBinary format.");
+        configDef.define(USE_ROW_BINARY_WITH_NAMES_AND_TYPES,
+                ConfigDef.Type.BOOLEAN,
+                useRowBinaryWithNamesAndTypesDefault,
+                ConfigDef.Importance.LOW,
+                "Use the RowBinaryWithNamesAndTypes format instead of RowBinary for schema-based inserts. Doesn't support defaults. default: " +
+                        useRowBinaryWithNamesAndTypesDefault,
+                group,
+                ++orderInGroup,
+                ConfigDef.Width.SHORT,
+                "Use RowBinaryWithNamesAndTypes format.");
         configDef.define(DATE_TIME_FORMAT,
                 ConfigDef.Type.LIST,
                 "",

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -1140,13 +1140,11 @@ public class ClickHouseWriter implements DBWriter {
 
     private ClickHouseFormat getRowBinaryFormat(boolean supportDefaults) {
         ClickHouseFormat format = ClickHouseFormat.RowBinary;
-        if (supportDefaults) {
-            if (csc.isUseRowBinaryWithNamesAndTypes()) {
-                LOGGER.warn("Configured to use RowBinaryWithNamesAndTypes and trying to write RowBinaryWithDefaults.");
-            }
-            format = ClickHouseFormat.RowBinaryWithDefaults;
-        } else if (csc.isUseRowBinaryWithNamesAndTypes()) {
+        if (csc.isUseRowBinaryWithNamesAndTypes()) {
+            // event with defaults we can use RowBinaryWithNamesAndTypes because server will insert default value for missing fields
             format = ClickHouseFormat.RowBinaryWithNamesAndTypes;
+        } else if (supportDefaults) {
+             format = ClickHouseFormat.RowBinaryWithDefaults;
         }
         return format;
     }

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -118,6 +118,7 @@ public class ClickHouseWriter implements DBWriter {
                 .useClientV2(useClientV2)
                 .setSslSocketSni(csc.getSslSocketSni())
                 .setClusterClause(csc.getClusterName())
+                .useRowBinaryWithNamesAndTypes(csc.isUseRowBinaryWithNamesAndTypes())
                 .build();
 
         if (!chc.ping()) {
@@ -1045,8 +1046,13 @@ public class ClickHouseWriter implements DBWriter {
             insertSettings.serverSetting(clickhouseSetting, csc.getClickhouseSettings().get(clickhouseSetting));
         }
 //        insertSettings.setOption(ClickHouseClientOption.WRITE_BUFFER_SIZE.name(), 8192);
+
+        ClickHouseFormat format = getRowBinaryFormat(supportDefaults);
         long pushStreamTime = 0;
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        if (format == ClickHouseFormat.RowBinaryWithNamesAndTypes) {
+            table.writeNamesAndTypes(stream);
+        }
         for (Record record : records) {
             if (record.getSinkRecord().value() != null) {
                 for (Column col : table.getRootColumnsList()) {
@@ -1063,10 +1069,6 @@ public class ClickHouseWriter implements DBWriter {
 
         InputStream data = new ByteArrayInputStream(stream.toByteArray());
 
-        ClickHouseFormat format = ClickHouseFormat.RowBinary;
-        if (supportDefaults) {
-            format = ClickHouseFormat.RowBinaryWithDefaults;
-        }
 
         try (InsertResponse insertResponse = awaitInsertResponse(client.insert(table.getName(), data, format, insertSettings), queryId)) {
             LOGGER.debug("Response Summary - Written Bytes: [{}], Written Rows: [{}] - (QueryId: [{}])", insertResponse.getWrittenBytes(), insertResponse.getWrittenRows(), queryId.getQueryId());
@@ -1094,12 +1096,8 @@ public class ClickHouseWriter implements DBWriter {
         long s2 = System.currentTimeMillis();
         long pushStreamTime = 0;
         try (ClickHouseClient client = getClient()) {
-            ClickHouseRequest.Mutation request;
-            if (supportDefaults) {
-                request = getMutationRequest(client, ClickHouseFormat.RowBinaryWithDefaults, table.getName(), database, queryId);
-            } else {
-                request = getMutationRequest(client, ClickHouseFormat.RowBinary, table.getName(), database, queryId);
-            }
+            ClickHouseFormat format = getRowBinaryFormat(supportDefaults);
+            final ClickHouseRequest.Mutation  request = getMutationRequest(client, format, table.getName(), database, queryId);
             ClickHouseConfig config = request.getConfig();
             CompletableFuture<ClickHouseResponse> future;
 
@@ -1108,6 +1106,11 @@ public class ClickHouseWriter implements DBWriter {
                 // start the worker thread which transfer data from the input into ClickHouse
                 future = request.data(stream.getInputStream()).execute();
                 // write bytes into the piped stream
+
+                // header if according format selected
+                if (format == ClickHouseFormat.RowBinaryWithNamesAndTypes) {
+                    table.writeNamesAndTypes(stream);
+                }
 
                 for (Record record : records) {
                     if (record.getSinkRecord().value() != null) {
@@ -1133,6 +1136,19 @@ public class ClickHouseWriter implements DBWriter {
         long s3 = System.currentTimeMillis();
         LOGGER.info("topic :{} partition: {} batchSize: {} push stream ms: {} data ms: {} send ms: {} (QueryId: [{}])", topic, partition, records.size(), pushStreamTime,s2 - s1, s3 - s2, queryId.getQueryId());
         statistics.insertTime(s2 - s1, topic);
+    }
+
+    private ClickHouseFormat getRowBinaryFormat(boolean supportDefaults) {
+        ClickHouseFormat format = ClickHouseFormat.RowBinary;
+        if (supportDefaults) {
+            if (csc.isUseRowBinaryWithNamesAndTypes()) {
+                LOGGER.warn("Configured to use RowBinaryWithNamesAndTypes and trying to write RowBinaryWithDefaults.");
+            }
+            format = ClickHouseFormat.RowBinaryWithDefaults;
+        } else if (csc.isUseRowBinaryWithNamesAndTypes()) {
+            format = ClickHouseFormat.RowBinaryWithNamesAndTypes;
+        }
+        return format;
     }
 
     protected void doInsertJson(List<Record> records, Table table, QueryIdentifier queryId) throws IOException, ExecutionException, InterruptedException {

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
@@ -65,6 +65,7 @@ public class ClickHouseHelperClient implements AutoCloseable {
     private boolean useClientV2 = false;
     private final String sslSocketSni;
     private final String clusterClause;
+    private final boolean useRowBinaryWithNamesAndTypes;
 
     public ClickHouseHelperClient(ClickHouseClientBuilder builder) {
         this.hostname = builder.hostname;
@@ -82,6 +83,7 @@ public class ClickHouseHelperClient implements AutoCloseable {
         this.useClientV2 = builder.useClientV2;
         this.sslSocketSni = builder.sslSocketSni;
         this.clusterClause = builder.clusterClause;
+        this.useRowBinaryWithNamesAndTypes = builder.useRowBinaryWithNamesAndTypes;
         // We are creating two clients, one for V1 and one for V2
         this.client = createClientV2();
         this.server = createClientV1();
@@ -413,6 +415,14 @@ public class ClickHouseHelperClient implements AutoCloseable {
                     return null;
                 }
                 table.addColumn(column);
+                if (useRowBinaryWithNamesAndTypes && !fieldDescriptor.isSubcolumn()) {
+                    table.rememberColumnNameAndType(fieldDescriptor.getName(), fieldDescriptor.getType());
+                }
+            }
+
+            // calculate header
+            if (useRowBinaryWithNamesAndTypes) {
+                table.composeRowBinaryWithNamesAndTypesHeader();
             }
             return table;
         } catch (ClickHouseException | JsonProcessingException e) {
@@ -464,7 +474,13 @@ public class ClickHouseHelperClient implements AutoCloseable {
                         return null;
                     }
                     table.addColumn(column);
+                    if (useRowBinaryWithNamesAndTypes && !fieldDescriptor.isSubcolumn()) {
+                        table.rememberColumnNameAndType(fieldDescriptor.getName(), fieldDescriptor.getType());
+                    }
                 }
+            }
+            if (useRowBinaryWithNamesAndTypes) {
+                table.composeRowBinaryWithNamesAndTypesHeader();
             }
         } catch (Exception e) {
             LOGGER.error("describeTableV2 failed", e);
@@ -566,6 +582,7 @@ public class ClickHouseHelperClient implements AutoCloseable {
         private boolean useClientV2 = true;
         private String sslSocketSni = "";
         private String clusterClause = "";
+        private boolean useRowBinaryWithNamesAndTypes = false;
 
         public ClickHouseClientBuilder(String hostname, int port, ClickHouseProxyType proxyType, String proxyHost, int proxyPort) {
             this.hostname = hostname;
@@ -623,6 +640,11 @@ public class ClickHouseHelperClient implements AutoCloseable {
 
         public ClickHouseClientBuilder setClusterClause(String clusterName) {
             this.clusterClause = (clusterName == null || clusterName.isEmpty()) ? "" : " ON CLUSTER '" + clusterName + "' ";
+            return this;
+        }
+
+        public ClickHouseClientBuilder useRowBinaryWithNamesAndTypes(boolean useRowBinaryWithNamesAndTypes) {
+            this.useRowBinaryWithNamesAndTypes = useRowBinaryWithNamesAndTypes;
             return this;
         }
 

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/mapping/Table.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/mapping/Table.java
@@ -1,5 +1,6 @@
 package com.clickhouse.kafka.connect.sink.db.mapping;
 
+import com.clickhouse.data.format.BinaryStreamUtils;
 import com.clickhouse.kafka.connect.util.Utils;
 import lombok.Getter;
 import lombok.Setter;
@@ -7,6 +8,10 @@ import lombok.experimental.Accessors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -40,6 +45,15 @@ public class Table {
     @Setter
     @Getter
     private int numColumns = 0;
+
+    // column names in the order data is sent
+    private final List<byte[]> rowBinaryHeaderColumnNames = new ArrayList<>();
+    // column types in the order of column names
+    private final List<byte[]> rowBinaryHeaderColumnTypes = new ArrayList<>();
+    // To allocate buffer for pre-baked rowBinaryWithNamesAndTypes header
+    private int estimatedHeaderSize = EST_HEADER_ADDED_LENGTH;
+    // pre-baked names and types header
+    private byte[] rowBinaryWithNamesAndTypesHeader = new byte[0];
 
     public Table(String database, String name) {
         this.database = database;
@@ -80,6 +94,34 @@ public class Table {
             rootColumnsList.add(column);
             rootColumnsMap.put(column.getName(), column);
         }
+    }
+
+    private static final int EST_HEADER_ADDED_LENGTH = 5 /* var int bytes for int */ * 2 /* name and type */;
+    public void rememberColumnNameAndType(String columnName, String columnType) {
+        byte[] nameBytes = columnName.getBytes(StandardCharsets.UTF_8);
+        byte[] typeBytes = columnType.getBytes(StandardCharsets.UTF_8);
+
+        rowBinaryHeaderColumnNames.add(nameBytes);
+        rowBinaryHeaderColumnTypes.add(typeBytes);
+        estimatedHeaderSize += nameBytes.length + typeBytes.length + EST_HEADER_ADDED_LENGTH;
+    }
+
+    public void composeRowBinaryWithNamesAndTypesHeader() {
+        ByteBuffer out = ByteBuffer.allocate(estimatedHeaderSize);
+        BinaryStreamUtils.writeVarInt(out, rowBinaryHeaderColumnNames.size());
+        for (byte[] columnName : rowBinaryHeaderColumnNames) {
+            BinaryStreamUtils.writeVarInt(out, columnName.length);
+            out.put(columnName);
+        }
+        for (byte[] columnType : rowBinaryHeaderColumnTypes) {
+            BinaryStreamUtils.writeVarInt(out, columnType.length);
+            out.put(columnType);
+        }
+        this.rowBinaryWithNamesAndTypesHeader = out.array();
+    }
+
+    public void writeNamesAndTypes(OutputStream out) throws IOException {
+        out.write(rowBinaryWithNamesAndTypesHeader, 0, rowBinaryWithNamesAndTypesHeader.length);
     }
 
     public Set<String> getMissingColumns(Collection<String> fieldNames) {

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/mapping/Table.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/mapping/Table.java
@@ -13,6 +13,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -52,8 +53,9 @@ public class Table {
     private final List<byte[]> rowBinaryHeaderColumnTypes = new ArrayList<>();
     // To allocate buffer for pre-baked rowBinaryWithNamesAndTypes header
     private int estimatedHeaderSize = EST_HEADER_ADDED_LENGTH;
-    // pre-baked names and types header
-    private byte[] rowBinaryWithNamesAndTypesHeader = new byte[0];
+    // pre-baked names and types header. Stays null until composed so callers can tell
+    // "header was never collected" apart from "header was collected but has no columns".
+    private byte[] rowBinaryWithNamesAndTypesHeader = null;
 
     public Table(String database, String name) {
         this.database = database;
@@ -117,7 +119,10 @@ public class Table {
             BinaryStreamUtils.writeVarInt(out, columnType.length);
             out.put(columnType);
         }
-        this.rowBinaryWithNamesAndTypesHeader = out.array();
+        // estimatedHeaderSize is an upper bound (var ints are assumed to be their max width), so
+        // trim to the bytes actually written. Otherwise trailing zero bytes would be sent to
+        // ClickHouse and corrupt the RowBinaryWithNamesAndTypes stream.
+        this.rowBinaryWithNamesAndTypesHeader = Arrays.copyOf(out.array(), out.position());
     }
 
     public void writeNamesAndTypes(OutputStream out) throws IOException {

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/mapping/Table.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/mapping/Table.java
@@ -53,9 +53,8 @@ public class Table {
     private final List<byte[]> rowBinaryHeaderColumnTypes = new ArrayList<>();
     // To allocate buffer for pre-baked rowBinaryWithNamesAndTypes header
     private int estimatedHeaderSize = EST_HEADER_ADDED_LENGTH;
-    // pre-baked names and types header. Stays null until composed so callers can tell
-    // "header was never collected" apart from "header was collected but has no columns".
-    private byte[] rowBinaryWithNamesAndTypesHeader = null;
+    // pre-baked names and types header.
+    private byte[] rowBinaryWithNamesAndTypesHeader = new byte[0];
 
     public Table(String database, String name) {
         this.database = database;
@@ -126,6 +125,9 @@ public class Table {
     }
 
     public void writeNamesAndTypes(OutputStream out) throws IOException {
+        if (rowBinaryWithNamesAndTypesHeader.length == 0) {
+            throw new IOException("Bug: Nothing to write - header is empty.");
+        }
         out.write(rowBinaryWithNamesAndTypesHeader, 0, rowBinaryWithNamesAndTypesHeader.length);
     }
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/RowBinaryWithNamesAndTypesTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/RowBinaryWithNamesAndTypesTest.java
@@ -1,5 +1,6 @@
 package com.clickhouse.kafka.connect.sink;
 
+import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
 import com.clickhouse.kafka.connect.sink.helper.CreateTableStatement;
@@ -9,6 +10,8 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/com/clickhouse/kafka/connect/sink/RowBinaryWithNamesAndTypesTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/RowBinaryWithNamesAndTypesTest.java
@@ -1,0 +1,154 @@
+package com.clickhouse.kafka.connect.sink;
+
+import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
+import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
+import com.clickhouse.kafka.connect.sink.helper.CreateTableStatement;
+import com.clickhouse.kafka.connect.sink.helper.SchemaTestData;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end coverage for {@code useRowBinaryWithNamesAndTypes=true}. The key scenario is inserting
+ * records that carry fewer fields than the destination table: because the connector sends a
+ * names-and-types header, ClickHouse can map by name and fill defaults for the columns that are not
+ * present in the stream, which is how the format addresses schema evolution.
+ */
+public class RowBinaryWithNamesAndTypesTest extends ClickHouseBase {
+
+    private static final int RECORD_COUNT = 10;
+
+    private Map<String, String> propsWithRowBinaryNamesAndTypes() {
+        Map<String, String> props = getBaseProps();
+        props.put(ClickHouseSinkConfig.USE_ROW_BINARY_WITH_NAMES_AND_TYPES, "true");
+        return props;
+    }
+
+    @Test
+    public void insertsMatchingRecordsWithNamesAndTypesHeader() {
+        Map<String, String> props = propsWithRowBinaryNamesAndTypes();
+        ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
+
+        String topic = createTopicName("rbwnat-basic-test");
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        new CreateTableStatement()
+                .tableName(topic)
+                .column("off16", "Int16")
+                .column("string", "String")
+                .engine("MergeTree")
+                .orderByColumn("off16")
+                .execute(chc);
+
+        Collection<SinkRecord> sr = SchemaTestData.createSimpleData(topic, 1, RECORD_COUNT);
+
+        ClickHouseSinkTask chst = new ClickHouseSinkTask();
+        chst.start(props);
+        chst.put(sr);
+        chst.stop();
+
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic);
+        assertEquals(sr.size(), rows.size());
+        for (JSONObject row : rows) {
+            assertEquals("test string", row.getString("string"));
+        }
+        ClickHouseTestHelpers.dropTable(chc, topic);
+    }
+
+    @Test
+    public void recordsWithFewerFieldsThanTableFillNullableColumn() {
+        // The table has a column the records never provide. With the names-and-types header the
+        // connector still describes every column, and the absent field lands as NULL.
+        Map<String, String> props = propsWithRowBinaryNamesAndTypes();
+        ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
+
+        String topic = createTopicName("rbwnat-fewer-fields-nullable-test");
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        new CreateTableStatement()
+                .tableName(topic)
+                .column("off16", "Int16")
+                .column("string", "String")
+                .column("extra", "Nullable(Int32)")
+                .engine("MergeTree")
+                .orderByColumn("off16")
+                .execute(chc);
+
+        Collection<SinkRecord> sr = SchemaTestData.createSimpleData(topic, 1, RECORD_COUNT);
+
+        ClickHouseSinkTask chst = new ClickHouseSinkTask();
+        chst.start(props);
+        chst.put(sr);
+        chst.stop();
+
+        assertEquals(sr.size(), ClickHouseTestHelpers.countRows(chc, topic));
+        List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic);
+        assertEquals(sr.size(), rows.size());
+        for (JSONObject row : rows) {
+            assertEquals("test string", row.getString("string"));
+            assertTrue(row.isNull("extra"), "Absent field should be stored as NULL, was: " + row.opt("extra"));
+        }
+        ClickHouseTestHelpers.dropTable(chc, topic);
+    }
+
+    @Test
+    public void oldSchemaRecordsInsertAfterDefaultColumnAdded() {
+        // Schema evolution: a non-nullable column with a DEFAULT is added to the table after the
+        // connector has been writing. Records keep arriving without that field; they must still be
+        // inserted and the new column must fall back to its default.
+        Map<String, String> props = propsWithRowBinaryNamesAndTypes();
+        ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
+
+        String topic = createTopicName("rbwnat-schema-evolution-default-test");
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        new CreateTableStatement()
+                .tableName(topic)
+                .column("off16", "Int16")
+                .column("string", "String")
+                .engine("MergeTree")
+                .orderByColumn("off16")
+                .execute(chc);
+
+        ClickHouseSinkTask chst = new ClickHouseSinkTask();
+        chst.start(props);
+
+        Collection<SinkRecord> firstBatch = SchemaTestData.createSimpleData(topic, 1, RECORD_COUNT);
+        chst.put(firstBatch);
+        assertEquals(firstBatch.size(), ClickHouseTestHelpers.countRows(chc, topic));
+
+        ClickHouseTestHelpers.executeQueryIgnoreResult(chc, String.format(
+                "ALTER TABLE `%s`%s ADD COLUMN num32_default Int32 DEFAULT 42 AFTER string",
+                topic, ClickHouseTestHelpers.getClusterClauseOrEmpty()));
+
+        // Same schema as before (off16, string), but past the previous offsets so the state machine
+        // treats them as new data rather than a retry/duplicate.
+        Collection<SinkRecord> secondBatch = firstBatch.stream()
+                .map(record -> new SinkRecord(
+                        record.topic(),
+                        record.kafkaPartition(),
+                        record.keySchema(),
+                        record.key(),
+                        record.valueSchema(),
+                        record.value(),
+                        record.kafkaOffset() + 1000,
+                        record.timestamp(),
+                        TimestampType.CREATE_TIME))
+                .collect(Collectors.toList());
+        chst.put(secondBatch);
+        chst.stop();
+
+        int totalRows = firstBatch.size() + secondBatch.size();
+        assertEquals(totalRows, ClickHouseTestHelpers.countRows(chc, topic));
+        // Every row (including the ones written before the column existed) resolves to the default.
+        assertEquals(42 * totalRows, ClickHouseTestHelpers.sumRows(chc, topic, "num32_default"));
+        ClickHouseTestHelpers.dropTable(chc, topic);
+    }
+}

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/mapping/TableTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/mapping/TableTest.java
@@ -1,45 +1,50 @@
 package com.clickhouse.kafka.connect.sink.db.mapping;
 
+import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
+import com.clickhouse.data.format.BinaryStreamUtils;
 import com.clickhouse.kafka.connect.ClickHouseSinkConnector;
 import com.clickhouse.kafka.connect.sink.ClickHouseBase;
+import com.clickhouse.kafka.connect.sink.ClickHouseSinkConfig;
 import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers;
 import com.clickhouse.kafka.connect.sink.helper.CreateTableStatement;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.clickhouse.kafka.connect.sink.helper.ClickHouseTestHelpers.newDescriptor;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class TableTest extends ClickHouseBase {
 
-    @Test
-    public void extractMapOfPrimitives() {
-        Table table = new Table("default", "t");
-
-        Column map = Column.extractColumn(newDescriptor("map", "Map(String, Decimal(5))"));
-        Column mapValues = Column.extractColumn(newDescriptor("map.values", "Array(Decimal(5))"));
-
-        assertEquals(Type.MAP, map.getType());
-        assertNull(map.getMapValueType());
-
-        table.addColumn(map);
-        table.addColumn(mapValues);
-
-        Column mapValueType = map.getMapValueType();
-        assertEquals(Type.Decimal, mapValueType.getType());
-        assertEquals(5, mapValueType.getPrecision());
+    private static Column add(Table table, String name, String type) {
+        Column column = Column.extractColumn(newDescriptor(name, type));
+        table.addColumn(column);
+        return column;
     }
 
-    @Test
-    public void extractNullables() {
-        Map<String, String> props = getBaseProps();
-        ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
+    private static Table tableWithHeader(String... namesAndTypes) {
+        Table table = new Table("default", "t");
+        for (int i = 0; i < namesAndTypes.length; i += 2) {
+            table.rememberColumnNameAndType(namesAndTypes[i], namesAndTypes[i + 1]);
+        }
+        table.composeRowBinaryWithNamesAndTypesHeader();
+        return table;
+    }
 
-        String tableName = createTopicName("extract-table-test");
+    // Creates a table (off16, Nullable(Date)), describes it and drops it, returning the description.
+    private Table describeOff16DateTable(Map<String, String> props, String namePrefix) {
+        ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
+        String tableName = createTopicName(namePrefix);
         ClickHouseTestHelpers.dropTable(chc, tableName);
         new CreateTableStatement()
                 .tableName(tableName)
@@ -48,10 +53,30 @@ class TableTest extends ClickHouseBase {
                 .engine("MergeTree").orderByColumn("off16").execute(chc);
 
         Table table = chc.describeTable(chc.getDatabase(), tableName);
+        ClickHouseTestHelpers.dropTable(chc, tableName);
+        return table;
+    }
+
+    @Test
+    public void extractMapOfPrimitives() {
+        Table table = new Table("default", "t");
+        Column map = add(table, "map", "Map(String, Decimal(5))");
+        assertEquals(Type.MAP, map.getType());
+        assertNull(map.getMapValueType());
+
+        add(table, "map.values", "Array(Decimal(5))");
+
+        Column mapValueType = map.getMapValueType();
+        assertEquals(Type.Decimal, mapValueType.getType());
+        assertEquals(5, mapValueType.getPrecision());
+    }
+
+    @Test
+    public void extractNullables() {
+        Table table = describeOff16DateTable(getBaseProps(), "extract-table-test");
         assertNotNull(table);
         assertEquals(2, table.getRootColumnsList().size());
         assertEquals(3, table.getAllColumnsList().size());
-        ClickHouseTestHelpers.dropTable(chc, tableName);
     }
 
     @Test
@@ -77,17 +102,12 @@ class TableTest extends ClickHouseBase {
     @Test
     public void extractMapWithComplexValue() {
         Table table = new Table("default", "t");
-
-        Column map = Column.extractColumn(newDescriptor("map", "Map(String, Map(String, Decimal(5)))"));
-        Column mapValues = Column.extractColumn(newDescriptor("map.values", "Array(Map(String, Decimal(5)))"));
-        Column mapValuesValues = Column.extractColumn(newDescriptor("map.values.values", "Array(Array(Decimal(5)))"));
-
+        Column map = add(table, "map", "Map(String, Map(String, Decimal(5)))");
         assertEquals(Type.MAP, map.getType());
         assertNull(map.getMapValueType());
 
-        table.addColumn(map);
-        table.addColumn(mapValues);
-        table.addColumn(mapValuesValues);
+        add(table, "map.values", "Array(Map(String, Decimal(5)))");
+        add(table, "map.values.values", "Array(Array(Decimal(5)))");
 
         Column mapValueType = map.getMapValueType();
         assertEquals(Type.MAP, mapValueType.getType());
@@ -101,19 +121,13 @@ class TableTest extends ClickHouseBase {
     @Test
     public void extractMapOfMapOfMapOfString() {
         Table table = new Table("default", "t");
-
-        Column map = Column.extractColumn(newDescriptor("map", "Map(String, Map(String, Map(String, String)))"));
-        Column mapValues = Column.extractColumn(newDescriptor("map.values", "Array(Map(String, Map(String, String)))"));
-        Column mapValuesValues = Column.extractColumn(newDescriptor("map.values.values", "Array(Array(Map(String, String)))"));
-        Column mapValuesValuesValues = Column.extractColumn(newDescriptor("map.values.values.values", "Array(Array(Array(String)))"));
-
+        Column map = add(table, "map", "Map(String, Map(String, Map(String, String)))");
         assertEquals(Type.MAP, map.getType());
         assertNull(map.getMapValueType());
 
-        table.addColumn(map);
-        table.addColumn(mapValues);
-        table.addColumn(mapValuesValues);
-        table.addColumn(mapValuesValuesValues);
+        add(table, "map.values", "Array(Map(String, Map(String, String)))");
+        add(table, "map.values.values", "Array(Array(Map(String, String)))");
+        add(table, "map.values.values.values", "Array(Array(Array(String)))");
 
         Column mapValueType = map.getMapValueType();
         assertEquals(Type.MAP, mapValueType.getType());
@@ -130,16 +144,12 @@ class TableTest extends ClickHouseBase {
     @Test
     public void extractTupleOfPrimitives() {
         Table table = new Table("default", "t");
-        Column tuple = Column.extractColumn(newDescriptor("tuple", "Tuple(first String, second Decimal(5))"));
-        Column tupleFirst = Column.extractColumn(newDescriptor("tuple.first", "String"));
-        Column tupleSecond = Column.extractColumn(newDescriptor("tuple.second", "Decimal(5)"));
-
+        Column tuple = add(table, "tuple", "Tuple(first String, second Decimal(5))");
         assertEquals(Type.TUPLE, tuple.getType());
         assertEquals(List.of(), tuple.getTupleFields());
 
-        table.addColumn(tuple);
-        table.addColumn(tupleFirst);
-        table.addColumn(tupleSecond);
+        add(table, "tuple.first", "String");
+        add(table, "tuple.second", "Decimal(5)");
 
         assertEquals(2, tuple.getTupleFields().size());
         assertEquals(List.of("tuple.first", "tuple.second"), tuple.getTupleFields().stream().map(Column::getName).collect(Collectors.toList()));
@@ -148,20 +158,105 @@ class TableTest extends ClickHouseBase {
     }
 
     @Test
+    public void rowBinaryHeaderIsNullWhenNotCollected() {
+        // Header stays null until the feature flag triggers composition during describe.
+        Table table = new Table("default", "t");
+        add(table, "off16", "Int16");
+        add(table, "name", "String");
+
+        assertNull(table.getRowBinaryWithNamesAndTypesHeader());
+        assertEquals(2, table.getRootColumnsList().size());
+    }
+
+    @Test
+    public void composeRowBinaryWithNamesAndTypesHeader() {
+        Table table = tableWithHeader("a", "UInt8", "b", "String");
+
+        // LEB128 count, then names, then types (each length-prefixed UTF-8).
+        byte[] expected = new byte[] {
+                0x02,
+                0x01, 'a',
+                0x01, 'b',
+                0x05, 'U', 'I', 'n', 't', '8',
+                0x06, 'S', 't', 'r', 'i', 'n', 'g'
+        };
+        assertArrayEquals(expected, table.getRowBinaryWithNamesAndTypesHeader());
+    }
+
+    @Test
+    public void composeEmptyRowBinaryWithNamesAndTypesHeader() {
+        assertArrayEquals(new byte[] {0x00}, tableWithHeader().getRowBinaryWithNamesAndTypesHeader());
+    }
+
+    @Test
+    public void writeNamesAndTypesEmitsExactlyComposedHeaderWithoutTrailingBytes() throws Exception {
+        // Any trailing padding from the over-estimated buffer would be read as row data by ClickHouse.
+        Table table = tableWithHeader("a", "UInt8", "b", "String");
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        table.writeNamesAndTypes(out);
+
+        assertArrayEquals(table.getRowBinaryWithNamesAndTypesHeader(), out.toByteArray());
+    }
+
+    @Test
+    public void describeCollectsRowBinaryHeaderWhenEnabled() throws Exception {
+        Map<String, String> props = getBaseProps();
+        props.put(ClickHouseSinkConfig.USE_ROW_BINARY_WITH_NAMES_AND_TYPES, "true");
+
+        Table table = describeOff16DateTable(props, "rbwnat-header-test");
+        assertNotNull(table);
+        byte[] header = table.getRowBinaryWithNamesAndTypesHeader();
+        assertNotNull(header);
+
+        HeaderContents decoded = decodeHeader(header);
+        List<String> expectedNames = table.getRootColumnsList().stream()
+                .map(Column::getName).collect(Collectors.toList());
+        assertEquals(expectedNames, decoded.names);
+        assertEquals(List.of("Int16", "Nullable(Date)"), decoded.types);
+    }
+
+    @Test
+    public void describeDoesNotCollectRowBinaryHeaderWhenDisabled() {
+        Table table = describeOff16DateTable(getBaseProps(), "rbwnat-header-disabled-test");
+        assertNotNull(table);
+        assertNull(table.getRowBinaryWithNamesAndTypesHeader());
+    }
+
+    private static final class HeaderContents {
+        final List<String> names;
+        final List<String> types;
+
+        HeaderContents(List<String> names, List<String> types) {
+            this.names = names;
+            this.types = types;
+        }
+    }
+
+    private static HeaderContents decodeHeader(byte[] header) throws Exception {
+        InputStream in = new ByteArrayInputStream(header);
+        int columns = BinaryStreamUtils.readVarInt(in);
+        List<String> names = new ArrayList<>();
+        List<String> types = new ArrayList<>();
+        for (int i = 0; i < columns; i++) {
+            names.add(BinaryStreamReader.readString(in));
+        }
+        for (int i = 0; i < columns; i++) {
+            types.add(BinaryStreamReader.readString(in));
+        }
+        return new HeaderContents(names, types);
+    }
+
+    @Test
     public void extractTupleOfTupleOfTuple() {
         Table table = new Table("default", "t");
-        Column tuple = Column.extractColumn(newDescriptor("tuple", "Tuple(tuple Tuple(tuple Tuple(string String)))"));
-        Column tupleTuple = Column.extractColumn(newDescriptor("tuple.tuple", "Tuple(tuple Tuple(string String))"));
-        Column tupleTupleTuple = Column.extractColumn(newDescriptor("tuple.tuple.tuple", "Tuple(string String)"));
-        Column tupleTupleTupleString = Column.extractColumn(newDescriptor("tuple.tuple.tuple.string", "String"));
-
+        Column tuple = add(table, "tuple", "Tuple(tuple Tuple(tuple Tuple(string String)))");
         assertEquals(Type.TUPLE, tuple.getType());
         assertEquals(List.of(), tuple.getTupleFields());
 
-        table.addColumn(tuple);
-        table.addColumn(tupleTuple);
-        table.addColumn(tupleTupleTuple);
-        table.addColumn(tupleTupleTupleString);
+        add(table, "tuple.tuple", "Tuple(tuple Tuple(string String))");
+        add(table, "tuple.tuple.tuple", "Tuple(string String)");
+        add(table, "tuple.tuple.tuple.string", "String");
 
         assertEquals(1, tuple.getTupleFields().size());
         assertEquals(1, tuple.getTupleFields().get(0).getTupleFields().size());

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/mapping/TableTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/mapping/TableTest.java
@@ -1,7 +1,6 @@
 package com.clickhouse.kafka.connect.sink.db.mapping;
 
 import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
-import com.clickhouse.data.format.BinaryStreamUtils;
 import com.clickhouse.kafka.connect.ClickHouseSinkConnector;
 import com.clickhouse.kafka.connect.sink.ClickHouseBase;
 import com.clickhouse.kafka.connect.sink.ClickHouseSinkConfig;
@@ -12,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TableTest extends ClickHouseBase {
 
@@ -164,7 +165,7 @@ class TableTest extends ClickHouseBase {
         add(table, "off16", "Int16");
         add(table, "name", "String");
 
-        assertNull(table.getRowBinaryWithNamesAndTypesHeader());
+        assertEquals(0, table.getRowBinaryWithNamesAndTypesHeader().length);
         assertEquals(2, table.getRootColumnsList().size());
     }
 
@@ -220,7 +221,7 @@ class TableTest extends ClickHouseBase {
     public void describeDoesNotCollectRowBinaryHeaderWhenDisabled() {
         Table table = describeOff16DateTable(getBaseProps(), "rbwnat-header-disabled-test");
         assertNotNull(table);
-        assertNull(table.getRowBinaryWithNamesAndTypesHeader());
+        assertEquals(0, table.getRowBinaryWithNamesAndTypesHeader().length);
     }
 
     private static final class HeaderContents {
@@ -235,14 +236,14 @@ class TableTest extends ClickHouseBase {
 
     private static HeaderContents decodeHeader(byte[] header) throws Exception {
         InputStream in = new ByteArrayInputStream(header);
-        int columns = BinaryStreamUtils.readVarInt(in);
+        int columns = readVarInt(in);
         List<String> names = new ArrayList<>();
         List<String> types = new ArrayList<>();
         for (int i = 0; i < columns; i++) {
-            names.add(BinaryStreamReader.readString(in));
+            names.add(readString(in));
         }
         for (int i = 0; i < columns; i++) {
-            types.add(BinaryStreamReader.readString(in));
+            types.add(readString(in));
         }
         return new HeaderContents(names, types);
     }
@@ -265,5 +266,13 @@ class TableTest extends ClickHouseBase {
         Column stringColumn = tuple.getTupleFields().get(0).getTupleFields().get(0).getTupleFields().get(0);
         assertEquals("tuple.tuple.tuple.string", stringColumn.getName());
         assertEquals(Type.STRING, stringColumn.getType());
+    }
+
+    private static int readVarInt(InputStream in) throws IOException {
+        return BinaryStreamReader.readVarInt(in);
+    }
+
+    private static String readString(InputStream in) throws IOException {
+        return BinaryStreamReader.readString(in);
     }
 }

--- a/src/testFixtures/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseTestHelpers.java
+++ b/src/testFixtures/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseTestHelpers.java
@@ -401,6 +401,7 @@ public class ClickHouseTestHelpers {
                 .setRetry(csc.getRetry())
                 .useClientV2("V2".equals(csc.getClientVersion()))
                 .setSslSocketSni(csc.getSslSocketSni())
+                .useRowBinaryWithNamesAndTypes(csc.isUseRowBinaryWithNamesAndTypes())
                 .build();
     }
 


### PR DESCRIPTION
## Summary
Adds support for `RowBinaryWithNamesAndTypes` to address issue inserting data and target table was altered. 

This format may be used to resolve issue with schema mismatch by sending only fields in SinkRecord schema. 
The main problem occurs when new field is added to table but old event should be written. `RowBinaryWithDefaults` solved this issue by setting "use default" flag before potential value. `RowBinaryWithNamesAndTypes` cannot do that and we have to compile header for each SinkRecord batch. 

This creates another problem when different versions of schema. 


Closes: https://github.com/ClickHouse/clickhouse-kafka-connect/issues/782

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
