### PR TITLE
Fix buffered sink duplicating records after a retriable insert failure #801

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,11 @@
   version is not deduplicated on the first insert after upgrading.
 * The connector no longer refuses to start with `Did not find any tables in destination` when `enableDbTopicSplit=true`
   and the configured database holds no tables, which is a valid multi-database setup.
-
+* With internal buffering (`bufferCount > 0`, `exactlyOnce=false`), a retriable insert failure such as code 252
+  `TOO_MANY_PARTS` left the failed batch in the buffer. Kafka Connect redelivers exactly that batch, so every retry
+  appended another copy and the eventual successful flush wrote each record several times. The batch is now removed
+  from the buffer when the flush fails, leaving the redelivery as the single copy.
+  (https://github.com/ClickHouse/clickhouse-kafka-connect/issues/801)
 # 1.5.0, 2026-08-05
 
 ## Improvements

--- a/src/main/java/com/clickhouse/kafka/connect/sink/AtLeastOnceBufferStrategy.java
+++ b/src/main/java/com/clickhouse/kafka/connect/sink/AtLeastOnceBufferStrategy.java
@@ -38,6 +38,7 @@ final class AtLeastOnceBufferStrategy implements DeliveryStrategy {
 
     @Override
     public void put(Collection<SinkRecord> records) {
+        int bufferedBeforePut = buffer.size();
         if (records != null && !records.isEmpty()) {
             buffer.addAll(records);
             LOGGER.debug("Buffered {} records, total buffer size: {}", records.size(), buffer.size());
@@ -51,7 +52,14 @@ final class AtLeastOnceBufferStrategy implements DeliveryStrategy {
         if (sizeThreshold || timeThreshold) {
             LOGGER.debug("Buffer flush triggered: size={}, sizeThreshold={}, timeThreshold={}, lastFlushTime={}",
                     buffer.size(), sizeThreshold, timeThreshold, lastFlushTime);
-            flushBuffer();
+            try {
+                flushBuffer();
+            } catch (RuntimeException e) {
+                // Connect redelivers exactly the records of this put() after a retriable
+                // failure, so keeping them buffered here would produce a second copy.
+                buffer.subList(bufferedBeforePut, buffer.size()).clear();
+                throw e;
+            }
         }
     }
 

--- a/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskBufferTest.java
+++ b/src/test/java/com/clickhouse/kafka/connect/sink/ClickHouseSinkTaskBufferTest.java
@@ -476,6 +476,42 @@ public class ClickHouseSinkTaskBufferTest extends ClickHouseBase {
     }
 
     @Test
+    public void retriableFlushFailureDoesNotDuplicateBufferedRecords() {
+        // A failed flush leaves the batch in the buffer. Connect redelivers exactly that
+        // batch, so unless it is dropped the retry buffers a second copy and the eventual
+        // successful flush writes every record twice.
+        Map<String, String> props = getBaseProps();
+        props.put(ClickHouseSinkConfig.BUFFER_COUNT, "500");
+        ClickHouseHelperClient chc = ClickHouseTestHelpers.createClient(props);
+        String topic = createTopicName("buffer_retry_no_duplicates_test");
+        ClickHouseTestHelpers.dropTable(chc, topic);
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+
+        ClickHouseSinkTask task = new ClickHouseSinkTask();
+        task.start(props);
+
+        List<SinkRecord> batch1 = SchemalessTestData.createPrimitiveTypes(topic, 1, 300);
+        task.put(batch1);
+        assertEquals(0, ClickHouseTestHelpers.countRows(chc, topic),
+                "Records should be buffered, not flushed yet");
+
+        // Drop the table so the flush triggered by the next batch fails.
+        ClickHouseTestHelpers.dropTable(chc, topic);
+
+        List<SinkRecord> batch2 = SchemalessTestData.createPrimitiveTypes(topic, 1, 300);
+        assertThrows(RuntimeException.class, () -> task.put(batch2));
+
+        // The failure condition clears and Connect redelivers the same batch.
+        new CreateTableStatement(PRIMITIVE_TYPES_TABLE).tableName(topic).execute(chc);
+        task.put(batch2);
+
+        assertEquals(600, ClickHouseTestHelpers.countRows(chc, topic),
+                "Redelivered records must not be buffered twice");
+
+        task.stop();
+    }
+
+    @Test
     public void putDirectFailsWithErrorTolerance_offsetsCommitted() {
         // Edge case: buffer flush triggers putDirect → insert fails → error tolerance swallows it.
         // With error tolerance, records go to DLQ and offsets ARE committed (same as non-buffered behavior).


### PR DESCRIPTION
## Summary

Fixes https://github.com/ClickHouse/clickhouse-kafka-connect/issues/801

With `bufferCount > 0` and `exactlyOnce=false`, `AtLeastOnceBufferStrategy.put()` appends the incoming records to the buffer and may then trigger `flushBuffer()`. `flushBuffer()` calls `flusher.flush(buffer)` and clears the buffer only afterwards, so when `ChunkFlusher.putDirect` passes a retriable server error to `Utils.handleException` (code 252 `TOO_MANY_PARTS` is in that list) the `RetriableException` propagates and the clear never runs.

Kafka Connect then redelivers exactly the records of that `put()` call and they are appended a second time. The buffer grows by one copy per retry, which matches the reported `1 -> 2 -> 3 ...` growth with consumer lag pinned at 1, and the eventual successful flush inserts every copy (`written_rows = 83` for a single produced record).

This records the buffer size before appending and truncates back to it if the flush throws, so the redelivered batch ends up as the only copy. Records buffered by earlier `put()` calls are kept, since Connect does not resend those.

`ExactlyOnceBufferStrategy.put()` has the same flush-then-clear shape (`chunk.clear()` after `flusher.flush(chunk)`) and looks affected in the same way. I have left it alone deliberately: this issue is specifically `exactlyOnce=false`, and that path interacts with the dedup token and the state machine. Happy to follow up separately if you would like it covered.

### Verification

`retriableFlushFailureDoesNotDuplicateBufferedRecords` was added to `ClickHouseSinkTaskBufferTest`. It buffers 300 records, drops the table so the flush triggered by the next batch fails, re-creates the table, and redelivers the failed batch the way Connect would.

With the production change reverted and the test kept, it fails with `expected: <600> but was: <900>` (the third copy) while the other 34 tests in the class still pass. With the change in place all 35 pass.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
