### PR TITLE
Add retryOnSocketException to retry SocketException in handleException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # 1.5.1 (not published)
 
+## Improvements
+
+* New `retryOnSocketException` setting (default `false`). When enabled, a `java.net.SocketException` (broken pipe,
+  connection reset) from the ClickHouse client is retried like the existing timeout cases instead of failing the
+  task. With client V2's persistent connections a single server-side connection reset otherwise fails every task at once.
+
 ## Bug Fixes
 
-* `java.net.SocketException` (broken pipe, connection reset) from the ClickHouse client is now retried like the
-  existing timeout cases instead of failing the task. With client V2's persistent connections a single server-side
-  connection reset otherwise fails every task at once.
 * With client V2, server errors arrive as `com.clickhouse.client.api.ServerException` rather than the V1
   `ClickHouseException`, so the retriable error-code list in `Utils.handleException` never matched and tasks
   failed instead of retrying. Both exception types now share the same list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.5.1 (not published)
+
+## Bug Fixes
+
+* `java.net.SocketException` (broken pipe, connection reset) from the ClickHouse client is now retried like the
+  existing timeout cases instead of failing the task. With client V2's persistent connections a single server-side
+  connection reset otherwise fails every task at once.
+
 # 1.5.0, 2026-08-05
 
 ## Improvements

