### PR TITLE
Apply the retriable error-code list to client V2 ServerException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.5.1 (not published)
+
+## Bug Fixes
+
+* With client V2, server errors arrive as `com.clickhouse.client.api.ServerException` rather than the V1
+  `ClickHouseException`, so the retriable error-code list in `Utils.handleException` never matched and tasks
+  failed instead of retrying. Both exception types now share the same list.
+
 # 1.5.0, 2026-08-05
 
 ## Improvements

--- a/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
+++ b/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
@@ -1,6 +1,7 @@
 package com.clickhouse.kafka.connect.util;
 
 import com.clickhouse.client.ClickHouseException;
+import com.clickhouse.client.api.ServerException;
 import com.clickhouse.kafka.connect.sink.data.Record;
 import com.clickhouse.kafka.connect.sink.db.mapping.Column;
 import com.clickhouse.kafka.connect.sink.db.mapping.Table;
@@ -37,10 +38,10 @@ public class Utils {
     }
 
     /**
-     * This will drill down to the first ClickHouseException in the exception chain
+     * This will drill down to the first ClickHouse server exception (client V1 or V2) in the exception chain
      *
      * @param e Exception to drill down
-     * @return ClickHouseException or null if none found
+     * @return the server exception, otherwise the deepest cause, or null if none found
      */
     public static Exception getRootCause(Exception e, Boolean prioritizeClickHouseException) {
         if (e == null)
@@ -48,12 +49,20 @@ public class Utils {
 
         Throwable runningException = e;//We have to use Throwable because of the getCause() signature
         while (runningException.getCause() != null &&
-                (!prioritizeClickHouseException || !(runningException instanceof ClickHouseException))) {
+                (!prioritizeClickHouseException || !isServerError(runningException))) {
             LOGGER.trace("Found exception: {}", runningException.getLocalizedMessage());
             runningException = runningException.getCause();
         }
 
         return runningException instanceof Exception ? (Exception) runningException : null;
+    }
+
+    private static boolean isServerError(Throwable t) {
+        return t instanceof ClickHouseException || t instanceof ServerException;
+    }
+
+    private static int getServerErrorCode(Throwable t) {
+        return t instanceof ServerException ? ((ServerException) t).getCode() : ((ClickHouseException) t).getErrorCode();
     }
 
 
@@ -69,10 +78,10 @@ public class Utils {
         //Let's check if we have a ClickHouseException to reference the error code
         //https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ErrorCodes.cpp
         Exception rootCause = Utils.getRootCause(e, true);
-        if (rootCause instanceof ClickHouseException) {
-            ClickHouseException clickHouseException = (ClickHouseException) rootCause;
-            LOGGER.warn("ClickHouseException code: {}", clickHouseException.getErrorCode());
-            switch (clickHouseException.getErrorCode()) {
+        if (isServerError(rootCause)) {
+            int errorCode = getServerErrorCode(rootCause);
+            LOGGER.warn("ClickHouse server error code: {}", errorCode);
+            switch (errorCode) {
                 case 3: // UNEXPECTED_END_OF_FILE
                 case 107: // FILE_DOESNT_EXIST
                 case 159: // TIMEOUT_EXCEEDED
@@ -90,7 +99,7 @@ public class Utils {
                 case 999: // KEEPER_EXCEPTION
                     throw new RetriableException(e);
                 default:
-                    LOGGER.error("Error code [{}] wasn't in the acceptable list.", clickHouseException.getErrorCode());
+                    LOGGER.error("Error code [{}] wasn't in the acceptable list.", errorCode);
                     break;
             }
         }

--- a/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
+++ b/src/main/java/com/clickhouse/kafka/connect/util/Utils.java
@@ -61,10 +61,6 @@ public class Utils {
         return t instanceof ClickHouseException || t instanceof ServerException;
     }
 
-    private static int getServerErrorCode(Throwable t) {
-        return t instanceof ServerException ? ((ServerException) t).getCode() : ((ClickHouseException) t).getErrorCode();
-    }
-
 
     /**
      * This method checks to see if we should retry, otherwise it just throws the exception again
@@ -79,7 +75,9 @@ public class Utils {
         //https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ErrorCodes.cpp
         Exception rootCause = Utils.getRootCause(e, true);
         if (isServerError(rootCause)) {
-            int errorCode = getServerErrorCode(rootCause);
+            int errorCode = rootCause instanceof ServerException
+                    ? ((ServerException) rootCause).getCode()
+                    : ((ClickHouseException) rootCause).getErrorCode();
             LOGGER.warn("ClickHouse server error code: {}", errorCode);
             switch (errorCode) {
                 case 3: // UNEXPECTED_END_OF_FILE

--- a/src/test/java/com/clickhouse/kafka/connect/sink/util/UtilsTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/util/UtilsTest.java
@@ -1,6 +1,7 @@
 package com.clickhouse.kafka.connect.sink.util;
 
 import com.clickhouse.client.ClickHouseException;
+import com.clickhouse.client.api.ServerException;
 import com.clickhouse.kafka.connect.sink.db.mapping.Column;
 import com.clickhouse.kafka.connect.sink.db.mapping.Table;
 import com.clickhouse.kafka.connect.util.Utils;
@@ -51,6 +52,33 @@ public class UtilsTest {
             Exception timeout = new IOException("Write timed out after 30000 ms");
             Utils.handleException(timeout, false, new ArrayList<>());
         });
+    }
+
+    @Test
+    @DisplayName("Test client V2 ServerException Root Cause")
+    public void TestServerExceptionRootCause() {
+        Exception e1 = new ServerException(252, "Too many parts", 500);
+        Exception e2 = new RuntimeException(new RuntimeException(e1));
+        assertEquals(e1, Utils.getRootCause(e2, true));
+    }
+
+    @Test
+    @DisplayName("Test client V2 ServerException retriable code")
+    public void TestServerExceptionRetriableCode() {
+        assertThrows(RetriableException.class, () -> {
+            Exception e = new RuntimeException(new ServerException(252, "Too many parts", 500));
+            Utils.handleException(e, false, new ArrayList<>());
+        });
+    }
+
+    @Test
+    @DisplayName("Test client V2 ServerException non-retriable code")
+    public void TestServerExceptionNonRetriableCode() {
+        RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
+            Exception e = new RuntimeException(new ServerException(60, "Table does not exist", 404));
+            Utils.handleException(e, false, new ArrayList<>());
+        });
+        assertFalse(thrown instanceof RetriableException);
     }
 
     private static Table tableWith(String tableName, String[]... colSpecs) {


### PR DESCRIPTION
## Summary
Fixes #818.

`Utils.handleException` decides whether a ClickHouse server error code is retriable by checking `rootCause instanceof com.clickhouse.client.ClickHouseException`, the client V1 exception. With `client_version=V2` the server error arrives as `com.clickhouse.client.api.ServerException`, which extends a different `ClickHouseException` (`com.clickhouse.client.api`), so the check never matches: `getRootCause(e, true)` walks past it to the deepest cause and the error-code switch is skipped. The result is that every code in the retriable list (`TOO_MANY_PARTS`, `MEMORY_LIMIT_EXCEEDED`, `KEEPER_EXCEPTION`, ...) fails the task with `errors.tolerance=none`, or drops the batch with `errors.tolerance=all`, once client-v2's few immediate in-process attempts are exhausted. V1 throws `RetriableException` and lets the Connect framework back off.

This makes `getRootCause` stop on either exception type and normalizes the code (`getErrorCode()` for V1, `getCode()` for V2) before the existing switch, so the connector keeps a single retriable list and V1 and V2 behave identically. No change for V1.

Tests cover root-cause resolution, a retriable code (252) and a non-retriable code (60) through `ServerException`.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
