### PR TITLE
[schema] Sticky Replica Routing on Schema related error. 

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
@@ -65,6 +65,7 @@ public class ClickHouseSinkConfig {
     public static final String AUTO_EVOLVE_STRUCT_TO_JSON = "auto.evolve.struct.to.json";
     public static final String CONNECTOR_RETRY_TIMEOUT = "errors.retry.timeout";
     public static final String CLUSTER_NAME = "clusterName";
+    public static final String ENABLE_REPLICA_PINNING = "enableReplicaPinning";
 
     public static final long MINIMAL_RETRY_TIMEOUT_THR_WARN = TimeUnit.SECONDS.toMillis(10);
     public static final String SSL_SOCKET_SNI = "ssl_socket_sni";
@@ -85,6 +86,7 @@ public class ClickHouseSinkConfig {
     public static final Long bufferFlushTimeDefault = 0L;
     public static final Long clickhouseClientInsertTimeoutMsDefault = TimeUnit.MINUTES.toMillis(4);
     public static final Boolean reportInsertedOffsetsDefault = Boolean.FALSE;
+    public static final Boolean enableReplicaPinningDefault = Boolean.FALSE;
 
     private final String hostname;
     private final int port;
@@ -127,6 +129,7 @@ public class ClickHouseSinkConfig {
     private final boolean binaryFormatWrtiteJsonAsString;
     private final String sslSocketSni;
     private final String clusterName;
+    private final boolean enableReplicaPinning;
 
     public enum InsertFormats {
         NONE,
@@ -310,6 +313,7 @@ public class ClickHouseSinkConfig {
         this.debeziumCDCEnabled = Boolean.parseBoolean(props.getOrDefault(DEBEZIUM_CDC_ENABLED, "false"));
         this.sslSocketSni = props.getOrDefault(SSL_SOCKET_SNI, "");
         this.clusterName = props.getOrDefault(CLUSTER_NAME, "");
+        this.enableReplicaPinning = Boolean.parseBoolean(props.getOrDefault(ENABLE_REPLICA_PINNING, enableReplicaPinningDefault.toString()));
 
         if (this.bufferCount > 0) {
             LOGGER.info("Internal buffering enabled: bufferCount={}, bufferFlushTime={}ms", this.bufferCount, this.bufferFlushTime);
@@ -769,6 +773,16 @@ public class ClickHouseSinkConfig {
                 ++orderInGroup,
                 ConfigDef.Width.MEDIUM,
                 "SSL Socket SNI"
+        );
+        configDef.define(ENABLE_REPLICA_PINNING,
+                ConfigDef.Type.BOOLEAN,
+                enableReplicaPinningDefault,
+                ConfigDef.Importance.LOW,
+                "Enable pinning requests to a single ClickHouse replica using X-ClickHouse-Replica-Tag header when retrying after failure. default: false",
+                group,
+                ++orderInGroup,
+                ConfigDef.Width.SHORT,
+                "Enable replica pinning."
         );
 
         String ddlGroup = "DDL";

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -997,8 +997,13 @@ public class ClickHouseWriter implements DBWriter {
             Optional<String> updateTableException = UPDATE_TABLE_EXCEPTION_STR_TO_ERROR_CODE.keySet().stream().filter(code -> e.getMessage().contains(code)).findFirst();
             if (e.getMessage() != null && updateTableException.isPresent() && retry) {
                 LOGGER.warn("Error code {}. Trying to update table mapping because ClickHouse table schema may have evolved.", UPDATE_TABLE_EXCEPTION_STR_TO_ERROR_CODE.get(updateTableException.get()));
-                Table tableTmp = urgentTableUpdate(table);
-                doInsertRawBinary(records, tableTmp, queryId, tableTmp.hasDefaults(), false);
+                try {
+                    chc.pinReplica();
+                    Table tableTmp = urgentTableUpdate(table);
+                    doInsertRawBinary(records, tableTmp, queryId, tableTmp.hasDefaults(), false);
+                } finally {
+                    chc.unpinReplica();
+                }
             } else {
                 LOGGER.error("Error inserting records", e);
                 throw e;
@@ -1049,6 +1054,7 @@ public class ClickHouseWriter implements DBWriter {
 
         InsertSettings insertSettings = new InsertSettings();
         insertSettings.setDatabase(database);
+        chc.setReplicaTagHeaderV2(insertSettings);
 
         String deduplicationToken = queryId.getDeduplicationToken();
         if (deduplicationToken != null) {
@@ -1127,6 +1133,7 @@ public class ClickHouseWriter implements DBWriter {
             } else {
                 request = getMutationRequest(client, ClickHouseFormat.RowBinary, table.getName(), database, queryId);
             }
+            chc.setReplicaTagHeaderV1(request);
             ClickHouseConfig config = request.getConfig();
             CompletableFuture<ClickHouseResponse> future;
 

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -92,6 +92,7 @@ public class ClickHouseWriter implements DBWriter {
                 .useClientV2(useClientV2)
                 .setSslSocketSni(csc.getSslSocketSni())
                 .setClusterClause(csc.getClusterName())
+                .enableReplicaPinning(csc.isEnableReplicaPinning())
                 .build();
 
         if (!chc.ping()) {
@@ -986,8 +987,13 @@ public class ClickHouseWriter implements DBWriter {
         } catch (ServerException e) {
             if (UPDATE_TABLE_ERROR_CODES_V2.contains(e.getCode()) && retry) {
                 LOGGER.warn("Error code {}. Trying to update table mapping because ClickHouse table schema may have evolved.", e.getCode());
-                Table tableTmp = urgentTableUpdate(table);
-                doInsertRawBinary(records, tableTmp, queryId, tableTmp.hasDefaults(), false);
+                try {
+                    chc.pinReplica();
+                    Table tableTmp = urgentTableUpdate(table);
+                    doInsertRawBinary(records, tableTmp, queryId, tableTmp.hasDefaults(), false);
+                } finally {
+                    chc.unpinReplica();
+                }
             } else {
                 LOGGER.error("Error inserting records", e);
                 throw e;
@@ -1054,6 +1060,7 @@ public class ClickHouseWriter implements DBWriter {
 
         InsertSettings insertSettings = new InsertSettings();
         insertSettings.setDatabase(database);
+        chc.setReplicaTagHeaderV2(insertSettings);
         chc.setReplicaTagHeaderV2(insertSettings);
 
         String deduplicationToken = queryId.getDeduplicationToken();
@@ -1275,6 +1282,7 @@ public class ClickHouseWriter implements DBWriter {
 
         InsertSettings insertSettings = new InsertSettings();
         insertSettings.setDatabase(database);
+        chc.setReplicaTagHeaderV2(insertSettings);
         String deduplicationToken = queryId.getDeduplicationToken();
         if (deduplicationToken != null) {
             insertSettings.setDeduplicationToken(deduplicationToken);
@@ -1411,6 +1419,7 @@ public class ClickHouseWriter implements DBWriter {
 
         InsertSettings insertSettings = new InsertSettings();
         insertSettings.setDatabase(database);
+        chc.setReplicaTagHeaderV2(insertSettings);
         String deduplicationToken = queryId.getDeduplicationToken();
         if (deduplicationToken != null) {
             insertSettings.setDeduplicationToken(deduplicationToken);
@@ -1480,6 +1489,7 @@ public class ClickHouseWriter implements DBWriter {
                 .setRetry(csc.getRetry())
                 .setSslSocketSni(csc.getSslSocketSni())
                 .setClusterClause(csc.getClusterName())
+                .enableReplicaPinning(csc.isEnableReplicaPinning())
                 .build();
 
         ClickHouseNode server = chcTmp.getServer();
@@ -1498,6 +1508,7 @@ public class ClickHouseWriter implements DBWriter {
         }
 
         request.option(ClickHouseClientOption.WRITE_BUFFER_SIZE, 8192);
+        chc.setReplicaTagHeaderV1(request);
 
         return request;
     }

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -1061,7 +1061,6 @@ public class ClickHouseWriter implements DBWriter {
         InsertSettings insertSettings = new InsertSettings();
         insertSettings.setDatabase(database);
         chc.setReplicaTagHeaderV2(insertSettings);
-        chc.setReplicaTagHeaderV2(insertSettings);
 
         String deduplicationToken = queryId.getDeduplicationToken();
         if (deduplicationToken != null) {

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
@@ -581,6 +581,10 @@ public class ClickHouseHelperClient implements AutoCloseable {
     // thread local without inheritance to pass replica tag to operations
     private final ThreadLocal<String> replicaTag = new ThreadLocal<>();
 
+    public String getReplicaTag() {
+        return replicaTag.get();
+    }
+
     /**
      * Pins replica for next calls until unpinReplica() is called.
      * This process is based on setting {@code X-ClickHouse-Replica-Tag} header to randomly generated string.
@@ -610,21 +614,14 @@ public class ClickHouseHelperClient implements AutoCloseable {
         String tag = replicaTag.get();
         if (tag != null && request != null) {
             try {
-                String customHeaders;
-                if (!request.hasOption(ClickHouseHttpOption.CUSTOM_HEADERS)) {
+                String customHeaders = (String) request.getConfig().getOption(ClickHouseHttpOption.CUSTOM_HEADERS);
+                if (customHeaders == null || customHeaders.trim().isEmpty()) {
                     customHeaders = REPLICA_TAG_HEADER + "=" + tag;
                 } else {
-                    customHeaders = (String) request.getConfig().getOption(ClickHouseHttpOption.CUSTOM_HEADERS);
-                    if (customHeaders == null || customHeaders.trim().isEmpty()) {
-                        customHeaders = REPLICA_TAG_HEADER + "=" + tag;
-                    } else if (customHeaders.contains(REPLICA_TAG_HEADER + "=")) {
-                        customHeaders = customHeaders.replaceAll(REPLICA_TAG_HEADER + "=[^,]*", REPLICA_TAG_HEADER + "=" + tag);
-                    } else {
-                        if (!customHeaders.trim().endsWith(",")) {
-                            customHeaders += ",";
-                        }
-                        customHeaders += REPLICA_TAG_HEADER + "=" + tag;
+                    if (!customHeaders.trim().endsWith(",")) {
+                        customHeaders += ",";
                     }
+                    customHeaders += REPLICA_TAG_HEADER + "=" + tag;
                 }
                 request.option(ClickHouseHttpOption.CUSTOM_HEADERS, customHeaders);
             } catch (Exception e) {

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
@@ -9,6 +9,7 @@ import com.clickhouse.client.ClickHouseRequest;
 import com.clickhouse.client.ClickHouseResponse;
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.enums.ProxyType;
+import com.clickhouse.client.api.insert.InsertSettings;
 import com.clickhouse.client.api.query.GenericRecord;
 import com.clickhouse.client.api.query.QueryResponse;
 import com.clickhouse.client.api.query.QuerySettings;
@@ -16,6 +17,7 @@ import com.clickhouse.client.api.query.Records;
 import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.client.config.ClickHouseProxyType;
 import com.clickhouse.client.config.ClickHouseSslMode;
+import com.clickhouse.client.http.config.ClickHouseHttpOption;
 import com.clickhouse.config.ClickHouseOption;
 import com.clickhouse.data.ClickHouseFormat;
 import com.clickhouse.data.ClickHouseRecord;
@@ -35,6 +37,7 @@ import java.io.Serializable;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 public class ClickHouseHelperClient implements AutoCloseable {
@@ -64,6 +67,9 @@ public class ClickHouseHelperClient implements AutoCloseable {
     private boolean useClientV2 = false;
     private final String sslSocketSni;
     private final String clusterClause;
+
+    // Part of HTTP protocol header
+    public static final String REPLICA_TAG_HEADER = "X-ClickHouse-Replica-Tag";
 
     public ClickHouseHelperClient(ClickHouseClientBuilder builder) {
         this.hostname = builder.hostname;
@@ -375,10 +381,10 @@ public class ClickHouseHelperClient implements AutoCloseable {
                 .options(getDefaultClientOptions())
                 .nodeSelector(ClickHouseNodeSelector.of(ClickHouseProtocol.HTTP))
                 .build();
-             ClickHouseResponse response = client.read(server)
+             ClickHouseResponse response = setReplicaTagHeaderV1(client.read(server)
                      .set("describe_include_subcolumns", true)
                      .format(ClickHouseFormat.JSONEachRow)
-                     .query(describeQuery)
+                     .query(describeQuery))
                      .executeAndWait()) {
 
             Set<String> skippedCols = new HashSet<>();
@@ -438,6 +444,7 @@ public class ClickHouseHelperClient implements AutoCloseable {
             QuerySettings settings = new QuerySettings().setFormat(ClickHouseFormat.JSONEachRow);
             settings.serverSetting("describe_include_subcolumns", "1");
             settings.setDatabase(database);
+            setReplicaTagHeaderV2(settings);
 
             boolean hasDefaults = false;
             int numColumns = 0;
@@ -556,6 +563,75 @@ public class ClickHouseHelperClient implements AutoCloseable {
             }
         }
         return tableList;
+    }
+
+    // thread local without inheritance to pass replica tag to operations
+    private final ThreadLocal<String> replicaTag = new ThreadLocal<>();
+
+    /**
+     * Pins replica for next calls until unpinReplica() is called.
+     * This process is based on setting {@code X-ClickHouse-Replica-Tag} header to randomly generated string.
+     * New random string is required to always pin to a new replica.
+     * This approach works on for ClickHouse cloud and when enabled.
+     * Pinning affects only insert and describe operations to make them hit same replica in case of failure.
+     * Do not call it in main path. Code that called pinReplica() must call unpinReplica()
+     */
+    public void pinReplica() {
+        try {
+            final String chars_en = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+            ThreadLocalRandom random = ThreadLocalRandom.current();
+            int size = 32;
+            final StringBuilder tag = new StringBuilder();
+            random.ints(size).forEach(operand -> tag.append(chars_en.charAt(operand % chars_en.length())));
+            replicaTag.set(tag.toString());
+            LOGGER.debug("Replica pinned by tag {}", replicaTag.get());
+        } catch (Exception e) {
+            LOGGER.error("Failed to pin replica", e);
+        }
+    }
+
+    public ClickHouseRequest setReplicaTagHeaderV1(ClickHouseRequest request) {
+        String tag = replicaTag.get();
+        if (tag != null && request != null) {
+            try {
+                String customHeaders;
+                if (!request.hasOption(ClickHouseHttpOption.CUSTOM_HEADERS)) {
+                    customHeaders = REPLICA_TAG_HEADER + "=" + tag;
+                } else {
+                    customHeaders = (String) request.getSetting(ClickHouseHttpOption.CUSTOM_HEADERS.getKey(), "");
+                    if (!customHeaders.trim().endsWith(",")) {
+                        customHeaders += ",";
+                    }
+                    customHeaders += REPLICA_TAG_HEADER + "=" + tag;
+                }
+                request.option(ClickHouseHttpOption.CUSTOM_HEADERS, customHeaders);
+            } catch (Exception e) {
+                LOGGER.error("Failed to set replica tag header", e);
+            }
+        }
+        return request;
+    }
+
+    public void setReplicaTagHeaderV2(QuerySettings settings) {
+        String tag = replicaTag.get();
+        if (tag != null && settings != null) {
+            settings.httpHeader(REPLICA_TAG_HEADER, tag);
+        }
+    }
+
+    public void setReplicaTagHeaderV2(InsertSettings settings) {
+        String tag = replicaTag.get();
+        if (tag != null && settings != null) {
+            settings.httpHeader(REPLICA_TAG_HEADER, tag);
+        }
+    }
+
+    /**
+     * Unpins replica for next operations.
+     * Do not call it in main path.
+     */
+    public void unpinReplica() {
+        replicaTag.remove();
     }
 
     @Override

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
@@ -67,6 +67,8 @@ public class ClickHouseHelperClient implements AutoCloseable {
     private boolean useClientV2 = false;
     private final String sslSocketSni;
     private final String clusterClause;
+    @Getter
+    private final boolean enableReplicaPinning;
 
     // Part of HTTP protocol header
     public static final String REPLICA_TAG_HEADER = "X-ClickHouse-Replica-Tag";
@@ -87,6 +89,7 @@ public class ClickHouseHelperClient implements AutoCloseable {
         this.useClientV2 = builder.useClientV2;
         this.sslSocketSni = builder.sslSocketSni;
         this.clusterClause = builder.clusterClause;
+        this.enableReplicaPinning = builder.enableReplicaPinning;
         // We are creating two clients, one for V1 and one for V2
         this.client = createClientV2();
         this.server = createClientV1();
@@ -166,6 +169,16 @@ public class ClickHouseHelperClient implements AutoCloseable {
                 .setPassword(this.password)
                 .setClientName(CONNECT_CLIENT_NAME)
                 .setDefaultDatabase(this.database);
+
+        if (jdbcConnectionProperties != null && !jdbcConnectionProperties.isEmpty()) {
+            String props = jdbcConnectionProperties.startsWith("?") ? jdbcConnectionProperties.substring(1) : jdbcConnectionProperties;
+            for (String pair : props.split("&")) {
+                String[] kv = pair.split("=", 2);
+                if (kv.length == 2 && !kv[0].isEmpty()) {
+                    clientBuilder.setOption(kv[0], kv[1]);
+                }
+            }
+        }
 
         if (proxyType != null && !proxyType.equals(ClickHouseProxyType.IGNORE)) {
             clientBuilder.addProxy(ProxyType.HTTP, proxyHost, proxyPort);
@@ -577,12 +590,15 @@ public class ClickHouseHelperClient implements AutoCloseable {
      * Do not call it in main path. Code that called pinReplica() must call unpinReplica()
      */
     public void pinReplica() {
+        if (!enableReplicaPinning) {
+            return;
+        }
         try {
             final String chars_en = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
             ThreadLocalRandom random = ThreadLocalRandom.current();
             int size = 32;
             final StringBuilder tag = new StringBuilder();
-            random.ints(size).forEach(operand -> tag.append(chars_en.charAt(operand % chars_en.length())));
+            random.ints(size, 0, chars_en.length()).forEach(operand -> tag.append(chars_en.charAt(operand)));
             replicaTag.set(tag.toString());
             LOGGER.debug("Replica pinned by tag {}", replicaTag.get());
         } catch (Exception e) {
@@ -598,11 +614,17 @@ public class ClickHouseHelperClient implements AutoCloseable {
                 if (!request.hasOption(ClickHouseHttpOption.CUSTOM_HEADERS)) {
                     customHeaders = REPLICA_TAG_HEADER + "=" + tag;
                 } else {
-                    customHeaders = (String) request.getSetting(ClickHouseHttpOption.CUSTOM_HEADERS.getKey(), "");
-                    if (!customHeaders.trim().endsWith(",")) {
-                        customHeaders += ",";
+                    customHeaders = (String) request.getConfig().getOption(ClickHouseHttpOption.CUSTOM_HEADERS);
+                    if (customHeaders == null || customHeaders.trim().isEmpty()) {
+                        customHeaders = REPLICA_TAG_HEADER + "=" + tag;
+                    } else if (customHeaders.contains(REPLICA_TAG_HEADER + "=")) {
+                        customHeaders = customHeaders.replaceAll(REPLICA_TAG_HEADER + "=[^,]*", REPLICA_TAG_HEADER + "=" + tag);
+                    } else {
+                        if (!customHeaders.trim().endsWith(",")) {
+                            customHeaders += ",";
+                        }
+                        customHeaders += REPLICA_TAG_HEADER + "=" + tag;
                     }
-                    customHeaders += REPLICA_TAG_HEADER + "=" + tag;
                 }
                 request.option(ClickHouseHttpOption.CUSTOM_HEADERS, customHeaders);
             } catch (Exception e) {
@@ -659,6 +681,7 @@ public class ClickHouseHelperClient implements AutoCloseable {
         private boolean useClientV2 = true;
         private String sslSocketSni = "";
         private String clusterClause = "";
+        private boolean enableReplicaPinning = false;
 
         public ClickHouseClientBuilder(String hostname, int port, ClickHouseProxyType proxyType, String proxyHost, int proxyPort) {
             this.hostname = hostname;
@@ -716,6 +739,11 @@ public class ClickHouseHelperClient implements AutoCloseable {
 
         public ClickHouseClientBuilder setClusterClause(String clusterName) {
             this.clusterClause = (clusterName == null || clusterName.isEmpty()) ? "" : " ON CLUSTER '" + clusterName + "' ";
+            return this;
+        }
+
+        public ClickHouseClientBuilder enableReplicaPinning(boolean enableReplicaPinning) {
+            this.enableReplicaPinning = enableReplicaPinning;
             return this;
         }
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseReplicaPinningMockServerTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseReplicaPinningMockServerTest.java
@@ -1,0 +1,222 @@
+package com.clickhouse.kafka.connect.sink.db;
+
+import com.clickhouse.client.config.ClickHouseProxyType;
+import com.clickhouse.kafka.connect.sink.db.helper.ClickHouseHelperClient;
+import com.clickhouse.kafka.connect.sink.db.mapping.Table;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class ClickHouseReplicaPinningMockServerTest {
+
+    private HttpServer server;
+    private int port;
+    private final List<RecordedRequest> recordedRequests = new CopyOnWriteArrayList<>();
+
+    public static class RecordedRequest {
+        private final String path;
+        private final String method;
+        private final Map<String, List<String>> headers;
+        private final String body;
+
+        public RecordedRequest(String path, String method, Map<String, List<String>> headers, String body) {
+            this.path = path;
+            this.method = method;
+            this.headers = headers;
+            this.body = body;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public String getMethod() {
+            return method;
+        }
+
+        public Map<String, List<String>> getHeaders() {
+            return headers;
+        }
+
+        public String getBody() {
+            return body;
+        }
+
+        public String getHeader(String name) {
+            for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+                if (entry.getKey().equalsIgnoreCase(name)) {
+                    List<String> values = entry.getValue();
+                    return (values != null && !values.isEmpty()) ? values.get(0) : null;
+                }
+            }
+            return null;
+        }
+    }
+
+    @BeforeEach
+    public void startServer() throws IOException {
+        recordedRequests.clear();
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        port = server.getAddress().getPort();
+        server.createContext("/", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                InputStream is = exchange.getRequestBody();
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                byte[] buf = new byte[1024];
+                int n;
+                while ((n = is.read(buf)) != -1) {
+                    baos.write(buf, 0, n);
+                }
+                String body = baos.toString("UTF-8");
+                recordedRequests.add(new RecordedRequest(
+                        exchange.getRequestURI().toString(),
+                        exchange.getRequestMethod(),
+                        new HashMap<>(exchange.getRequestHeaders()),
+                        body
+                ));
+
+                byte[] responseBytes = "Ok.\n".getBytes("UTF-8");
+                if (body.contains("DESCRIBE TABLE") || exchange.getRequestURI().toString().contains("DESCRIBE")) {
+                    responseBytes = "{\"name\":\"id\",\"type\":\"Int32\",\"default_type\":\"\",\"default_expression\":\"\",\"comment\":\"\",\"is_subcolumn\":false}\n".getBytes("UTF-8");
+                } else if (body.contains("SELECT version()") || exchange.getRequestURI().toString().contains("version")) {
+                    responseBytes = "24.3.1.1\n".getBytes("UTF-8");
+                }
+
+                exchange.sendResponseHeaders(200, responseBytes.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(responseBytes);
+                }
+            }
+        });
+        server.start();
+    }
+
+    @AfterEach
+    public void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void testReplicaTaggingFlowClientV1() {
+        ClickHouseHelperClient chc = new ClickHouseHelperClient.ClickHouseClientBuilder("127.0.0.1", port, ClickHouseProxyType.IGNORE, null, -1)
+                .setDatabase("default")
+                .useClientV2(false)
+                .setJdbcConnectionProperties("compress=0&decompress=0")
+                .enableReplicaPinning(true)
+                .build();
+
+        // 1. Initial describe call before pinning: tag header should NOT be present
+        recordedRequests.clear();
+        Table table1 = chc.describeTable("default", "test_table");
+        Assertions.assertNotNull(table1);
+        Assertions.assertFalse(recordedRequests.isEmpty());
+        RecordedRequest initialReq = recordedRequests.get(recordedRequests.size() - 1);
+        Assertions.assertNull(initialReq.getHeader(ClickHouseHelperClient.REPLICA_TAG_HEADER));
+
+        // 2. Failure occurs -> pinReplica() is called
+        chc.pinReplica();
+
+        // 3. Retry describe call while pinned: tag header SHOULD be present
+        recordedRequests.clear();
+        Table table2 = chc.describeTable("default", "test_table");
+        Assertions.assertNotNull(table2);
+        Assertions.assertFalse(recordedRequests.isEmpty());
+        RecordedRequest pinnedReq1 = recordedRequests.get(recordedRequests.size() - 1);
+        String replicaTag = pinnedReq1.getHeader(ClickHouseHelperClient.REPLICA_TAG_HEADER);
+        Assertions.assertNotNull(replicaTag);
+
+        // Subsequent call while still pinned should reuse the same tag
+        recordedRequests.clear();
+        Table table3 = chc.describeTable("default", "test_table");
+        Assertions.assertNotNull(table3);
+        Assertions.assertFalse(recordedRequests.isEmpty());
+        RecordedRequest pinnedReq2 = recordedRequests.get(recordedRequests.size() - 1);
+        Assertions.assertEquals(replicaTag, pinnedReq2.getHeader(ClickHouseHelperClient.REPLICA_TAG_HEADER));
+
+        // 4. Retry finishes -> unpinReplica() is called
+        chc.unpinReplica();
+
+        // 5. Subsequent call after unpinning: tag header should NOT be present
+        recordedRequests.clear();
+        Table table4 = chc.describeTable("default", "test_table");
+        Assertions.assertNotNull(table4);
+        Assertions.assertFalse(recordedRequests.isEmpty());
+        RecordedRequest unpinnedReq = recordedRequests.get(recordedRequests.size() - 1);
+        Assertions.assertNull(unpinnedReq.getHeader(ClickHouseHelperClient.REPLICA_TAG_HEADER));
+    }
+
+    @Test
+    public void testReplicaTaggingFlowClientV2() {
+        ClickHouseHelperClient chc = new ClickHouseHelperClient.ClickHouseClientBuilder("127.0.0.1", port, ClickHouseProxyType.IGNORE, null, -1)
+                .setDatabase("default")
+                .useClientV2(true)
+                .setJdbcConnectionProperties("compress=false&decompress=false")
+                .enableReplicaPinning(true)
+                .build();
+
+        // Initial call without pinning
+        recordedRequests.clear();
+        Table table1 = chc.describeTable("default", "test_table");
+        Assertions.assertNotNull(table1);
+        Assertions.assertFalse(recordedRequests.isEmpty());
+        RecordedRequest initialReq = recordedRequests.get(recordedRequests.size() - 1);
+        Assertions.assertNull(initialReq.getHeader(ClickHouseHelperClient.REPLICA_TAG_HEADER));
+
+        // Pin replica on failure
+        chc.pinReplica();
+
+        // Pinned call
+        recordedRequests.clear();
+        Table table2 = chc.describeTable("default", "test_table");
+        Assertions.assertNotNull(table2);
+        Assertions.assertFalse(recordedRequests.isEmpty());
+        RecordedRequest pinnedReq = recordedRequests.get(recordedRequests.size() - 1);
+        String tag = pinnedReq.getHeader(ClickHouseHelperClient.REPLICA_TAG_HEADER);
+        Assertions.assertNotNull(tag, "Headers received: " + pinnedReq.getHeaders());
+
+        // Unpin replica after retry
+        chc.unpinReplica();
+
+        // Unpinned call
+        recordedRequests.clear();
+        Table table3 = chc.describeTable("default", "test_table");
+        Assertions.assertNotNull(table3);
+        Assertions.assertFalse(recordedRequests.isEmpty());
+        RecordedRequest unpinnedReq = recordedRequests.get(recordedRequests.size() - 1);
+        Assertions.assertNull(unpinnedReq.getHeader(ClickHouseHelperClient.REPLICA_TAG_HEADER));
+    }
+
+    @Test
+    public void testReplicaTaggingDisabledFeatureFlag() {
+        ClickHouseHelperClient chc = new ClickHouseHelperClient.ClickHouseClientBuilder("127.0.0.1", port, ClickHouseProxyType.IGNORE, null, -1)
+                .setDatabase("default")
+                .useClientV2(false)
+                .setJdbcConnectionProperties("compress=0&decompress=0")
+                .enableReplicaPinning(false)
+                .build();
+
+        chc.pinReplica();
+
+        recordedRequests.clear();
+        Table table = chc.describeTable("default", "test_table");
+        Assertions.assertNotNull(table);
+        Assertions.assertFalse(recordedRequests.isEmpty());
+        RecordedRequest req = recordedRequests.get(recordedRequests.size() - 1);
+        Assertions.assertNull(req.getHeader(ClickHouseHelperClient.REPLICA_TAG_HEADER));
+    }
+}

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClientTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClientTest.java
@@ -266,6 +266,19 @@ public class ClickHouseHelperClientTest extends ClickHouseBase {
     }
 
     @Test
+    public void testSetReplicaTagHeaderV1_EmptyCustomHeaders() {
+        ClickHouseHelperClient client = new ClickHouseHelperClient.ClickHouseClientBuilder("localhost", 8123, null, null, -1)
+                .enableReplicaPinning(true)
+                .build();
+        client.pinReplica();
+        ClickHouseRequest<?> req = createMockRequest();
+        req.option(ClickHouseHttpOption.CUSTOM_HEADERS, "");
+        client.setReplicaTagHeaderV1(req);
+        String customHeaders = (String) req.getConfig().getOption(ClickHouseHttpOption.CUSTOM_HEADERS);
+        Assertions.assertTrue(customHeaders.startsWith(ClickHouseHelperClient.REPLICA_TAG_HEADER + "="), "Got customHeaders: " + customHeaders);
+    }
+
+    @Test
     public void testSetReplicaTagHeaderV1_PreExistingCustomHeadersWithoutTrailingComma() {
         ClickHouseHelperClient client = new ClickHouseHelperClient.ClickHouseClientBuilder("localhost", 8123, null, null, -1)
                 .enableReplicaPinning(true)
@@ -275,7 +288,7 @@ public class ClickHouseHelperClientTest extends ClickHouseBase {
         req.option(ClickHouseHttpOption.CUSTOM_HEADERS, "Header1=Val1,Header2=Val2");
         client.setReplicaTagHeaderV1(req);
         String customHeaders = (String) req.getConfig().getOption(ClickHouseHttpOption.CUSTOM_HEADERS);
-        Assertions.assertTrue(customHeaders.startsWith("Header1=Val1,Header2=Val2," + ClickHouseHelperClient.REPLICA_TAG_HEADER + "="), "Got customHeaders: " + customHeaders);
+        Assertions.assertEquals("Header1=Val1,Header2=Val2," + ClickHouseHelperClient.REPLICA_TAG_HEADER + "=" + client.getReplicaTag(), customHeaders);
     }
 
     @Test
@@ -288,11 +301,11 @@ public class ClickHouseHelperClientTest extends ClickHouseBase {
         req.option(ClickHouseHttpOption.CUSTOM_HEADERS, "Header1=Val1,");
         client.setReplicaTagHeaderV1(req);
         String customHeaders = (String) req.getConfig().getOption(ClickHouseHttpOption.CUSTOM_HEADERS);
-        Assertions.assertTrue(customHeaders.startsWith("Header1=Val1," + ClickHouseHelperClient.REPLICA_TAG_HEADER + "="), "Got customHeaders: " + customHeaders);
+        Assertions.assertEquals("Header1=Val1," + ClickHouseHelperClient.REPLICA_TAG_HEADER + "=" + client.getReplicaTag(), customHeaders);
     }
 
     @Test
-    public void testSetReplicaTagHeaderV1_OverridingExistingReplicaTag() {
+    public void testSetReplicaTagHeaderV1_AppendsToExistingReplicaTag() {
         ClickHouseHelperClient client = new ClickHouseHelperClient.ClickHouseClientBuilder("localhost", 8123, null, null, -1)
                 .enableReplicaPinning(true)
                 .build();
@@ -301,9 +314,7 @@ public class ClickHouseHelperClientTest extends ClickHouseBase {
         req.option(ClickHouseHttpOption.CUSTOM_HEADERS, "Header1=Val1,X-ClickHouse-Replica-Tag=oldTag123,Header2=Val2");
         client.setReplicaTagHeaderV1(req);
         String customHeaders = (String) req.getConfig().getOption(ClickHouseHttpOption.CUSTOM_HEADERS);
-        Assertions.assertTrue(customHeaders.contains("Header1=Val1,X-ClickHouse-Replica-Tag="), "Got customHeaders: " + customHeaders);
-        Assertions.assertTrue(customHeaders.contains(",Header2=Val2"), "Got customHeaders: " + customHeaders);
-        Assertions.assertFalse(customHeaders.contains("oldTag123"), "Got customHeaders: " + customHeaders);
+        Assertions.assertEquals("Header1=Val1,X-ClickHouse-Replica-Tag=oldTag123,Header2=Val2," + ClickHouseHelperClient.REPLICA_TAG_HEADER + "=" + client.getReplicaTag(), customHeaders);
     }
 
     @Test

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClientTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClientTest.java
@@ -1,5 +1,12 @@
 package com.clickhouse.kafka.connect.sink.db.helper;
 
+import com.clickhouse.client.ClickHouseClient;
+import com.clickhouse.client.ClickHouseNode;
+import com.clickhouse.client.ClickHouseProtocol;
+import com.clickhouse.client.ClickHouseRequest;
+import com.clickhouse.client.api.insert.InsertSettings;
+import com.clickhouse.client.api.query.QuerySettings;
+import com.clickhouse.client.http.config.ClickHouseHttpOption;
 import com.clickhouse.kafka.connect.sink.ClickHouseBase;
 import com.clickhouse.kafka.connect.sink.db.mapping.Table;
 import com.clickhouse.kafka.connect.sink.helper.ClickHouseCluster;
@@ -224,5 +231,110 @@ public class ClickHouseHelperClientTest extends ClickHouseBase {
         } finally {
             ClickHouseTestHelpers.dropTable(chc, topic);
         }
+    }
+
+    private ClickHouseRequest<?> createMockRequest() {
+        ClickHouseNode node = ClickHouseNode.builder()
+                .host("localhost")
+                .port(ClickHouseProtocol.HTTP, 8123)
+                .build();
+        return ClickHouseClient.newInstance(ClickHouseProtocol.HTTP).read(node);
+    }
+
+    @Test
+    public void testSetReplicaTagHeaderV1_DisabledFeatureFlag() {
+        ClickHouseHelperClient client = new ClickHouseHelperClient.ClickHouseClientBuilder("localhost", 8123, null, null, -1)
+                .enableReplicaPinning(false)
+                .build();
+        client.pinReplica();
+        ClickHouseRequest<?> req = createMockRequest();
+        client.setReplicaTagHeaderV1(req);
+        Assertions.assertFalse(req.hasOption(ClickHouseHttpOption.CUSTOM_HEADERS));
+    }
+
+    @Test
+    public void testSetReplicaTagHeaderV1_NoPriorCustomHeaders() {
+        ClickHouseHelperClient client = new ClickHouseHelperClient.ClickHouseClientBuilder("localhost", 8123, null, null, -1)
+                .enableReplicaPinning(true)
+                .build();
+        client.pinReplica();
+        ClickHouseRequest<?> req = createMockRequest();
+        client.setReplicaTagHeaderV1(req);
+        Assertions.assertTrue(req.hasOption(ClickHouseHttpOption.CUSTOM_HEADERS));
+        String customHeaders = (String) req.getConfig().getOption(ClickHouseHttpOption.CUSTOM_HEADERS);
+        Assertions.assertTrue(customHeaders.startsWith(ClickHouseHelperClient.REPLICA_TAG_HEADER + "="), "Got customHeaders: " + customHeaders);
+    }
+
+    @Test
+    public void testSetReplicaTagHeaderV1_PreExistingCustomHeadersWithoutTrailingComma() {
+        ClickHouseHelperClient client = new ClickHouseHelperClient.ClickHouseClientBuilder("localhost", 8123, null, null, -1)
+                .enableReplicaPinning(true)
+                .build();
+        client.pinReplica();
+        ClickHouseRequest<?> req = createMockRequest();
+        req.option(ClickHouseHttpOption.CUSTOM_HEADERS, "Header1=Val1,Header2=Val2");
+        client.setReplicaTagHeaderV1(req);
+        String customHeaders = (String) req.getConfig().getOption(ClickHouseHttpOption.CUSTOM_HEADERS);
+        Assertions.assertTrue(customHeaders.startsWith("Header1=Val1,Header2=Val2," + ClickHouseHelperClient.REPLICA_TAG_HEADER + "="), "Got customHeaders: " + customHeaders);
+    }
+
+    @Test
+    public void testSetReplicaTagHeaderV1_PreExistingCustomHeadersWithTrailingComma() {
+        ClickHouseHelperClient client = new ClickHouseHelperClient.ClickHouseClientBuilder("localhost", 8123, null, null, -1)
+                .enableReplicaPinning(true)
+                .build();
+        client.pinReplica();
+        ClickHouseRequest<?> req = createMockRequest();
+        req.option(ClickHouseHttpOption.CUSTOM_HEADERS, "Header1=Val1,");
+        client.setReplicaTagHeaderV1(req);
+        String customHeaders = (String) req.getConfig().getOption(ClickHouseHttpOption.CUSTOM_HEADERS);
+        Assertions.assertTrue(customHeaders.startsWith("Header1=Val1," + ClickHouseHelperClient.REPLICA_TAG_HEADER + "="), "Got customHeaders: " + customHeaders);
+    }
+
+    @Test
+    public void testSetReplicaTagHeaderV1_OverridingExistingReplicaTag() {
+        ClickHouseHelperClient client = new ClickHouseHelperClient.ClickHouseClientBuilder("localhost", 8123, null, null, -1)
+                .enableReplicaPinning(true)
+                .build();
+        client.pinReplica();
+        ClickHouseRequest<?> req = createMockRequest();
+        req.option(ClickHouseHttpOption.CUSTOM_HEADERS, "Header1=Val1,X-ClickHouse-Replica-Tag=oldTag123,Header2=Val2");
+        client.setReplicaTagHeaderV1(req);
+        String customHeaders = (String) req.getConfig().getOption(ClickHouseHttpOption.CUSTOM_HEADERS);
+        Assertions.assertTrue(customHeaders.contains("Header1=Val1,X-ClickHouse-Replica-Tag="), "Got customHeaders: " + customHeaders);
+        Assertions.assertTrue(customHeaders.contains(",Header2=Val2"), "Got customHeaders: " + customHeaders);
+        Assertions.assertFalse(customHeaders.contains("oldTag123"), "Got customHeaders: " + customHeaders);
+    }
+
+    @Test
+    public void testSetReplicaTagHeaderV1_UnpinReset() {
+        ClickHouseHelperClient client = new ClickHouseHelperClient.ClickHouseClientBuilder("localhost", 8123, null, null, -1)
+                .enableReplicaPinning(true)
+                .build();
+        client.pinReplica();
+        client.unpinReplica();
+        ClickHouseRequest<?> req = createMockRequest();
+        client.setReplicaTagHeaderV1(req);
+        Assertions.assertFalse(req.hasOption(ClickHouseHttpOption.CUSTOM_HEADERS));
+    }
+
+    @Test
+    public void testSetReplicaTagHeaderV2() {
+        ClickHouseHelperClient client = new ClickHouseHelperClient.ClickHouseClientBuilder("localhost", 8123, null, null, -1)
+                .enableReplicaPinning(true)
+                .build();
+        client.pinReplica();
+        QuerySettings qs = new QuerySettings();
+        InsertSettings is = new InsertSettings();
+        client.setReplicaTagHeaderV2(qs);
+        client.setReplicaTagHeaderV2(is);
+        String expectedOptionKey = "http_header_" + ClickHouseHelperClient.REPLICA_TAG_HEADER.toUpperCase(java.util.Locale.US);
+        Assertions.assertNotNull(qs.getAllSettings().get(expectedOptionKey));
+        Assertions.assertNotNull(is.getAllSettings().get(expectedOptionKey));
+
+        client.unpinReplica();
+        QuerySettings qs2 = new QuerySettings();
+        client.setReplicaTagHeaderV2(qs2);
+        Assertions.assertNull(qs2.getAllSettings().get(expectedOptionKey));
     }
 }

--- a/src/testFixtures/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseTestHelpers.java
+++ b/src/testFixtures/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseTestHelpers.java
@@ -401,6 +401,7 @@ public class ClickHouseTestHelpers {
                 .setRetry(csc.getRetry())
                 .useClientV2("V2".equals(csc.getClientVersion()))
                 .setSslSocketSni(csc.getSslSocketSni())
+                .enableReplicaPinning(csc.isEnableReplicaPinning())
                 .build();
     }
 


### PR DESCRIPTION
## Summary

See https://github.com/ClickHouse/clickhouse-kafka-connect/issues/827 for problem description

- Adds property `enableReplicaPinning` . Affects error handling when schema mismatch 
- Adds sending `X-ClickHouse-Replica-Tag` when pinning enabled and error detected. 

Closes: https://github.com/ClickHouse/clickhouse-kafka-connect/issues/827

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
