### PR TITLE
benchmark: register nightly dispatch + fix images OIDC wiring; add ch_version covariate

### DIFF
--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -24,6 +24,14 @@
 name: Benchmark v2 nightly pair
 
 on:
+  # REGISTRATION TRIGGER (mirrors benchmark-images.yml): GitHub only exposes
+  # workflow_dispatch for a workflow that exists on the default branch OR has at
+  # least one run. This workflow lives on a feature branch, so a push touching
+  # THIS file creates a (skipped — see the per-job `if`) run that registers it
+  # for dispatch. Without this, `gh workflow run benchmark-nightly.yml` 404s.
+  push:
+    branches: [benchmark-v2-consolidated]
+    paths: [".github/workflows/benchmark-nightly.yml"]
   schedule:
     # 04:15 UTC nightly (placeholder; align cadence with the Spark benchmark).
     - cron: '15 4 * * *'
@@ -35,15 +43,25 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write   # benchmark-images.yml pushes to GHCR
+  packages: read    # (legacy GHCR read; images now push to ECR via OIDC)
+  id-token: write   # REQUIRED so the reusable benchmark-images.yml can mint an
+                    # OIDC token for AssumeRoleWithWebIdentity -> ECR. Top-level
+                    # so the `images:` reusable-workflow job inherits it; run-pair
+                    # re-declares its own permissions block below.
 
 jobs:
   # Build both arm images (head + pinned) and export their refs.
   images:
+    # push events exist only to register the workflow for dispatch — skip then.
+    if: github.event_name != 'push'
     uses: ./.github/workflows/benchmark-images.yml
+    # Pass repo secrets (CLICKBENCH_AWS_ROLE_ARN + GITHUB_TOKEN) into the
+    # reusable workflow; without this its OIDC step assumes an EMPTY role ARN.
+    secrets: inherit
 
   run-pair:
     needs: images
+    if: github.event_name != 'push'
     runs-on: ubuntu-22.04
     permissions:
       id-token: write   # AWS OIDC (mirror the Spark CI pattern)

--- a/benchmarks/e2e/infra/README.md
+++ b/benchmarks/e2e/infra/README.md
@@ -201,10 +201,17 @@ long-lived keys), then reads run config from GitHub secrets. Mirror that here:
   | Secret | Use |
   |---|---|
   | `KAFKA_BENCH_AWS_ROLE_ARN` | OIDC role the CI job assumes (region us-east-2) |
