### PR TITLE
Expose client request compression as a connector config for v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * New `retryOnSocketException` setting (default `false`). When enabled, a `java.net.SocketException` (broken pipe,
   connection reset) from the ClickHouse client is retried like the existing timeout cases instead of failing the
   task. With client V2's persistent connections a single server-side connection reset otherwise fails every task at once.
-* Added `clientCompression` connector configuration to control ClickHouse client request compression for the V2 insert and exactly-once state-store paths. The default is `false`, preserving existing behavior unless users opt in. Configuring `clientCompression=true` with `clientVersion=V1` is rejected. (https://github.com/ClickHouse/clickhouse-kafka-connect/issues/528)
+* Added `clientCompression` connector configuration to control ClickHouse client request compression for V2 insert traffic and exactly-once state-store writes. The default is `false`, preserving existing behavior unless users opt in. Configuring `clientCompression=true` with `client_version=V1`, including the unset `client_version` default, is rejected. (https://github.com/ClickHouse/clickhouse-kafka-connect/issues/528)
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * New `retryOnSocketException` setting (default `false`). When enabled, a `java.net.SocketException` (broken pipe,
   connection reset) from the ClickHouse client is retried like the existing timeout cases instead of failing the
   task. With client V2's persistent connections a single server-side connection reset otherwise fails every task at once.
+* Added `clientCompression` connector configuration to control ClickHouse client request compression for the V2 insert and exactly-once state-store paths. The default is `false`, preserving existing behavior unless users opt in. Configuring `clientCompression=true` with `clientVersion=V1` is rejected. (https://github.com/ClickHouse/clickhouse-kafka-connect/issues/528)
 
 ## Bug Fixes
 

--- a/src/main/java/com/clickhouse/kafka/connect/ClickHouseSinkConnector.java
+++ b/src/main/java/com/clickhouse/kafka/connect/ClickHouseSinkConnector.java
@@ -5,6 +5,8 @@ import com.clickhouse.kafka.connect.sink.ClickHouseSinkConfig;
 import com.clickhouse.kafka.connect.sink.ClickHouseSinkTask;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
 import org.apache.kafka.connect.sink.SinkConnectorContext;
@@ -97,6 +99,17 @@ public class ClickHouseSinkConnector extends SinkConnector {
         ClickHouseSinkConfig sinkConfig;
         try {
             sinkConfig = new ClickHouseSinkConfig(connectorConfigs);
+        } catch (ConfigException e) {
+            config.configValues().stream()
+                    .filter(configValue -> configValue.name().equals(ClickHouseSinkConfig.CLIENT_COMPRESSION))
+                    .findFirst()
+                    .orElseGet(() -> {
+                        ConfigValue configValue = new ConfigValue(ClickHouseSinkConfig.CLIENT_COMPRESSION);
+                        config.configValues().add(configValue);
+                        return configValue;
+                    })
+                    .addErrorMessage(e.getMessage());
+            return config;
         } catch (Exception e) {
             return config;
         }

--- a/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
@@ -314,9 +314,9 @@ public class ClickHouseSinkConfig {
         this.sslSocketSni = props.getOrDefault(SSL_SOCKET_SNI, "");
         this.clusterName = props.getOrDefault(CLUSTER_NAME, "");
         this.clientCompression = Boolean.parseBoolean(props.getOrDefault(CLIENT_COMPRESSION, clientCompressionDefault.toString()));
-        if (this.clientCompression && this.clientVersion != null && this.clientVersion.trim().equalsIgnoreCase("V1")) {
+        if (this.clientCompression && "V1".equals(this.clientVersion)) {
             throw new ConfigException(CLIENT_COMPRESSION, true,
-                    "clientCompression is supported only with clientVersion=V2");
+                    "clientCompression is supported only with client_version=V2; unset client_version defaults to V1");
         }
 
         if (this.bufferCount > 0) {
@@ -666,7 +666,7 @@ public class ClickHouseSinkConfig {
                 ConfigDef.Type.BOOLEAN,
                 clientCompressionDefault,
                 ConfigDef.Importance.LOW,
-                "Enable client request compression. default: false",
+                "Enable V2 client request compression. Requires client_version=V2. default: false",
                 group,
                 ++orderInGroup,
                 ConfigDef.Width.SHORT,

--- a/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfig.java
@@ -65,6 +65,7 @@ public class ClickHouseSinkConfig {
     public static final String AUTO_EVOLVE_STRUCT_TO_JSON = "auto.evolve.struct.to.json";
     public static final String CONNECTOR_RETRY_TIMEOUT = "errors.retry.timeout";
     public static final String CLUSTER_NAME = "clusterName";
+    public static final String CLIENT_COMPRESSION = "clientCompression";
 
     public static final long MINIMAL_RETRY_TIMEOUT_THR_WARN = TimeUnit.SECONDS.toMillis(10);
     public static final String SSL_SOCKET_SNI = "ssl_socket_sni";
@@ -85,6 +86,7 @@ public class ClickHouseSinkConfig {
     public static final Long bufferFlushTimeDefault = 0L;
     public static final Long clickhouseClientInsertTimeoutMsDefault = TimeUnit.MINUTES.toMillis(4);
     public static final Boolean reportInsertedOffsetsDefault = Boolean.FALSE;
+    public static final Boolean clientCompressionDefault = Boolean.FALSE;
 
     private final String hostname;
     private final int port;
@@ -127,6 +129,7 @@ public class ClickHouseSinkConfig {
     private final boolean binaryFormatWrtiteJsonAsString;
     private final String sslSocketSni;
     private final String clusterName;
+    private final boolean clientCompression;
 
     public enum InsertFormats {
         NONE,
@@ -310,6 +313,11 @@ public class ClickHouseSinkConfig {
         this.debeziumCDCEnabled = Boolean.parseBoolean(props.getOrDefault(DEBEZIUM_CDC_ENABLED, "false"));
         this.sslSocketSni = props.getOrDefault(SSL_SOCKET_SNI, "");
         this.clusterName = props.getOrDefault(CLUSTER_NAME, "");
+        this.clientCompression = Boolean.parseBoolean(props.getOrDefault(CLIENT_COMPRESSION, clientCompressionDefault.toString()));
+        if (this.clientCompression && this.clientVersion != null && this.clientVersion.trim().equalsIgnoreCase("V1")) {
+            throw new ConfigException(CLIENT_COMPRESSION, true,
+                    "clientCompression is supported only with clientVersion=V2");
+        }
 
         if (this.bufferCount > 0) {
             LOGGER.info("Internal buffering enabled: bufferCount={}, bufferFlushTime={}ms", this.bufferCount, this.bufferFlushTime);
@@ -322,8 +330,8 @@ public class ClickHouseSinkConfig {
         String jsonAsString = getClickhouseSettings().get("input_format_binary_read_json_as_string");
         this.binaryFormatWrtiteJsonAsString = jsonAsString != null && (jsonAsString.equalsIgnoreCase("true") || jsonAsString.equals("1"));
 
-        LOGGER.debug("ClickHouseSinkConfig: hostname: {}, port: {}, database: {}, username: {}, sslEnabled: {}, timeout: {}, retry: {}, exactlyOnce: {}",
-                hostname, port, database, username, sslEnabled, timeout, retry, exactlyOnce);
+        LOGGER.debug("ClickHouseSinkConfig: hostname: {}, port: {}, database: {}, username: {}, sslEnabled: {}, timeout: {}, retry: {}, exactlyOnce: {}, clientCompression: {}",
+                hostname, port, database, username, sslEnabled, timeout, retry, exactlyOnce, clientCompression);
         LOGGER.debug("ClickHouseSinkConfig: clickhouseSettings: {}", clickhouseSettings);
         LOGGER.debug("ClickHouseSinkConfig: topicToTableMap: {}", topicToTableMap);
 
@@ -653,6 +661,16 @@ public class ClickHouseSinkConfig {
                 ++orderInGroup,
                 ConfigDef.Width.SHORT,
                 "Client version"
+        );
+        configDef.define(CLIENT_COMPRESSION,
+                ConfigDef.Type.BOOLEAN,
+                clientCompressionDefault,
+                ConfigDef.Importance.LOW,
+                "Enable client request compression. default: false",
+                group,
+                ++orderInGroup,
+                ConfigDef.Width.SHORT,
+                "Enable client request compression."
         );
         configDef.define(TOLERATE_STATE_MISMATCH,
                 ConfigDef.Type.BOOLEAN,

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriter.java
@@ -92,6 +92,7 @@ public class ClickHouseWriter implements DBWriter {
                 .useClientV2(useClientV2)
                 .setSslSocketSni(csc.getSslSocketSni())
                 .setClusterClause(csc.getClusterName())
+                .setClientCompression(csc.isClientCompression())
                 .build();
 
         if (!chc.ping()) {
@@ -1065,6 +1066,7 @@ public class ClickHouseWriter implements DBWriter {
         for (String clickhouseSetting : csc.getClickhouseSettings().keySet()) {//THIS ASSUMES YOU DON'T ADD insert_deduplication_token
             insertSettings.serverSetting(clickhouseSetting, csc.getClickhouseSettings().get(clickhouseSetting));
         }
+        insertSettings.compressClientRequest(csc.isClientCompression());
         ClickHouseFormat format = ClickHouseFormat.RowBinary;
         if (supportDefaults) {
             format = ClickHouseFormat.RowBinaryWithDefaults;
@@ -1283,6 +1285,7 @@ public class ClickHouseWriter implements DBWriter {
         for (String clickhouseSetting : csc.getClickhouseSettings().keySet()) {//THIS ASSUMES YOU DON'T ADD insert_deduplication_token
             insertSettings.serverSetting(clickhouseSetting, csc.getClickhouseSettings().get(clickhouseSetting));
         }
+        insertSettings.compressClientRequest(csc.isClientCompression());
 
         AtomicLong dataSerializeTime = new AtomicLong(0);
         DataStreamWriter dataWriter = out -> {
@@ -1419,6 +1422,7 @@ public class ClickHouseWriter implements DBWriter {
         for (String clickhouseSetting : csc.getClickhouseSettings().keySet()) {//THIS ASSUMES YOU DON'T ADD insert_deduplication_token
             insertSettings.serverSetting(clickhouseSetting, csc.getClickhouseSettings().get(clickhouseSetting));
         }
+        insertSettings.compressClientRequest(csc.isClientCompression());
         // We don't validate the schema for JSON inserts.  ClickHouse will ignore unknown fields based on the
         // input_format_skip_unknown_fields setting, and missing fields will use ClickHouse defaults
         ClickHouseFormat clickHouseFormat = getStringInsertFormat();

--- a/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClient.java
@@ -64,6 +64,7 @@ public class ClickHouseHelperClient implements AutoCloseable {
     private boolean useClientV2 = false;
     private final String sslSocketSni;
     private final String clusterClause;
+    private final boolean clientCompression;
 
     public ClickHouseHelperClient(ClickHouseClientBuilder builder) {
         this.hostname = builder.hostname;
@@ -81,6 +82,7 @@ public class ClickHouseHelperClient implements AutoCloseable {
         this.useClientV2 = builder.useClientV2;
         this.sslSocketSni = builder.sslSocketSni;
         this.clusterClause = builder.clusterClause;
+        this.clientCompression = builder.clientCompression;
         // We are creating two clients, one for V1 and one for V2
         this.client = createClientV2();
         this.server = createClientV1();
@@ -159,7 +161,8 @@ public class ClickHouseHelperClient implements AutoCloseable {
                 .setUsername(this.username)
                 .setPassword(this.password)
                 .setClientName(CONNECT_CLIENT_NAME)
-                .setDefaultDatabase(this.database);
+                .setDefaultDatabase(this.database)
+                .compressClientRequest(this.clientCompression);
 
         if (proxyType != null && !proxyType.equals(ClickHouseProxyType.IGNORE)) {
             clientBuilder.addProxy(ProxyType.HTTP, proxyHost, proxyPort);
@@ -583,6 +586,7 @@ public class ClickHouseHelperClient implements AutoCloseable {
         private boolean useClientV2 = true;
         private String sslSocketSni = "";
         private String clusterClause = "";
+        private boolean clientCompression = false;
 
         public ClickHouseClientBuilder(String hostname, int port, ClickHouseProxyType proxyType, String proxyHost, int proxyPort) {
             this.hostname = hostname;
@@ -640,6 +644,11 @@ public class ClickHouseHelperClient implements AutoCloseable {
 
         public ClickHouseClientBuilder setClusterClause(String clusterName) {
             this.clusterClause = (clusterName == null || clusterName.isEmpty()) ? "" : " ON CLUSTER '" + clusterName + "' ";
+            return this;
+        }
+
+        public ClickHouseClientBuilder setClientCompression(boolean clientCompression) {
+            this.clientCompression = clientCompression;
             return this;
         }
 

--- a/src/main/java/com/clickhouse/kafka/connect/sink/state/provider/KeeperStateProvider.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/state/provider/KeeperStateProvider.java
@@ -54,6 +54,7 @@ public class KeeperStateProvider extends BaseStateProviderImpl {
                 .setTimeout(timeout)
                 .setRetry(csc.getRetry())
                 .useClientV2(useClientV2)
+                .setClientCompression(csc.isClientCompression())
                 .build();
 
         if (!chc.ping()) {

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfigTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfigTest.java
@@ -1,7 +1,9 @@
 package com.clickhouse.kafka.connect.sink;
 
 import com.clickhouse.kafka.connect.ClickHouseSinkConnector;
+import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.ConfigValue;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -26,7 +28,36 @@ public class ClickHouseSinkConfigTest {
         ConfigException error = Assertions.assertThrows(ConfigException.class,
                 () -> new ClickHouseSinkConfig(props));
 
-        Assertions.assertTrue(error.getMessage().contains("clientVersion=V2"));
+        Assertions.assertTrue(error.getMessage().contains(ClickHouseSinkConfig.CLIENT_COMPRESSION));
+        Assertions.assertTrue(error.getMessage().contains(ClickHouseSinkConnector.CLIENT_VERSION));
+    }
+
+    @Test
+    public void clientCompressionRejectsUnsetClientVersionBecauseItDefaultsToV1() {
+        Map<String, String> props = baseProps();
+        props.remove(ClickHouseSinkConnector.CLIENT_VERSION);
+        props.put(ClickHouseSinkConfig.CLIENT_COMPRESSION, "true");
+
+        ConfigException error = Assertions.assertThrows(ConfigException.class,
+                () -> new ClickHouseSinkConfig(props));
+
+        Assertions.assertTrue(error.getMessage().contains(ClickHouseSinkConfig.CLIENT_COMPRESSION));
+        Assertions.assertTrue(error.getMessage().contains(ClickHouseSinkConnector.CLIENT_VERSION));
+    }
+
+    @Test
+    public void validateReportsClientCompressionErrors() {
+        Map<String, String> props = baseProps();
+        props.put(ClickHouseSinkConnector.CLIENT_VERSION, "V1");
+        props.put(ClickHouseSinkConfig.CLIENT_COMPRESSION, "true");
+
+        Config config = new ClickHouseSinkConnector().validate(props);
+        ConfigValue configValue = config.configValues().stream()
+                .filter(value -> value.name().equals(ClickHouseSinkConfig.CLIENT_COMPRESSION))
+                .findFirst()
+                .orElseThrow();
+
+        Assertions.assertFalse(configValue.errorMessages().isEmpty());
     }
 
     private Map<String, String> baseProps() {

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfigTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkConfigTest.java
@@ -1,0 +1,43 @@
+package com.clickhouse.kafka.connect.sink;
+
+import com.clickhouse.kafka.connect.ClickHouseSinkConnector;
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ClickHouseSinkConfigTest {
+
+    @Test
+    public void clientCompressionDefaultsToFalseWhenUnset() {
+        ClickHouseSinkConfig config = new ClickHouseSinkConfig(baseProps());
+
+        Assertions.assertFalse(config.isClientCompression());
+    }
+
+    @Test
+    public void clientCompressionRejectsV1Client() {
+        Map<String, String> props = baseProps();
+        props.put(ClickHouseSinkConnector.CLIENT_VERSION, "V1");
+        props.put(ClickHouseSinkConfig.CLIENT_COMPRESSION, "true");
+
+        ConfigException error = Assertions.assertThrows(ConfigException.class,
+                () -> new ClickHouseSinkConfig(props));
+
+        Assertions.assertTrue(error.getMessage().contains("clientVersion=V2"));
+    }
+
+    private Map<String, String> baseProps() {
+        Map<String, String> props = new HashMap<>();
+        props.put(ClickHouseSinkConnector.HOSTNAME, "localhost");
+        props.put(ClickHouseSinkConnector.PORT, "8123");
+        props.put(ClickHouseSinkConnector.DATABASE, "default");
+        props.put(ClickHouseSinkConnector.USERNAME, "default");
+        props.put(ClickHouseSinkConnector.PASSWORD, "");
+        props.put(ClickHouseSinkConnector.SSL_ENABLED, "false");
+        props.put(ClickHouseSinkConnector.CLIENT_VERSION, "V2");
+        return props;
+    }
+}

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/ClickHouseWriterTest.java
@@ -586,9 +586,23 @@ public class ClickHouseWriterTest extends ClickHouseBase {
 
     @Test
     public void doInsertJsonUsesEquivalentWirePathAcrossClients() {
-        List<String> v1Rows = runJsonInsertAndReadRows("V1");
-        List<String> v2Rows = runJsonInsertAndReadRows("V2");
+        List<String> v1Rows = runJsonInsertAndReadRows("V1", Map.of());
+        List<String> v2Rows = runJsonInsertAndReadRows("V2", Map.of());
         assertEquals(v1Rows, v2Rows, "Expected V1 and V2 to persist identical rows for JSON inserts");
+    }
+
+    @Test
+    public void doInsertJsonWithV2ClientCompressionEnabledOrDisabledPersistsIdenticalRows() {
+        List<String> expectedRows = List.of("1|alpha", "2|beta", "3|gamma");
+        List<String> compressedRows = runJsonInsertAndReadRows("V2", Map.of(
+                ClickHouseSinkConfig.CLIENT_COMPRESSION, "true"));
+        List<String> uncompressedRows = runJsonInsertAndReadRows("V2", Map.of(
+                ClickHouseSinkConfig.CLIENT_COMPRESSION, "false"));
+
+        assertEquals(expectedRows, compressedRows,
+                "Expected V2 JSON inserts with client request compression enabled to persist the inserted rows");
+        assertEquals(expectedRows, uncompressedRows,
+                "Expected V2 JSON inserts with client request compression disabled to persist the inserted rows");
     }
 
     private List<String> runStringInsertAndReadRows(String clientVersion, String insertFormat) {
@@ -646,9 +660,10 @@ public class ClickHouseWriterTest extends ClickHouseBase {
         }
     }
 
-    private List<String> runJsonInsertAndReadRows(String clientVersion) {
+    private List<String> runJsonInsertAndReadRows(String clientVersion, Map<String, String> overrides) {
         Map<String, String> props = getBaseProps();
         props.put(ClickHouseSinkConnector.CLIENT_VERSION, clientVersion);
+        props.putAll(overrides);
         ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
         String topic = createTopicName("json_parity_" + clientVersion.toLowerCase());
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClientConfigTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/db/helper/ClickHouseHelperClientConfigTest.java
@@ -1,0 +1,22 @@
+package com.clickhouse.kafka.connect.sink.db.helper;
+
+import com.clickhouse.client.config.ClickHouseProxyType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class ClickHouseHelperClientConfigTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void clientCompressionIsPropagatedToV2Client(boolean clientCompression) {
+        try (ClickHouseHelperClient client = new ClickHouseHelperClient.ClickHouseClientBuilder(
+                "localhost", 8123, ClickHouseProxyType.IGNORE, "", -1)
+                .setClientCompression(clientCompression)
+                .build()) {
+            Assertions.assertEquals(
+                    String.valueOf(clientCompression),
+                    client.getClient().getConfiguration().get("decompress"));
+        }
+    }
+}

--- a/src/testFixtures/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseTestHelpers.java
+++ b/src/testFixtures/java/com/clickhouse/kafka/connect/sink/helper/ClickHouseTestHelpers.java
@@ -425,6 +425,7 @@ public class ClickHouseTestHelpers {
                 .setRetry(csc.getRetry())
                 .useClientV2("V2".equals(csc.getClientVersion()))
                 .setSslSocketSni(csc.getSslSocketSni())
+                .setClientCompression(csc.isClientCompression())
                 .build();
     }
 


### PR DESCRIPTION
Implements [528 - Expose in configuration client compression](https://github.com/clickhouse/clickhouse-kafka-connect/issues/528) for the V2 client.

This exposes client request compression as a connector setting. The connector now accepts a single boolean `clientCompression` flag. The default is `false`, preserving existing behavior unless users opt in.

When enabled, the connector applies the client library's native request-compression toggle on the V2 insert path and on V2 exactly-once state-store writes. To avoid surprising behavior on the older client implementation, `clientCompression=true` is rejected when the connector would use V1, including the current unset `client_version` default.

The scope is intentionally narrow: this PR exposes the connector-level boolean without expanding the configuration surface around compression algorithms.

Tests cover the connector/config seams. Because test coverage is not good enough for this aprticular feature, I first considered adding it to the benchmarks but thought this might be just re-testing the client and it would differ from what exists in the repo already. Instead, I built a separate lab just to manually validate that compression happens as expected. It's in a branch on ky fork:

- https://github.com/pcalcado/clickhouse-kafka-connect/pull/2

In that lab, V2 JSON inserts of a 100k-row mixed-cardinality profile payload showed median captured wire bytes drop from ~111MB to ~95MB with `clientCompression=true`. Elapsed time was slightly higher in that run, so I am treating this as wire-behavior evidence of the PR working. Happy to do something else to validate if this isn't good enough.
