### PR TITLE
[Data] Conversion of number types to wider ones. 

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -1,13 +1,6 @@
 package com.clickhouse.kafka.connect.sink.db;
 
-import com.clickhouse.client.ClickHouseClient;
-import com.clickhouse.client.ClickHouseConfig;
-import com.clickhouse.client.ClickHouseNode;
-import com.clickhouse.client.ClickHouseNodeSelector;
-import com.clickhouse.client.ClickHouseProtocol;
-import com.clickhouse.client.ClickHouseRequest;
-import com.clickhouse.client.ClickHouseResponse;
-import com.clickhouse.client.ClickHouseResponseSummary;
+import com.clickhouse.client.*;
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.DataStreamWriter;
 import com.clickhouse.client.api.ServerException;
@@ -48,25 +41,8 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.*;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -253,7 +229,37 @@ public class ClickHouseWriter implements DBWriter {
         }
     }
 
-    private static final Set<String> INT_TYPES = Set.of("INT8", "INT16", "INT32", "INT64", "UINT8", "UINT16", "UINT32", "UINT64");
+    private static final Map<Type, Integer> CLICKHOUSE_TYPE_BIT_WIDTHS;
+    static {
+        Map<Type, Integer> map = new EnumMap<>(Type.class);
+        map.put(Type.INT8, 8);
+        map.put(Type.UINT8, 8);
+        map.put(Type.Enum8, 8);
+        map.put(Type.INT16, 16);
+        map.put(Type.UINT16, 16);
+        map.put(Type.Enum16, 16);
+        map.put(Type.INT32, 32);
+        map.put(Type.UINT32, 32);
+        map.put(Type.FLOAT32, 32);
+        map.put(Type.INT64, 64);
+        map.put(Type.UINT64, 64);
+        map.put(Type.FLOAT64, 64);
+        map.put(Type.INT128, 128);
+        map.put(Type.UINT128, 128);
+        CLICKHOUSE_TYPE_BIT_WIDTHS = Collections.unmodifiableMap(map);
+    }
+
+    private static final Map<Schema.Type, Integer> KAFKA_SCHEMA_TYPE_BIT_WIDTHS;
+    static {
+        Map<Schema.Type, Integer> map = new EnumMap<>(Schema.Type.class);
+        map.put(Schema.Type.INT8, 8);
+        map.put(Schema.Type.INT16, 16);
+        map.put(Schema.Type.INT32, 32);
+        map.put(Schema.Type.INT64, 64);
+        map.put(Schema.Type.FLOAT32, 32);
+        map.put(Schema.Type.FLOAT64, 64);
+        KAFKA_SCHEMA_TYPE_BIT_WIDTHS = Collections.unmodifiableMap(map);
+    }
 
     protected boolean validateDataSchema(Table table, Record record, boolean onlyFieldsName) {
         boolean validSchema = true;
@@ -312,15 +318,26 @@ public class ClickHouseWriter implements DBWriter {
                                 if (colTypeName.equals("VARIANT") && dataTypeName.equals("STRUCT"))
                                     continue;
 
-                                if (INT_TYPES.contains(colTypeName)) {
+                                // Check numeric types
+                                Integer colWidth = CLICKHOUSE_TYPE_BIT_WIDTHS.get(type);
+                                Integer dataWidth = KAFKA_SCHEMA_TYPE_BIT_WIDTHS.get(obj.getFieldType());
+
+                                boolean isDataFloat = obj.getFieldType() == Schema.Type.FLOAT32 || obj.getFieldType() == Schema.Type.FLOAT64;
+                                boolean isColFloat = type == Type.FLOAT32 || type == Type.FLOAT64;
+
+                                if (isDataFloat && !isColFloat) {
+                                    // Float data cannot be written to non-float column
+                                } else if (colWidth != null && dataWidth != null && dataWidth <= colWidth) {
                                     continue;
                                 }
 
-                                if (colTypeName.equalsIgnoreCase("BOOLEAN") &&
-                                        INT_TYPES.contains(dataTypeName.toUpperCase())) {
+                                boolean isColNumeric = colWidth != null;
+                                boolean isDataNumeric = dataWidth != null;
+                                if ((type == Type.BOOLEAN && isDataNumeric) || (isColNumeric && obj.getFieldType() == Schema.Type.BOOLEAN)) {
                                     continue;
                                 }
 
+                                // Check decimal types
                                 if (("DECIMAL".equalsIgnoreCase(colTypeName) && "org.apache.kafka.connect.data.Decimal".equals(objSchema.name())))
                                     continue;
 
@@ -726,10 +743,10 @@ public class ClickHouseWriter implements DBWriter {
         } else {
             switch (columnType) {
                 case INT8:
-                    BinaryStreamUtils.writeInt8(stream, (Byte) value);
+                    BinaryStreamUtils.writeInt8(stream, ((Number) value).byteValue());
                     break;
                 case INT16:
-                    BinaryStreamUtils.writeInt16(stream, (Short) value);
+                    BinaryStreamUtils.writeInt16(stream, ((Number) value).shortValue());
                     break;
                 case INT32:
                     if (value.getClass().getName().endsWith(".Date")) {
@@ -737,7 +754,7 @@ public class ClickHouseWriter implements DBWriter {
                         int time = (int) date.getTime();
                         BinaryStreamUtils.writeInt32(stream, time);
                     } else {
-                        BinaryStreamUtils.writeInt32(stream, (Integer) value);
+                        BinaryStreamUtils.writeInt32(stream, ((Number) value).intValue());
                     }
                     break;
                 case DateTime64:
@@ -747,26 +764,26 @@ public class ClickHouseWriter implements DBWriter {
                         long time = date.getTime();
                         BinaryStreamUtils.writeInt64(stream, time);
                     } else {
-                        BinaryStreamUtils.writeInt64(stream, (Long) value);
+                        BinaryStreamUtils.writeInt64(stream, ((Number) value).longValue());
                     }
                     break;
                 case UINT8:
-                    BinaryStreamUtils.writeUnsignedInt8(stream, (Byte) value);
+                    BinaryStreamUtils.writeUnsignedInt8(stream, Byte.toUnsignedInt(((Number) value).byteValue()));
                     break;
                 case UINT16:
-                    BinaryStreamUtils.writeUnsignedInt16(stream, ((Number) value).shortValue());
+                    BinaryStreamUtils.writeUnsignedInt16(stream, Short.toUnsignedInt(((Number) value).shortValue()));
                     break;
                 case UINT32:
-                    BinaryStreamUtils.writeUnsignedInt32(stream, ((Number) value).intValue());
+                    BinaryStreamUtils.writeUnsignedInt32(stream, Integer.toUnsignedLong(((Number) value).intValue()));
                     break;
                 case UINT64:
                     BinaryStreamUtils.writeUnsignedInt64(stream, ((Number) value).longValue());
                     break;
                 case FLOAT32:
-                    BinaryStreamUtils.writeFloat32(stream, (Float) value);
+                    BinaryStreamUtils.writeFloat32(stream, ((Number) value).floatValue());
                     break;
                 case FLOAT64:
-                    BinaryStreamUtils.writeFloat64(stream, (Double) value);
+                    BinaryStreamUtils.writeFloat64(stream, ((Number) value).doubleValue());
                     break;
                 case BOOLEAN:
                     if (value instanceof Number) {

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
@@ -1875,32 +1875,45 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         ClickHouseTestHelpers.dropTable(chc, topic);
     }
 
-    @Test
-    public void testInt32ToInt64ConversionWithConnectSchema() throws Exception {
-        String topic = createTopicName("test_int32_to_int64_connect");
+    private static Stream<Arguments> integerTypesConnectSchemaProvider() {
+        List<Arguments> args = new ArrayList<>();
+        List<String> targetTypes = List.of("Int64", "Int128");
+        for (String targetType : targetTypes) {
+            args.add(Arguments.of("INT8_to_" + targetType, Schema.INT8_SCHEMA, (byte) 12, (byte) 34, Arrays.asList((byte) 100, (byte) 110, (byte) 120), targetType));
+            args.add(Arguments.of("INT16_to_" + targetType, Schema.INT16_SCHEMA, (short) 1234, (short) 5678, Arrays.asList((short) 100, (short) 200, (short) 300), targetType));
+            args.add(Arguments.of("INT32_to_" + targetType, Schema.INT32_SCHEMA, 12345, 67890, Arrays.asList(100, 200, 300), targetType));
+            args.add(Arguments.of("INT64_to_" + targetType, Schema.INT64_SCHEMA, 123456789L, 987654321L, Arrays.asList(100L, 200L, 300L), targetType));
+        }
+        return args.stream();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("integerTypesConnectSchemaProvider")
+    public void testInt32ToInt64ConversionWithConnectSchema(String name, Schema fieldSchema, Object idVal, Object val, List<?> arrVal, String targetType) throws Exception {
+        String topic = createTopicName("test_" + name.toLowerCase() + "_connect");
         Map<String, String> props = getBaseProps();
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         ClickHouseTestHelpers.dropTable(chc, topic);
 
         new CreateTableStatement()
                 .tableName(topic)
-                .column("id", "Int64")
-                .column("val_int32", "Int64")
-                .column("arr_int32", "Array(Int64)")
+                .column("id", targetType)
+                .column("val_int32", targetType)
+                .column("arr_int32", "Array(" + targetType + ")")
                 .engine("MergeTree")
                 .orderByColumn("id")
                 .execute(chc);
 
         Schema schema = SchemaBuilder.struct()
-                .field("id", Schema.INT32_SCHEMA)
-                .field("val_int32", Schema.INT32_SCHEMA)
-                .field("arr_int32", SchemaBuilder.array(Schema.INT32_SCHEMA).build())
+                .field("id", fieldSchema)
+                .field("val_int32", fieldSchema)
+                .field("arr_int32", SchemaBuilder.array(fieldSchema).build())
                 .build();
 
         Struct struct = new Struct(schema)
-                .put("id", 12345)
-                .put("val_int32", 67890)
-                .put("arr_int32", Arrays.asList(100, 200, 300));
+                .put("id", idVal)
+                .put("val_int32", val)
+                .put("arr_int32", arrVal);
 
         SinkRecord record = new SinkRecord(topic, 0, null, null, schema, struct, 0);
 
@@ -1912,13 +1925,13 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
         List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic);
         assertEquals(1, rows.size());
         JSONObject row = rows.get(0);
-        assertEquals(12345L, row.getLong("id"));
-        assertEquals(67890L, row.getLong("val_int32"));
+        assertEquals(((Number) idVal).longValue(), row.getLong("id"));
+        assertEquals(((Number) val).longValue(), row.getLong("val_int32"));
         JSONArray arr = row.getJSONArray("arr_int32");
-        assertEquals(3, arr.length());
-        assertEquals(100, arr.getInt(0));
-        assertEquals(200, arr.getInt(1));
-        assertEquals(300, arr.getInt(2));
+        assertEquals(arrVal.size(), arr.length());
+        for (int i = 0; i < arrVal.size(); i++) {
+            assertEquals(((Number) arrVal.get(i)).longValue(), arr.getLong(i));
+        }
 
         ClickHouseTestHelpers.dropTable(chc, topic);
     }

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskWithSchemaTest.java
@@ -13,6 +13,8 @@ import com.clickhouse.kafka.connect.test.TestProtos;
 import com.clickhouse.kafka.connect.test.junit.extension.FromVersionConditionExtension;
 import com.clickhouse.kafka.connect.test.junit.extension.SinceClickHouseVersion;
 import com.clickhouse.kafka.connect.util.Utils;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.DynamicMessage;
 import io.confluent.connect.protobuf.ProtobufConverter;
 import io.confluent.connect.protobuf.ProtobufConverterConfig;
 import io.confluent.connect.protobuf.ProtobufDataConfig;
@@ -21,6 +23,8 @@ import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializerConfig;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
@@ -1868,6 +1872,178 @@ public class ClickHouseSinkTaskWithSchemaTest extends ClickHouseBase {
             assertEquals(formatter.format(event.getTime1()), row.get("time1"));
             assertEquals(event.getTime2().atDate(LocalDate.of(1970, 1, 1)).format(localFormatter), row.get("time2"));
         }
+        ClickHouseTestHelpers.dropTable(chc, topic);
+    }
+
+    @Test
+    public void testInt32ToInt64ConversionWithConnectSchema() throws Exception {
+        String topic = createTopicName("test_int32_to_int64_connect");
+        Map<String, String> props = getBaseProps();
+        ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
+        ClickHouseTestHelpers.dropTable(chc, topic);
+
+        new CreateTableStatement()
+                .tableName(topic)
+                .column("id", "Int64")
+                .column("val_int32", "Int64")
+                .column("arr_int32", "Array(Int64)")
+                .engine("MergeTree")
+                .orderByColumn("id")
+                .execute(chc);
+
+        Schema schema = SchemaBuilder.struct()
+                .field("id", Schema.INT32_SCHEMA)
+                .field("val_int32", Schema.INT32_SCHEMA)
+                .field("arr_int32", SchemaBuilder.array(Schema.INT32_SCHEMA).build())
+                .build();
+
+        Struct struct = new Struct(schema)
+                .put("id", 12345)
+                .put("val_int32", 67890)
+                .put("arr_int32", Arrays.asList(100, 200, 300));
+
+        SinkRecord record = new SinkRecord(topic, 0, null, null, schema, struct, 0);
+
+        ClickHouseSinkTask chst = new ClickHouseSinkTask();
+        chst.start(props);
+        chst.put(List.of(record));
+        chst.stop();
+
+        List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic);
+        assertEquals(1, rows.size());
+        JSONObject row = rows.get(0);
+        assertEquals(12345L, row.getLong("id"));
+        assertEquals(67890L, row.getLong("val_int32"));
+        JSONArray arr = row.getJSONArray("arr_int32");
+        assertEquals(3, arr.length());
+        assertEquals(100, arr.getInt(0));
+        assertEquals(200, arr.getInt(1));
+        assertEquals(300, arr.getInt(2));
+
+        ClickHouseTestHelpers.dropTable(chc, topic);
+    }
+
+    @Test
+    public void testInt32ToInt64ConversionWithAvro() throws Exception {
+        String topic = createTopicName("test_int32_to_int64_avro");
+        org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.record("Int32ToInt64Avro")
+                .namespace("com.clickhouse.kafka.connect.avro.test")
+                .fields()
+                .name("id").type().intType().noDefault()
+                .name("val_int32").type().intType().noDefault()
+                .name("arr_int32").type().array().items().intType().noDefault()
+                .endRecord();
+
+        GenericRecord record = new GenericData.Record(avroSchema);
+        record.put("id", 42);
+        record.put("val_int32", 9999);
+        record.put("arr_int32", Arrays.asList(1, 2, 3));
+
+        List<SinkRecord> sinkRecords = SchemaTestData.convertAvroToSinkRecord(topic, new AvroSchema(avroSchema), List.of(record));
+
+        Map<String, String> props = getBaseProps();
+        ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
+        ClickHouseTestHelpers.dropTable(chc, topic);
+
+        new CreateTableStatement()
+                .tableName(topic)
+                .column("id", "Int64")
+                .column("val_int32", "Int64")
+                .column("arr_int32", "Array(Int64)")
+                .engine("MergeTree")
+                .orderByColumn("id")
+                .execute(chc);
+
+        ClickHouseSinkTask chst = new ClickHouseSinkTask();
+        chst.start(props);
+        chst.put(sinkRecords);
+        chst.stop();
+
+        List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic);
+        assertEquals(1, rows.size());
+        JSONObject row = rows.get(0);
+        assertEquals(42L, row.getLong("id"));
+        assertEquals(9999L, row.getLong("val_int32"));
+        JSONArray arr = row.getJSONArray("arr_int32");
+        assertEquals(3, arr.length());
+        assertEquals(1, arr.getInt(0));
+        assertEquals(2, arr.getInt(1));
+        assertEquals(3, arr.getInt(2));
+
+        ClickHouseTestHelpers.dropTable(chc, topic);
+    }
+
+    @Test
+    public void testInt32ToInt64ConversionWithProtobuf() throws Exception {
+        String topic = createTopicName("test_int32_to_int64_proto");
+        String protoSchemaStr = "syntax = \"proto3\";\n" +
+                "package com.clickhouse.kafka.connect.proto.test;\n" +
+                "message Int32ToInt64Msg {\n" +
+                "  int32 id = 1;\n" +
+                "  int32 val_int32 = 2;\n" +
+                "  repeated int32 arr_int32 = 3;\n" +
+                "}\n";
+
+        ProtobufSchema schema = new ProtobufSchema(protoSchemaStr);
+        Descriptor descriptor = schema.toDescriptor();
+
+        MockSchemaRegistryClient schemaRegistry = new MockSchemaRegistryClient();
+        schemaRegistry.register(topic + "-value", schema);
+
+        KafkaProtobufSerializer<DynamicMessage> serializer = new KafkaProtobufSerializer<>(schemaRegistry);
+        Map<String, Object> serializerConfig = new HashMap<>();
+        serializerConfig.put(KafkaProtobufSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "mock://test-proto-url");
+        serializerConfig.put(KafkaProtobufSerializerConfig.AUTO_REGISTER_SCHEMAS, true);
+        serializer.configure(serializerConfig, false);
+
+        ProtobufConverter converter = new ProtobufConverter(schemaRegistry);
+        Map<String, Object> converterConfig = new HashMap<>();
+        converterConfig.put(ProtobufConverterConfig.AUTO_REGISTER_SCHEMAS, true);
+        converterConfig.put(ProtobufDataConfig.GENERATE_INDEX_FOR_UNIONS_CONFIG, false);
+        converterConfig.put(KafkaProtobufSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "mock://test-proto-url");
+        converter.configure(converterConfig, false);
+
+        DynamicMessage msg = DynamicMessage.newBuilder(descriptor)
+                .setField(descriptor.findFieldByName("id"), 777)
+                .setField(descriptor.findFieldByName("val_int32"), 888)
+                .addRepeatedField(descriptor.findFieldByName("arr_int32"), 5)
+                .addRepeatedField(descriptor.findFieldByName("arr_int32"), 6)
+                .addRepeatedField(descriptor.findFieldByName("arr_int32"), 7)
+                .build();
+
+        byte[] serialized = serializer.serialize(topic, msg);
+        SchemaAndValue connectData = converter.toConnectData(topic, serialized);
+        SinkRecord record = new SinkRecord(topic, 0, null, null, connectData.schema(), connectData.value(), 0);
+
+        Map<String, String> props = getBaseProps();
+        ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
+        ClickHouseTestHelpers.dropTable(chc, topic);
+
+        new CreateTableStatement()
+                .tableName(topic)
+                .column("id", "Int64")
+                .column("val_int32", "Int64")
+                .column("arr_int32", "Array(Int64)")
+                .engine("MergeTree")
+                .orderByColumn("id")
+                .execute(chc);
+
+        ClickHouseSinkTask chst = new ClickHouseSinkTask();
+        chst.start(props);
+        chst.put(List.of(record));
+        chst.stop();
+
+        List<JSONObject> rows = ClickHouseTestHelpers.getAllRowsAsJson(chc, topic);
+        assertEquals(1, rows.size());
+        JSONObject row = rows.get(0);
+        assertEquals(777L, row.getLong("id"));
+        assertEquals(888L, row.getLong("val_int32"));
+        JSONArray arr = row.getJSONArray("arr_int32");
+        assertEquals(3, arr.length());
+        assertEquals(5, arr.getInt(0));
+        assertEquals(6, arr.getInt(1));
+        assertEquals(7, arr.getInt(2));
+
         ClickHouseTestHelpers.dropTable(chc, topic);
     }
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterColumnContextTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterColumnContextTest.java
@@ -212,6 +212,49 @@ public class ClickHouseWriterColumnContextTest {
     }
 
     @Test
+    public void validateDataSchemaBooleanAndNumericConversions() {
+        ClickHouseWriter writer = newWriter();
+
+        // 1. Boolean Kafka field -> Numeric ClickHouse columns should be allowed
+        String[] numericChCols = {"Int8", "Int16", "Int32", "Int64", "UInt8", "UInt16", "UInt32", "UInt64", "Float32", "Float64", "Int128", "UInt128"};
+        for (String chType : numericChCols) {
+            Table t = new Table("default", "test_table", false, List.of(Column.extractColumn("v", chType, false, false, false)), 1);
+            Schema s = SchemaBuilder.struct().field("v", Schema.BOOLEAN_SCHEMA).build();
+            com.clickhouse.kafka.connect.sink.data.Record r = com.clickhouse.kafka.connect.sink.data.Record.convert(
+                    new SinkRecord("test_table", 0, null, null, s, new Struct(s).put("v", true), 0), false, ".", "default", false);
+            assertTrue(writer.validateDataSchema(t, r, false), "BOOLEAN -> " + chType + " should be allowed");
+        }
+
+        // 2. Numeric Kafka fields -> Boolean ClickHouse column should be allowed
+        Schema[] numericKafkaSchemas = {
+                Schema.INT8_SCHEMA, Schema.INT16_SCHEMA, Schema.INT32_SCHEMA, Schema.INT64_SCHEMA,
+                Schema.FLOAT32_SCHEMA, Schema.FLOAT64_SCHEMA
+        };
+        Object[] sampleNumericValues = {(byte) 1, (short) 1, 1, 1L, 1.0f, 1.0d};
+
+        Table tableBool = new Table("default", "test_table", false, List.of(Column.extractColumn("v", "Bool", false, false, false)), 1);
+        for (int i = 0; i < numericKafkaSchemas.length; i++) {
+            Schema s = SchemaBuilder.struct().field("v", numericKafkaSchemas[i]).build();
+            com.clickhouse.kafka.connect.sink.data.Record r = com.clickhouse.kafka.connect.sink.data.Record.convert(
+                    new SinkRecord("test_table", 0, null, null, s, new Struct(s).put("v", sampleNumericValues[i]), 0), false, ".", "default", false);
+            assertTrue(writer.validateDataSchema(tableBool, r, false), numericKafkaSchemas[i].type() + " -> Boolean should be allowed");
+        }
+
+        // 3. Non-numeric non-boolean Kafka field -> Boolean ClickHouse column should be rejected
+        Schema stringSchema = SchemaBuilder.struct().field("v", Schema.STRING_SCHEMA).build();
+        com.clickhouse.kafka.connect.sink.data.Record rString = com.clickhouse.kafka.connect.sink.data.Record.convert(
+                new SinkRecord("test_table", 0, null, null, stringSchema, new Struct(stringSchema).put("v", "true"), 0), false, ".", "default", false);
+        assertFalse(writer.validateDataSchema(tableBool, rString, false), "STRING -> Boolean should be rejected");
+
+        // 4. Boolean Kafka field -> Non-numeric, non-Date ClickHouse column (e.g. Decimal) should be rejected
+        Table tableDecimal = new Table("default", "test_table", false, List.of(Column.extractColumn("v", "Decimal(9,2)", false, false, false)), 1);
+        Schema boolSchema = SchemaBuilder.struct().field("v", Schema.BOOLEAN_SCHEMA).build();
+        com.clickhouse.kafka.connect.sink.data.Record rBool = com.clickhouse.kafka.connect.sink.data.Record.convert(
+                new SinkRecord("test_table", 0, null, null, boolSchema, new Struct(boolSchema).put("v", true), 0), false, ".", "default", false);
+        assertFalse(writer.validateDataSchema(tableDecimal, rBool, false), "BOOLEAN -> Decimal should be rejected");
+    }
+
+    @Test
     public void integerSerializationValuesAndTypes() throws Exception {
         ClickHouseWriter writer = newWriter();
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterColumnContextTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterColumnContextTest.java
@@ -1,5 +1,6 @@
 package com.clickhouse.kafka.connect.sink.db;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -8,12 +9,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.clickhouse.kafka.connect.sink.data.Data;
 import com.clickhouse.kafka.connect.sink.db.mapping.Column;
+import com.clickhouse.kafka.connect.sink.db.mapping.Table;
 import com.clickhouse.kafka.connect.util.jmx.SinkTaskStatistics;
 import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.List;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -69,5 +75,214 @@ public class ClickHouseWriterColumnContextTest {
         assertTrue(message.contains(CONTEXT_PREFIX), "should carry the column context: " + message);
         assertTrue(message.indexOf(CONTEXT_PREFIX) == message.lastIndexOf(CONTEXT_PREFIX),
                 "context prefix should not be duplicated on nested types: " + message);
+    }
+
+    @Test
+    public void integerValueWithinRangeSucceeds() {
+        ClickHouseWriter writer = newWriter();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        Column colInt64 = Column.extractColumn("val", "Int64", false, false, false);
+        Column colInt32 = Column.extractColumn("val", "Int32", false, false, false);
+        Column colInt16 = Column.extractColumn("val", "Int16", false, false, false);
+        Column colInt8 = Column.extractColumn("val", "Int8", false, false, false);
+
+        Data val100 = new Data(Schema.INT32_SCHEMA, 100);
+
+        org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> writer.doWriteColValue(colInt64, out, val100, false));
+        org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> writer.doWriteColValue(colInt32, out, val100, false));
+        org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> writer.doWriteColValue(colInt16, out, val100, false));
+        org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> writer.doWriteColValue(colInt8, out, val100, false));
+    }
+
+    @Test
+    public void validateDataSchemaAllowsNarrowerOrEqualDataType() {
+        ClickHouseWriter writer = newWriter();
+
+        Column col64 = Column.extractColumn("val64", "Int64", false, false, false);
+        Column col32 = Column.extractColumn("val32", "Int32", false, false, false);
+        Table table = new Table("default", "test_table", false, List.of(col64, col32), 2);
+
+        Schema schema = SchemaBuilder.struct()
+                .field("val64", Schema.INT32_SCHEMA)
+                .field("val32", Schema.INT16_SCHEMA)
+                .build();
+        Struct struct = new Struct(schema)
+                .put("val64", 100)
+                .put("val32", (short) 50);
+
+        SinkRecord sr = new SinkRecord("test_table", 0, null, null, schema, struct, 0);
+        com.clickhouse.kafka.connect.sink.data.Record record =
+                com.clickhouse.kafka.connect.sink.data.Record.convert(sr, false, ".", "default", false);
+
+        assertTrue(writer.validateDataSchema(table, record, false),
+                "Schema validation should pass when data types are narrower or equal to column types");
+    }
+
+    @Test
+    public void validateDataSchemaRejectsWiderDataType() {
+        ClickHouseWriter writer = newWriter();
+
+        Column col32 = Column.extractColumn("val", "Int32", false, false, false);
+        Table table = new Table("default", "test_table", false, List.of(col32), 1);
+
+        Schema schema = SchemaBuilder.struct()
+                .field("val", Schema.INT64_SCHEMA)
+                .build();
+        Struct struct = new Struct(schema)
+                .put("val", 123456789L);
+
+        SinkRecord sr = new SinkRecord("test_table", 0, null, null, schema, struct, 0);
+        com.clickhouse.kafka.connect.sink.data.Record record =
+                com.clickhouse.kafka.connect.sink.data.Record.convert(sr, false, ".", "default", false);
+
+        assertFalse(writer.validateDataSchema(table, record, false),
+                "Schema validation should fail when data type (INT64) is wider than column type (Int32)");
+    }
+
+    @Test
+    public void validateDataSchemaExhaustiveBitWidthMatrix() {
+        ClickHouseWriter writer = newWriter();
+
+        // Check narrower or equal numeric conversions pass
+        String[] allowedColsForInt8 = {"Int8", "Int16", "Int32", "Int64", "UInt8", "UInt16", "UInt32", "UInt64", "Float32", "Float64"};
+        for (String chType : allowedColsForInt8) {
+            Table t = new Table("default", "test_table", false, List.of(Column.extractColumn("v", chType, false, false, false)), 1);
+            Schema s = SchemaBuilder.struct().field("v", Schema.INT8_SCHEMA).build();
+            com.clickhouse.kafka.connect.sink.data.Record r = com.clickhouse.kafka.connect.sink.data.Record.convert(
+                    new SinkRecord("test_table", 0, null, null, s, new Struct(s).put("v", (byte) 1), 0), false, ".", "default", false);
+            assertTrue(writer.validateDataSchema(t, r, false), "INT8 -> " + chType + " should be allowed");
+        }
+
+        String[] allowedColsForInt16 = {"Int16", "Int32", "Int64", "UInt16", "UInt32", "UInt64", "Float32", "Float64"};
+        for (String chType : allowedColsForInt16) {
+            Table t = new Table("default", "test_table", false, List.of(Column.extractColumn("v", chType, false, false, false)), 1);
+            Schema s = SchemaBuilder.struct().field("v", Schema.INT16_SCHEMA).build();
+            com.clickhouse.kafka.connect.sink.data.Record r = com.clickhouse.kafka.connect.sink.data.Record.convert(
+                    new SinkRecord("test_table", 0, null, null, s, new Struct(s).put("v", (short) 1), 0), false, ".", "default", false);
+            assertTrue(writer.validateDataSchema(t, r, false), "INT16 -> " + chType + " should be allowed");
+        }
+
+        String[] allowedColsForInt32 = {"Int32", "Int64", "UInt32", "UInt64", "Float32", "Float64"};
+        for (String chType : allowedColsForInt32) {
+            Table t = new Table("default", "test_table", false, List.of(Column.extractColumn("v", chType, false, false, false)), 1);
+            Schema s = SchemaBuilder.struct().field("v", Schema.INT32_SCHEMA).build();
+            com.clickhouse.kafka.connect.sink.data.Record r = com.clickhouse.kafka.connect.sink.data.Record.convert(
+                    new SinkRecord("test_table", 0, null, null, s, new Struct(s).put("v", 1), 0), false, ".", "default", false);
+            assertTrue(writer.validateDataSchema(t, r, false), "INT32 -> " + chType + " should be allowed");
+        }
+
+        String[] allowedColsForInt64 = {"Int64", "UInt64", "Float64"};
+        for (String chType : allowedColsForInt64) {
+            Table t = new Table("default", "test_table", false, List.of(Column.extractColumn("v", chType, false, false, false)), 1);
+            Schema s = SchemaBuilder.struct().field("v", Schema.INT64_SCHEMA).build();
+            com.clickhouse.kafka.connect.sink.data.Record r = com.clickhouse.kafka.connect.sink.data.Record.convert(
+                    new SinkRecord("test_table", 0, null, null, s, new Struct(s).put("v", 1L), 0), false, ".", "default", false);
+            assertTrue(writer.validateDataSchema(t, r, false), "INT64 -> " + chType + " should be allowed");
+        }
+
+        // Check wider into narrower numeric conversions fail
+        String[] rejectedColsForInt64 = {"Int32", "Int16", "Int8", "UInt32", "UInt16", "UInt8", "Float32"};
+        for (String chType : rejectedColsForInt64) {
+            Table t = new Table("default", "test_table", false, List.of(Column.extractColumn("v", chType, false, false, false)), 1);
+            Schema s = SchemaBuilder.struct().field("v", Schema.INT64_SCHEMA).build();
+            com.clickhouse.kafka.connect.sink.data.Record r = com.clickhouse.kafka.connect.sink.data.Record.convert(
+                    new SinkRecord("test_table", 0, null, null, s, new Struct(s).put("v", 1L), 0), false, ".", "default", false);
+            assertFalse(writer.validateDataSchema(t, r, false), "INT64 -> " + chType + " should be rejected");
+        }
+
+        String[] rejectedColsForInt32 = {"Int16", "Int8", "UInt16", "UInt8"};
+        for (String chType : rejectedColsForInt32) {
+            Table t = new Table("default", "test_table", false, List.of(Column.extractColumn("v", chType, false, false, false)), 1);
+            Schema s = SchemaBuilder.struct().field("v", Schema.INT32_SCHEMA).build();
+            com.clickhouse.kafka.connect.sink.data.Record r = com.clickhouse.kafka.connect.sink.data.Record.convert(
+                    new SinkRecord("test_table", 0, null, null, s, new Struct(s).put("v", 1), 0), false, ".", "default", false);
+            assertFalse(writer.validateDataSchema(t, r, false), "INT32 -> " + chType + " should be rejected");
+        }
+
+        // Float data into Integer column should be rejected
+        String[] rejectedColsForFloat64 = {"Int64", "Int32", "Int16", "Int8", "UInt64", "UInt32", "UInt16", "UInt8"};
+        for (String chType : rejectedColsForFloat64) {
+            Table t = new Table("default", "test_table", false, List.of(Column.extractColumn("v", chType, false, false, false)), 1);
+            Schema s = SchemaBuilder.struct().field("v", Schema.FLOAT64_SCHEMA).build();
+            com.clickhouse.kafka.connect.sink.data.Record r = com.clickhouse.kafka.connect.sink.data.Record.convert(
+                    new SinkRecord("test_table", 0, null, null, s, new Struct(s).put("v", 1.23d), 0), false, ".", "default", false);
+            assertFalse(writer.validateDataSchema(t, r, false), "FLOAT64 -> " + chType + " should be rejected");
+        }
+    }
+
+    @Test
+    public void integerSerializationValuesAndTypes() throws Exception {
+        ClickHouseWriter writer = newWriter();
+
+        // 1. INT8 value widening (-128, 127) -> Int8, Int16, Int32, Int64
+        Column colInt8 = Column.extractColumn("val", "Int8", false, false, false);
+        Column colInt16 = Column.extractColumn("val", "Int16", false, false, false);
+        Column colInt32 = Column.extractColumn("val", "Int32", false, false, false);
+        Column colInt64 = Column.extractColumn("val", "Int64", false, false, false);
+
+        Data dataByteMin = new Data(Schema.INT8_SCHEMA, (byte) -128);
+
+        ByteArrayOutputStream out8 = new ByteArrayOutputStream();
+        writer.doWriteColValue(colInt8, out8, dataByteMin, false);
+        assertEquals(-128, out8.toByteArray()[0]);
+
+        ByteArrayOutputStream out16 = new ByteArrayOutputStream();
+        writer.doWriteColValue(colInt16, out16, dataByteMin, false);
+        assertEquals((short) -128, ByteBuffer.wrap(out16.toByteArray()).order(ByteOrder.LITTLE_ENDIAN).getShort());
+
+        ByteArrayOutputStream out32 = new ByteArrayOutputStream();
+        writer.doWriteColValue(colInt32, out32, dataByteMin, false);
+        assertEquals(-128, ByteBuffer.wrap(out32.toByteArray()).order(ByteOrder.LITTLE_ENDIAN).getInt());
+
+        ByteArrayOutputStream out64 = new ByteArrayOutputStream();
+        writer.doWriteColValue(colInt64, out64, dataByteMin, false);
+        assertEquals(-128L, ByteBuffer.wrap(out64.toByteArray()).order(ByteOrder.LITTLE_ENDIAN).getLong());
+
+        // 2. INT16 value widening (-32768, 32767) -> Int16, Int32, Int64
+        Data dataShortMin = new Data(Schema.INT16_SCHEMA, (short) -32768);
+
+        out32 = new ByteArrayOutputStream();
+        writer.doWriteColValue(colInt32, out32, dataShortMin, false);
+        assertEquals(-32768, ByteBuffer.wrap(out32.toByteArray()).order(ByteOrder.LITTLE_ENDIAN).getInt());
+
+        out64 = new ByteArrayOutputStream();
+        writer.doWriteColValue(colInt64, out64, dataShortMin, false);
+        assertEquals(-32768L, ByteBuffer.wrap(out64.toByteArray()).order(ByteOrder.LITTLE_ENDIAN).getLong());
+
+        // 3. INT32 value widening (Integer.MIN_VALUE, Integer.MAX_VALUE, -1, 0, 100) -> Int32, Int64, UInt32, Float64
+        Data dataIntMin = new Data(Schema.INT32_SCHEMA, Integer.MIN_VALUE);
+        Data dataIntMax = new Data(Schema.INT32_SCHEMA, Integer.MAX_VALUE);
+        Data dataNegOne = new Data(Schema.INT32_SCHEMA, -1);
+
+        out64 = new ByteArrayOutputStream();
+        writer.doWriteColValue(colInt64, out64, dataIntMin, false);
+        assertEquals((long) Integer.MIN_VALUE, ByteBuffer.wrap(out64.toByteArray()).order(ByteOrder.LITTLE_ENDIAN).getLong());
+
+        out64 = new ByteArrayOutputStream();
+        writer.doWriteColValue(colInt64, out64, dataIntMax, false);
+        assertEquals((long) Integer.MAX_VALUE, ByteBuffer.wrap(out64.toByteArray()).order(ByteOrder.LITTLE_ENDIAN).getLong());
+
+        Column colUInt32 = Column.extractColumn("val", "UInt32", false, false, false);
+        out32 = new ByteArrayOutputStream();
+        writer.doWriteColValue(colUInt32, out32, dataNegOne, false);
+        assertEquals(-1, ByteBuffer.wrap(out32.toByteArray()).order(ByteOrder.LITTLE_ENDIAN).getInt()); // 0xFFFFFFFF bitwise
+
+        Column colFloat64 = Column.extractColumn("val", "Float64", false, false, false);
+        out64 = new ByteArrayOutputStream();
+        writer.doWriteColValue(colFloat64, out64, new Data(Schema.INT32_SCHEMA, 12345), false);
+        assertEquals(12345.0d, ByteBuffer.wrap(out64.toByteArray()).order(ByteOrder.LITTLE_ENDIAN).getDouble());
+
+        // 4. INT64 values (Long.MIN_VALUE, Long.MAX_VALUE)
+        Data dataLongMin = new Data(Schema.INT64_SCHEMA, Long.MIN_VALUE);
+        Data dataLongMax = new Data(Schema.INT64_SCHEMA, Long.MAX_VALUE);
+
+        out64 = new ByteArrayOutputStream();
+        writer.doWriteColValue(colInt64, out64, dataLongMin, false);
+        assertEquals(Long.MIN_VALUE, ByteBuffer.wrap(out64.toByteArray()).order(ByteOrder.LITTLE_ENDIAN).getLong());
+
+        out64 = new ByteArrayOutputStream();
+        writer.doWriteColValue(colInt64, out64, dataLongMax, false);
+        assertEquals(Long.MAX_VALUE, ByteBuffer.wrap(out64.toByteArray()).order(ByteOrder.LITTLE_ENDIAN).getLong());
     }
 }


### PR DESCRIPTION
## Summary
- Updates schema validation to allow only smaller numbers be written to same size or bigger columns 
- Cast number values to Number  and take needed part. Resolves class cast exception 


Closes: https://github.com/ClickHouse/clickhouse-kafka-connect/issues/642



## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