-  | `KAFKA_BENCH_TARGET_CH_HOST` | dedicated Cloud target host -> `TARGET_CH_HOST` |
-  | `KAFKA_BENCH_TARGET_CH_USER` | -> `TARGET_CH_USER` |
-  | `KAFKA_BENCH_TARGET_CH_PASSWORD` | -> `TARGET_CH_PASSWORD` |
-  | `KAFKA_BENCH_METRICS_CH_HOST` / `_USER` / `_PASSWORD` | `perf.*` metrics landing (shared DWH pipeline) |
+  | `KAFKA_TARGET_CH_HOST` | dedicated Cloud target host -> `TARGET_CH_HOST` |
+  | `KAFKA_TARGET_CH_USER` | -> `TARGET_CH_USER` |
+  | `KAFKA_TARGET_CH_PASSWORD` | -> `TARGET_CH_PASSWORD` |
+  | `KAFKA_METRICS_CH_HOST` / `_USER` / `_PASSWORD` | `perf.*` metrics landing (shared DWH pipeline) |
+
+  > **Secret-prefix note:** the CH-credential secrets use the bare `KAFKA_`
+  > prefix (`KAFKA_TARGET_CH_*` / `KAFKA_METRICS_CH_*`), matching `sql/README.md`
+  > and the names `benchmark-nightly.yml` actually consumes. Only the AWS OIDC
+  > role keeps the `KAFKA_BENCH_` prefix (`KAFKA_BENCH_AWS_ROLE_ARN`). Earlier
+  > drafts of this table used `KAFKA_BENCH_TARGET_CH_*` — that spelling is wrong;
+  > the workflow pins the `sql/README.md` spelling as the single source of truth.
 
   CH connection values are injected as env at run time and **never committed**.
 - The role and secrets are provisioned once (out of band, like the Spark CI

--- a/benchmarks/e2e/sql/bootstrap/02_additional_capture_grants.sql
+++ b/benchmarks/e2e/sql/bootstrap/02_additional_capture_grants.sql
@@ -28,3 +28,8 @@
 GRANT SELECT ON system.merge_tree_settings TO kafka_benchmark;
 GRANT SELECT ON system.asynchronous_metrics TO kafka_benchmark;
 GRANT SELECT ON system.merges TO kafka_benchmark;
+
+-- Added for task #54 (ch_version covariate): 21_pre_run_covariates.sql also reads
+-- system.build_options.VERSION_INTEGER via remoteSecure to record the target's
+-- ClickHouse version as a numeric covariate.
+GRANT SELECT ON system.build_options TO kafka_benchmark;

--- a/benchmarks/e2e/sql/capture/21_pre_run_covariates.sql
+++ b/benchmarks/e2e/sql/capture/21_pre_run_covariates.sql
@@ -45,4 +45,14 @@ SELECT {run_id:String} AS run_id, metric_name, unit, value FROM (
          toFloat64(count())
   FROM remoteSecure({target_addr:String}, system.parts, {target_user:String}, {target_password:String})
   WHERE database = {ch_database:String} AND table = {ch_table:String} AND active
+  UNION ALL
+  -- Server version as a numeric covariate (task #54): a Cloud upgrade can shift
+  -- Tier-1 cost WITHOUT a restart, so ch_uptime alone cannot flag it.
+  -- system.build_options.VERSION_INTEGER is monotonic and already numeric
+  -- (e.g. 24.8.1 -> 24008001), round-tripping cleanly through the Float64 column.
+  -- Needs GRANT SELECT ON system.build_options (see 02_additional_capture_grants.sql).
+  SELECT 'ch_version', 'version_int',
+         toFloat64(toUInt64OrZero(coalesce(any(value), '0')))
+  FROM remoteSecure({target_addr:String}, system.build_options, {target_user:String}, {target_password:String})
+  WHERE name = 'VERSION_INTEGER'
 );


### PR DESCRIPTION
Bundles three benchmark-v2 prep fixes so the nightly can be dispatched and can authenticate (tasks #53, #47, #54). Does **not** remove the human-gated blockers to a first live run (IAM change, secret values, EKS/CH provisioning) — it makes the workflow dispatchable and able to build images.

## Nightly workflow can now dispatch + authenticate (#53)
- Adds a `push`-register trigger scoped to `benchmark-v2-consolidated` so `workflow_dispatch` becomes available (GitHub only registers dispatch once a workflow is on the default branch or has run once). The registering commit is a no-op via `if: github.event_name != 'push'` job guards.
- Adds top-level `id-token: write` and `secrets: inherit` on the reusable `images` job, so the OIDC->ECR build can mint a token and see `CLICKBENCH_AWS_ROLE_ARN` (both were missing, so the job could not authenticate).

## Secret-name reconcile (#47)
- `benchmarks/e2e/infra/README.md` now matches the secret names the workflow actually consumes (`KAFKA_TARGET_CH_*` / `KAFKA_METRICS_CH_*`).

## ch_version covariate (#54)
- `21_pre_run_covariates.sql` records `ch_version` from `system.build_options.VERSION_INTEGER` (numeric, monotonic) via `remoteSecure`, so a Cloud version upgrade that shifts Tier-1 cost **without** a restart becomes a filterable fact (`ch_uptime` only catches restarts).
- `02_additional_capture_grants.sql` adds the matching `GRANT SELECT ON system.build_options`.

**Validate before merge:** confirm `VERSION_INTEGER` exists in `system.build_options` on the target's ClickHouse version, and that the new grant is applied on the live service; otherwise fall back to parsing `version()`.