--- a/src/main/java/com/clickhouse/kafka/connect/sink/ChunkFlusher.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ChunkFlusher.java
@@ -68,7 +68,8 @@ final class ChunkFlusher {
         } catch (Exception e) {
             LOGGER.trace("Passing the exception to the exception handler.");
             boolean errorTolerance = clickHouseSinkConfig != null && clickHouseSinkConfig.isErrorsTolerance();
-            Utils.handleException(e, errorTolerance, records);
+            boolean retryOnSocketException = clickHouseSinkConfig != null && clickHouseSinkConfig.isRetryOnSocketException();
+            Utils.handleException(e, errorTolerance, retryOnSocketException, records);
             if (errorTolerance && errorReporter != null) {
                 LOGGER.warn("Sending [{}] records to DLQ for exception: {}", records.size(), e.getLocalizedMessage());
                 records.forEach(r -> Utils.sendTODlq(errorReporter, r, e));

--- a/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
@@ -36,6 +36,7 @@ public class ClickHouseSinkConfig {
     public static final String CLICKHOUSE_SETTINGS = "clickhouseSettings";
     public static final String TABLE_MAPPING = "topic2TableMap";
     public static final String ERRORS_TOLERANCE = "errors.tolerance";
+    public static final String RETRY_ON_SOCKET_EXCEPTION = "retryOnSocketException";
     public static final String TABLE_REFRESH_INTERVAL = "tableRefreshInterval";
     public static final String CUSTOM_INSERT_FORMAT_ENABLE = "customInsertFormat";
     public static final String INSERT_FORMAT = "insertFormat";
@@ -98,6 +99,7 @@ public class ClickHouseSinkConfig {
     private final long tableRefreshInterval;
     private final boolean suppressTableExistenceException;
     private final boolean errorsTolerance;
+    private final boolean retryOnSocketException;
     private final Map<String, String> clickhouseSettings;
     private final Map<String, String> topicToTableMap;
     private final ClickHouseProxyType proxyType;
@@ -216,6 +218,7 @@ public class ClickHouseSinkConfig {
 
         String errorsToleranceString = props.getOrDefault(ERRORS_TOLERANCE, ERROR_TOLERANCE_NONE).trim();
         errorsTolerance = errorsToleranceString.equalsIgnoreCase(ERROR_TOLERANCE_ALL);
+        retryOnSocketException = Boolean.parseBoolean(props.getOrDefault(RETRY_ON_SOCKET_EXCEPTION, "false"));
 
         Map<String, String> clickhouseSettings = new HashMap<>();
         String clickhouseSettingsString = props.getOrDefault("clickhouseSettings", "").trim();
@@ -512,6 +515,15 @@ public class ClickHouseSinkConfig {
                 ++orderInGroup,
                 ConfigDef.Width.SHORT,
                 "Tolerate errors.");
+        configDef.define(RETRY_ON_SOCKET_EXCEPTION,
+                ConfigDef.Type.BOOLEAN,
+                false,
+                ConfigDef.Importance.LOW,
+                "Retry the batch when the ClickHouse client fails with a java.net.SocketException (connection reset, broken pipe, connection refused) instead of failing the task. The task keeps retrying while the condition persists. default: false",
+                group,
+                ++orderInGroup,
+                ConfigDef.Width.SHORT,
+                "Retry on socket exception.");
         configDef.define(CUSTOM_INSERT_FORMAT_ENABLE,
                 ConfigDef.Type.BOOLEAN,
                 customInsertFormatDefault,

--- a/src/main/java/com/clickhouse/kafka/connect/sink/ProxySinkTask.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ProxySinkTask.java
@@ -98,7 +98,7 @@ public final class ProxySinkTask {
                 processing.doLogic(rec);
             } catch (Exception e) {
                 boolean errorTolerance = clickHouseSinkConfig.isErrorsTolerance();
-                Utils.handleException(e, errorTolerance, records); // This will throw RetriableException and failed records will be retried. No need to continue with the next topic & partition
+                Utils.handleException(e, errorTolerance, clickHouseSinkConfig.isRetryOnSocketException(), records); // This will throw RetriableException and failed records will be retried. No need to continue with the next topic & partition
                 if (errorTolerance) {
                     failedMessages.add(new Utils.FailedRecords(rec, e));
                     statistics.sentToDLQ(rec.size());

--- a/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
+++ b/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
@@ -69,7 +69,7 @@ public class Utils {
      * @param e Exception to check
      */
 
-    public static void handleException(Exception e, boolean errorsTolerance, Collection<SinkRecord> records) {
+    public static void handleException(Exception e, boolean errorsTolerance, boolean retryOnSocketException, Collection<SinkRecord> records) {
         LOGGER.warn("Deciding how to handle exception: {}", e.getLocalizedMessage());
 
         //Let's check if we have a ClickHouseException to reference the error code
@@ -116,7 +116,7 @@ public class Utils {
         } else if (rootCause instanceof UnknownHostException) {
             LOGGER.warn("UnknownHostException thrown, wrapping exception: {}", e.getLocalizedMessage());
             throw new RetriableException(e);
-        } else if (rootCause instanceof SocketException) {
+        } else if (retryOnSocketException && rootCause instanceof SocketException) {
             LOGGER.warn("SocketException thrown, wrapping exception: {}", e.getLocalizedMessage());
             throw new RetriableException(e);
         } else if (rootCause instanceof IOException) {

--- a/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
+++ b/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -107,6 +108,9 @@ public class Utils {
             throw new RetriableException(e);
         } else if (rootCause instanceof UnknownHostException) {
             LOGGER.warn("UnknownHostException thrown, wrapping exception: {}", e.getLocalizedMessage());
+            throw new RetriableException(e);
+        } else if (rootCause instanceof SocketException) {
+            LOGGER.warn("SocketException thrown, wrapping exception: {}", e.getLocalizedMessage());
             throw new RetriableException(e);
         } else if (rootCause instanceof IOException) {
             final String msg = rootCause.getMessage();

--- a/src/test/java/com/clickhouse/kafka/connect/sink/util/UtilsTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/util/UtilsTest.java
@@ -1,6 +1,7 @@
 package com.clickhouse.kafka.connect.sink.util;
 
 import com.clickhouse.client.ClickHouseException;
+import com.clickhouse.client.api.DataTransferException;
 import com.clickhouse.kafka.connect.sink.db.mapping.Column;
 import com.clickhouse.kafka.connect.sink.db.mapping.Table;
 import com.clickhouse.kafka.connect.util.Utils;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,6 +52,15 @@ public class UtilsTest {
         assertThrows(RetriableException.class, () -> {
             Exception timeout = new IOException("Write timed out after 30000 ms");
             Utils.handleException(timeout, false, new ArrayList<>());
+        });
+    }
+
+    @Test
+    @DisplayName("Test SocketException Throw Cause")
+    public void TestSocketExceptionCause() {
+        assertThrows(RetriableException.class, () -> {
+            Exception brokenPipe = new RuntimeException(new DataTransferException("Insert failed", new SocketException("Broken pipe")));
+            Utils.handleException(brokenPipe, false, new ArrayList<>());
         });
     }
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/util/UtilsTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/util/UtilsTest.java
@@ -52,17 +52,27 @@ public class UtilsTest {
     public void TestClickHouseClientTimeoutCause(){
         assertThrows(RetriableException.class, () -> {
             Exception timeout = new IOException("Write timed out after 30000 ms");
-            Utils.handleException(timeout, false, new ArrayList<>());
+            Utils.handleException(timeout, false, false, new ArrayList<>());
         });
     }
 
     @Test
-    @DisplayName("Test SocketException Throw Cause")
-    public void TestSocketExceptionCause() {
+    @DisplayName("Test SocketException retried when enabled")
+    public void TestSocketExceptionRetriedWhenEnabled() {
         assertThrows(RetriableException.class, () -> {
             Exception brokenPipe = new RuntimeException(new DataTransferException("Insert failed", new SocketException("Broken pipe")));
-            Utils.handleException(brokenPipe, false, new ArrayList<>());
+            Utils.handleException(brokenPipe, false, true, new ArrayList<>());
         });
+    }
+
+    @Test
+    @DisplayName("Test SocketException not retried by default")
+    public void TestSocketExceptionNotRetriedByDefault() {
+        RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
+            Exception brokenPipe = new RuntimeException(new DataTransferException("Insert failed", new SocketException("Broken pipe")));
+            Utils.handleException(brokenPipe, false, false, new ArrayList<>());
+        });
+        assertFalse(thrown instanceof RetriableException);
     }
 
     @DisplayName("Test client V2 ServerException Root Cause")
@@ -77,7 +87,7 @@ public class UtilsTest {
     public void TestServerExceptionRetriableCode() {
         assertThrows(RetriableException.class, () -> {
             Exception e = new RuntimeException(new ServerException(252, "Too many parts", 500));
-            Utils.handleException(e, false, new ArrayList<>());
+            Utils.handleException(e, false, false, new ArrayList<>());
         });
     }
 
@@ -86,7 +96,7 @@ public class UtilsTest {
     public void TestServerExceptionNonRetriableCode() {
         RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
             Exception e = new RuntimeException(new ServerException(60, "Table does not exist", 404));
-            Utils.handleException(e, false, new ArrayList<>());
+            Utils.handleException(e, false, false, new ArrayList<>());
         });
         assertFalse(thrown instanceof RetriableException);
     }


### PR DESCRIPTION
## Summary
A `java.net.SocketException` (broken pipe, connection reset) from the ClickHouse client is currently non-retriable in `Utils.handleException`: it isn't a `SocketTimeoutException` and its message doesn't start with "Read/Write timed out after", so with `errors.tolerance=none` the task is killed, and with `errors.tolerance=all` the batch is dropped.

This adds a `retryOnSocketException` setting (default `false`, preserving current behavior). When enabled, `SocketException` is treated like the existing timeout cases and throws `RetriableException`, letting the Connect framework redeliver the batch with backoff. It matters more with `client_version=V2`: the pooled, persistent connections mean a single server-side connection reset (replica restart, upgrade, scale event) surfaces as a broken pipe on every task's next insert at once. Observed with v1.5.0 on ClickHouse Cloud: 55 tasks across two connectors failed within seconds on

```
com.clickhouse.client.api.DataTransferException: Insert failed (Attempt: 1/4 ...)
Caused by: java.net.SocketException: Broken pipe
    at ...ChunkedOutputStream.write
    at ...ClickHouseWriter.writeRecordsJson
```

The client's own retry loop does not cover this fault (`HttpAPIClientHelper.shouldRetry` only matches no-response, connect/pool timeouts and server-retryable codes), so the connector is the right place for it.

Retry safety: a broken pipe during the request body means the server never received a complete insert, so nothing was applied. A reset while reading the response has the same ambiguity as the already-retried read timeout and code 319 (`UNKNOWN_STATUS_OF_INSERT`), covered by the same `insert_deduplication_token` the connector sets on every insert.

Related: #455 and #587 ask for a configurable retriable list; this adds one opt-in case and doesn't preclude that.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
